### PR TITLE
perf(core): reduce encoding and typed storage allocations

### DIFF
--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -220,6 +220,11 @@ impl DB {
         Ok(self.0.get(key)?)
     }
 
+    // Keep the native value pinned only while the typed layer decodes it.
+    fn retrieve_pinned(&self, key: &[u8]) -> Result<Option<rocksdb::DBPinnableSlice<'_>>> {
+        Ok(self.0.get_pinned(key)?)
+    }
+
     /// Retrieve all values stored under a key prefix.
     pub fn retrieve_values_by_prefix(&self, prefix: &[u8]) -> Result<Vec<Vec<u8>>> {
         let mut values = Vec::new();
@@ -231,7 +236,7 @@ impl DB {
             if !key.starts_with(prefix) {
                 break;
             }
-            values.push(value.to_vec());
+            values.push(value.into_vec());
         }
         Ok(values)
     }

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -133,8 +133,8 @@ impl TypedDB {
         key: impl AsRef<[u8]>,
     ) -> Result<Option<V>> {
         self.db
-            .retrieve(&self.prefixed_key(prefix.as_ref(), key.as_ref()))?
-            .map(|v| V::read_from(&mut v.as_slice()))
+            .retrieve_pinned(&self.prefixed_key(prefix.as_ref(), key.as_ref()))?
+            .map(|v| V::read_from_slice(v.as_ref()))
             .transpose()
             .map_err(Into::into)
     }
@@ -167,7 +167,7 @@ impl TypedDB {
         self.db
             .retrieve_values_by_prefix(&prefix)?
             .into_iter()
-            .map(|value| V::read_from(&mut value.as_slice()).map_err(Into::into))
+            .map(|value| V::read_from_slice(&value).map_err(Into::into))
             .collect()
     }
 
@@ -247,5 +247,181 @@ impl TypedDbBatch {
     /// Atomically commit this batch.
     pub fn commit(self) -> Result<()> {
         self.batch.commit()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperlane_core::{HyperlaneMessage, KnownHyperlaneDomain, MerkleTreeInsertion, H256};
+
+    #[test]
+    fn pinned_typed_read_dispatches_slice_override() {
+        #[derive(Debug, PartialEq)]
+        struct SliceDecoded(u32);
+        impl Decode for SliceDecoded {
+            fn read_from<R: std::io::Read>(
+                _: &mut R,
+            ) -> std::result::Result<Self, hyperlane_core::HyperlaneProtocolError> {
+                panic!("typed read must dispatch the slice override");
+            }
+            fn read_from_slice(
+                bytes: &[u8],
+            ) -> std::result::Result<Self, hyperlane_core::HyperlaneProtocolError> {
+                u32::read_from_slice(bytes).map(Self)
+            }
+        }
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let typed = TypedDB::new(&HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum), db);
+        typed.store_encodable(b"slice_", b"key", &42u32).unwrap();
+        assert_eq!(
+            typed
+                .retrieve_decodable::<SliceDecoded>(b"slice_", b"key")
+                .unwrap(),
+            Some(SliceDecoded(42))
+        );
+        assert_eq!(
+            typed
+                .retrieve_decodables_by_prefix::<SliceDecoded>(b"slice_")
+                .unwrap(),
+            vec![SliceDecoded(42)]
+        );
+    }
+
+    #[test]
+    fn prefix_reads_preserve_order_errors_and_owned_results() {
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let typed = TypedDB::new(
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+            db.clone(),
+        );
+        for key in [3u32, 1, 2] {
+            typed
+                .store_keyed_encodable(b"ordered_", &key, &vec![key; 4])
+                .unwrap();
+        }
+        typed
+            .store_keyed_encodable(b"other_", &0u32, &vec![9u32])
+            .unwrap();
+        let values = typed
+            .retrieve_decodables_by_prefix::<Vec<u32>>(b"ordered_")
+            .unwrap();
+        assert_eq!(values, vec![vec![1; 4], vec![2; 4], vec![3; 4]]);
+        let malformed_key = typed.prefixed_key(b"ordered_", &2u32.to_vec());
+        db.store(&malformed_key, &[0]).unwrap();
+        assert!(typed
+            .retrieve_decodables_by_prefix::<Vec<u32>>(b"ordered_")
+            .is_err());
+        typed
+            .store_keyed_encodable(b"ordered_", &2u32, &vec![2u32; 4])
+            .unwrap();
+        assert_eq!(
+            typed
+                .retrieve_decodables_by_prefix::<Vec<u32>>(b"ordered_")
+                .unwrap(),
+            values
+        );
+        drop(typed);
+        drop(db);
+        assert_eq!(values[1], vec![2; 4]);
+    }
+
+    #[test]
+    fn pinned_typed_reads_preserve_values_and_domain_isolation() {
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let typed = TypedDB::new(&domain, db.clone());
+        let other = TypedDB::new(
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+            db.clone(),
+        );
+        let insertion = MerkleTreeInsertion::new(42, H256::repeat_byte(0x12));
+        typed
+            .store_keyed_encodable(b"leaf_", &42u32, &insertion)
+            .unwrap();
+        assert_eq!(
+            typed
+                .retrieve_keyed_decodable::<_, MerkleTreeInsertion>(b"leaf_", &42u32)
+                .unwrap(),
+            Some(insertion)
+        );
+        assert!(other
+            .retrieve_keyed_decodable::<_, MerkleTreeInsertion>(b"leaf_", &42u32)
+            .unwrap()
+            .is_none());
+        for length in [0, 1, 4096] {
+            let message = HyperlaneMessage {
+                body: vec![0xab; length],
+                ..Default::default()
+            };
+            typed
+                .store_encodable(b"message_", b"key", &message)
+                .unwrap();
+            let encoded = db
+                .retrieve(&typed.prefixed_key(b"message_", b"key"))
+                .unwrap()
+                .unwrap();
+            let legacy = HyperlaneMessage::read_from(&mut encoded.as_slice()).unwrap();
+            let pinned: HyperlaneMessage = typed
+                .retrieve_decodable(b"message_", b"key")
+                .unwrap()
+                .unwrap();
+            assert_eq!(pinned, legacy);
+            assert_eq!(pinned, message);
+        }
+    }
+
+    #[test]
+    fn pinned_typed_reads_propagate_decode_errors_and_release_the_value() {
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let typed = TypedDB::new(
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+            db.clone(),
+        );
+        assert!(typed
+            .retrieve_decodable::<HyperlaneMessage>(b"message_", b"key")
+            .unwrap()
+            .is_none());
+        let key = typed.prefixed_key(b"message_", b"key");
+        db.store(&key, &[1, 2]).unwrap();
+        let error = typed
+            .retrieve_decodable::<HyperlaneMessage>(b"message_", b"key")
+            .unwrap_err();
+        assert!(matches!(error, DbError::HyperlaneError(_)));
+
+        let message = HyperlaneMessage {
+            body: vec![0xab; 4096],
+            ..Default::default()
+        };
+        typed
+            .store_encodable(b"message_", b"key", &message)
+            .unwrap();
+        let decoded: HyperlaneMessage = typed
+            .retrieve_decodable(b"message_", b"key")
+            .unwrap()
+            .unwrap();
+        let replacement = HyperlaneMessage {
+            body: vec![0xcd; 32],
+            ..Default::default()
+        };
+        typed
+            .store_encodable(b"message_", b"key", &replacement)
+            .unwrap();
+        assert_eq!(
+            typed
+                .retrieve_decodable::<HyperlaneMessage>(b"message_", b"key")
+                .unwrap(),
+            Some(replacement)
+        );
+        drop(typed);
+        drop(db);
+        // The decoded object owns its body; no native database pin escapes.
+        assert_eq!(decoded, message);
+        let reopened = DB::from_path(directory.path()).unwrap();
+        assert!(reopened.retrieve(&key).unwrap().is_some());
     }
 }

--- a/rust/main/hyperlane-core/src/traits/encode.rs
+++ b/rust/main/hyperlane-core/src/traits/encode.rs
@@ -29,6 +29,18 @@ pub trait Decode {
     where
         R: std::io::Read,
         Self: Sized;
+
+    /// Decode an owned value from an available byte slice.
+    ///
+    /// The default retains the reader decoder's trailing-byte behavior. Types
+    /// with a slice-aware decoder may override this while preserving the accepted
+    /// format and failure contract; parser diagnostic positions may differ.
+    fn read_from_slice(mut bytes: &[u8]) -> Result<Self, HyperlaneProtocolError>
+    where
+        Self: Sized,
+    {
+        Self::read_from(&mut bytes)
+    }
 }
 
 #[cfg(feature = "ethers")]
@@ -343,6 +355,18 @@ mod test {
     use std::io::Cursor;
 
     use crate::{Decode, Encode, Indexed, H256};
+
+    #[test]
+    fn slice_decode_default_preserves_binary_trailing_bytes_and_errors() {
+        let bytes = [0, 0, 0, 42, 99];
+        assert_eq!(u32::read_from_slice(&bytes).unwrap(), 42);
+        assert_eq!(u32::read_from(&mut bytes.as_slice()).unwrap(), 42);
+        for bytes in [&[][..], &[0, 0, 0][..]] {
+            let reader = u32::read_from(&mut &bytes[..]).unwrap_err();
+            let slice = u32::read_from_slice(bytes).unwrap_err();
+            assert_eq!(reader.to_string(), slice.to_string());
+        }
+    }
 
     #[test]
     fn test_encoding_indexed() {

--- a/rust/main/hyperlane-core/src/traits/signing.rs
+++ b/rust/main/hyperlane-core/src/traits/signing.rs
@@ -3,11 +3,10 @@ use std::fmt::{Debug, Formatter};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use serde::{
-    ser::{SerializeStruct, Serializer},
+    ser::{Error, SerializeStruct, Serializer},
     Deserialize, Serialize,
 };
 
-use crate::utils::bytes_to_hex;
 use crate::{Signature, H160, H256};
 
 /// An error incurred by a signer
@@ -100,7 +99,13 @@ impl<T: Signable + Serialize> Serialize for SignedType<T> {
         state.serialize_field("value", &self.value)?;
         state.serialize_field("signature", &self.signature)?;
         let sig: [u8; 65] = self.signature.into();
-        state.serialize_field("serialized_signature", &bytes_to_hex(&sig))?;
+        // The prefixed hex representation has a fixed size. Serialize it directly
+        // from the stack instead of allocating an intermediate hex String.
+        let mut encoded = [0u8; 132];
+        encoded[..2].copy_from_slice(b"0x");
+        hex::encode_to_slice(sig, &mut encoded[2..]).map_err(S::Error::custom)?;
+        let encoded = std::str::from_utf8(&encoded).map_err(S::Error::custom)?;
+        state.serialize_field("serialized_signature", encoded)?;
         state.end()
     }
 }
@@ -135,52 +140,100 @@ impl<T: Signable + Debug> Debug for SignedType<T> {
     }
 }
 
-// Copied from https://github.com/hyperlane-xyz/ethers-rs/blob/hyperlane/ethers-core/src/utils/hash.rs
-// so that we can get EIP-191 hashing without the `ethers` feature
+// EIP-191 hashing without the `ethers` feature.
 mod hashes {
-    const PREFIX: &str = "\x19Ethereum Signed Message:\n";
     use crate::H256;
     use tiny_keccak::{Hasher, Keccak};
 
-    /// Hash a message according to EIP-191.
-    ///
-    /// The data is a UTF-8 encoded string and will enveloped as follows:
-    /// `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed
-    /// using keccak256.
-    pub fn hash_message<S>(message: S) -> H256
-    where
-        S: AsRef<[u8]>,
-    {
-        let message = message.as_ref();
-
-        let mut eth_message = format!("{PREFIX}{}", message.len()).into_bytes();
-        eth_message.extend_from_slice(message);
-        keccak256(&eth_message).into()
-    }
-
-    /// Compute the Keccak-256 hash of input bytes.
-    // TODO: Add Solidity Keccak256 packing support
-    pub fn keccak256<S>(bytes: S) -> [u8; 32]
-    where
-        S: AsRef<[u8]>,
-    {
+    /// Wrap a signing hash in EIP-191. Signable always supplies exactly 32 bytes.
+    pub fn hash_message(message: H256) -> H256 {
         let mut output = [0u8; 32];
         let mut hasher = Keccak::v256();
-        hasher.update(bytes.as_ref());
+        hasher.update(b"\x19Ethereum Signed Message:\n32");
+        hasher.update(message.as_ref());
         hasher.finalize(&mut output);
-        output
+        output.into()
     }
 
     #[test]
-    #[cfg(feature = "ethers")]
-    fn ensure_signed_hashes_match() {
-        assert_eq!(
-            ethers_core::utils::hash_message(b"gm crypto!"),
-            hash_message(b"gm crypto!").into()
-        );
-        assert_eq!(
-            ethers_core::utils::hash_message(b"hyperlane"),
-            hash_message(b"hyperlane").into()
-        );
+    fn signed_hashes_match_legacy_envelope() {
+        // Compare the streamed implementation with the original concatenated
+        // envelope for every repeated byte and every single-bit position.
+        let values = (0..=u8::MAX)
+            .map(H256::repeat_byte)
+            .chain((0..256).map(|bit| {
+                let mut bytes = [0; 32];
+                bytes[bit / 8] = 1 << (bit % 8);
+                H256::from(bytes)
+            }));
+        for value in values {
+            let mut envelope =
+                format!("\x19Ethereum Signed Message:\n{}", value.as_bytes().len()).into_bytes();
+            envelope.extend_from_slice(value.as_bytes());
+            let mut expected = [0; 32];
+            let mut hasher = Keccak::v256();
+            hasher.update(&envelope);
+            hasher.finalize(&mut expected);
+            assert_eq!(hash_message(value), H256::from(expected));
+            #[cfg(feature = "ethers")]
+            assert_eq!(
+                hash_message(value),
+                H256::from(ethers_core::utils::hash_message(value.as_bytes()).0)
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Checkpoint, CheckpointWithMessageId, U256};
+
+    struct LegacySigned<'a>(&'a SignedType<CheckpointWithMessageId>);
+
+    impl Serialize for LegacySigned<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("SignedType", 3)?;
+            state.serialize_field("value", &self.0.value)?;
+            state.serialize_field("signature", &self.0.signature)?;
+            let sig: [u8; 65] = self.0.signature.into();
+            state.serialize_field("serialized_signature", &crate::utils::bytes_to_hex(&sig))?;
+            state.end()
+        }
+    }
+
+    #[test]
+    fn signed_json_preserves_signature_encoding_and_roundtrip() {
+        for v in [0, 1, 27, 28, 255, 256, u64::MAX] {
+            for limb in [U256::zero(), U256::one(), U256::MAX] {
+                let signed = SignedType {
+                    value: CheckpointWithMessageId {
+                        checkpoint: Checkpoint {
+                            merkle_tree_hook_address: H256::repeat_byte(0x11),
+                            mailbox_domain: 42161,
+                            root: H256::repeat_byte(0x22),
+                            index: 2_500_000,
+                        },
+                        message_id: H256::repeat_byte(0x33),
+                    },
+                    signature: Signature {
+                        r: limb,
+                        s: limb,
+                        v,
+                    },
+                };
+                let json = serde_json::to_vec(&signed).unwrap();
+                assert_eq!(json, serde_json::to_vec(&LegacySigned(&signed)).unwrap());
+                assert_eq!(
+                    serde_json::to_vec_pretty(&signed).unwrap(),
+                    serde_json::to_vec_pretty(&LegacySigned(&signed)).unwrap()
+                );
+                let decoded: SignedType<CheckpointWithMessageId> =
+                    serde_json::from_slice(&json).unwrap();
+                assert_eq!(decoded, signed);
+                let json: serde_json::Value = serde_json::from_slice(&json).unwrap();
+                assert_eq!(json["serialized_signature"].as_str().unwrap().len(), 132);
+            }
+        }
     }
 }

--- a/rust/main/hyperlane-core/src/types/message.rs
+++ b/rust/main/hyperlane-core/src/types/message.rs
@@ -18,9 +18,7 @@ pub type RawHyperlaneMessage = Vec<u8>;
 
 impl From<&HyperlaneMessage> for RawHyperlaneMessage {
     fn from(m: &HyperlaneMessage) -> Self {
-        let mut message_vec = vec![];
-        m.write_to(&mut message_vec).expect("!write_to");
-        message_vec
+        m.to_vec()
     }
 }
 
@@ -107,6 +105,13 @@ impl From<&RawHyperlaneMessage> for HyperlaneMessage {
 }
 
 impl Encode for HyperlaneMessage {
+    fn to_vec(&self) -> Vec<u8> {
+        let mut bytes =
+            Vec::with_capacity(HYPERLANE_MESSAGE_PREFIX_LEN.saturating_add(self.body.len()));
+        self.write_to(&mut bytes).expect("!alloc");
+        bytes
+    }
+
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
         W: std::io::Write,
@@ -186,6 +191,30 @@ mod tests {
 
     fn valid_message_bytes() -> RawHyperlaneMessage {
         RawHyperlaneMessage::from(&sample_message())
+    }
+
+    #[test]
+    fn owned_encodings_match_canonical_writer_at_capacity_boundaries() {
+        use crate::Encode;
+
+        for body_len in [0, 1, 4, 5, 31, 32, 63, 64, 127, 128, 4096, 65536] {
+            for nonce in [0, 42, u32::MAX] {
+                let message = HyperlaneMessage {
+                    nonce,
+                    body: (0..body_len).map(|i| i as u8).collect(),
+                    ..sample_message()
+                };
+                let mut canonical = Vec::new();
+                let written = message.write_to(&mut canonical).unwrap();
+                assert_eq!(written, HYPERLANE_MESSAGE_PREFIX_LEN + body_len);
+                assert_eq!(message.to_vec(), canonical);
+                assert_eq!(RawHyperlaneMessage::from(&message), canonical);
+                assert_eq!(
+                    HyperlaneMessage::read_from(&mut canonical.as_slice()).unwrap(),
+                    message
+                );
+            }
+        }
     }
 
     #[test]

--- a/rust/main/lander/src/dispatcher/db.rs
+++ b/rust/main/lander/src/dispatcher/db.rs
@@ -5,3 +5,6 @@ mod transaction;
 pub use loader::*;
 pub use payload::*;
 pub use transaction::*;
+
+#[cfg(test)]
+mod json_decode_tests;

--- a/rust/main/lander/src/dispatcher/db/json_decode_tests.rs
+++ b/rust/main/lander/src/dispatcher/db/json_decode_tests.rs
@@ -1,0 +1,260 @@
+use std::fmt::Debug;
+
+use hyperlane_base::db::{HyperlaneRocksDB, DB};
+use hyperlane_core::{Decode, HyperlaneProtocolError, KnownHyperlaneDomain};
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::{PayloadDb, TransactionDb};
+use crate::adapter::chains::ethereum::tests::{dummy_evm_tx, ExpectedTxType};
+use crate::{payload::FullPayload, tests::test_utils::dummy_tx, transaction::TransactionStatus};
+
+fn assert_json_decode_equivalence<T>(value: &T)
+where
+    T: Decode + Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    let bytes = serde_json::to_vec(value).unwrap();
+    let json = String::from_utf8(bytes.clone()).unwrap();
+    let mut invalid_utf8 = bytes.clone();
+    let at = bytes
+        .windows(12)
+        .position(|s| s == b"probe marker")
+        .unwrap();
+    invalid_utf8[at] = 255;
+    let duplicate_status =
+        serde_json::to_string(&serde_json::to_value(value).unwrap()["status"]).unwrap();
+    let cases = [
+        ("valid", bytes.clone()),
+        ("truncated", bytes[..bytes.len() - 1].to_vec()),
+        ("whitespace", [bytes.as_slice(), b" \n\t"].concat()),
+        ("trailing JSON", [bytes.as_slice(), b"{}"].concat()),
+        ("trailing junk", [bytes.as_slice(), b"x"].concat()),
+        ("trailing invalid byte", [bytes.as_slice(), &[255]].concat()),
+        ("wrong type", b"[]".to_vec()),
+        ("empty", vec![]),
+        (
+            "unknown field",
+            [b"{\"unused_probe\":true,".as_slice(), &bytes[1..]].concat(),
+        ),
+        (
+            "duplicate field",
+            [
+                format!("{{\"status\":{duplicate_status},").as_bytes(),
+                &bytes[1..],
+            ]
+            .concat(),
+        ),
+        (
+            "invalid escape",
+            json.replace("probe marker", r"\q").into_bytes(),
+        ),
+        (
+            "invalid surrogate",
+            json.replace("probe marker", r"\uD800").into_bytes(),
+        ),
+        (
+            "escaped Unicode",
+            json.replace("probe marker", r"line\n\uD83D\uDE00")
+                .into_bytes(),
+        ),
+        ("invalid UTF-8 string", invalid_utf8),
+    ];
+    for (name, input) in cases {
+        let reader = T::read_from(&mut input.as_slice());
+        let slice = T::read_from_slice(&input);
+        match (reader, slice) {
+            (Ok(reader), Ok(slice)) => assert_eq!(reader, slice, "{name}"),
+            (
+                Err(HyperlaneProtocolError::IoError(reader)),
+                Err(HyperlaneProtocolError::IoError(slice)),
+            ) => {
+                assert_eq!(reader.kind(), slice.kind(), "{name}");
+                assert!(reader
+                    .to_string()
+                    .starts_with("Failed to deserialize. Error: "));
+                assert!(slice
+                    .to_string()
+                    .starts_with("Failed to deserialize. Error: "));
+                // Serde's reader and slice parser can report different source
+                // columns; preserve acceptance/category rather than exact text.
+                let reader = serde_json::from_reader::<_, T>(input.as_slice()).unwrap_err();
+                let slice = serde_json::from_slice::<T>(&input).unwrap_err();
+                assert_eq!(reader.classify(), slice.classify(), "{name}");
+            }
+            outcomes => panic!("{name}: inconsistent decode outcomes: {outcomes:?}"),
+        }
+    }
+}
+
+#[test]
+fn payload_and_transaction_slice_decoders_match_reader_contracts() {
+    for length in [0, 32, 4096] {
+        let mut payload = FullPayload::default();
+        payload.data = vec![17; length];
+        payload.details.metadata = "probe marker".to_owned();
+        payload.details.success_criteria = Some(vec![17; length]);
+        let transaction = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
+        assert_json_decode_equivalence(&payload);
+        assert_json_decode_equivalence(&transaction);
+        let evm = dummy_evm_tx(
+            ExpectedTxType::Eip1559,
+            vec![payload],
+            TransactionStatus::PendingInclusion,
+            ethers::types::H160::zero(),
+        );
+        assert_json_decode_equivalence(&evm);
+    }
+}
+
+#[tokio::test]
+async fn slice_decoded_records_survive_database_reopen() {
+    let directory = tempfile::tempdir().unwrap();
+    let domain = KnownHyperlaneDomain::Arbitrum.into();
+    let db = HyperlaneRocksDB::new(&domain, DB::from_path(directory.path()).unwrap());
+    let mut payload = FullPayload::random();
+    payload.data = vec![17; 4096];
+    payload.details.metadata = "Unicode payload 🦀".to_owned();
+    let transaction = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
+    db.store_payload_by_uuid(&payload).await.unwrap();
+    db.store_transaction_by_uuid(&transaction).await.unwrap();
+    let read_payload = db
+        .retrieve_payload_by_uuid(&payload.details.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    let read_transaction = db
+        .retrieve_transaction_by_uuid(&transaction.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    drop(db);
+    assert_eq!(read_payload, payload);
+    assert_eq!(read_transaction, transaction);
+    let db = HyperlaneRocksDB::new(&domain, DB::from_path(directory.path()).unwrap());
+    assert_eq!(
+        db.retrieve_payload_by_uuid(&payload.details.uuid)
+            .await
+            .unwrap(),
+        Some(payload)
+    );
+    assert_eq!(
+        db.retrieve_transaction_by_uuid(&transaction.uuid)
+            .await
+            .unwrap(),
+        Some(transaction)
+    );
+}
+
+#[tokio::test]
+async fn uuid_point_getters_preserve_encoded_keys_errors_and_reopen() {
+    use crate::transaction::Transaction;
+    use hyperlane_core::{identifiers::UniqueIdentifier, Encode};
+    for byte in 0..=255 {
+        let key = UniqueIdentifier::new(uuid::Uuid::from_bytes([byte; 16]));
+        assert_eq!(Encode::to_vec(&key), key.as_bytes());
+    }
+    let directory = tempfile::tempdir().unwrap();
+    let domain = KnownHyperlaneDomain::Arbitrum.into();
+    let key = UniqueIdentifier::new(uuid::Uuid::from_bytes([0x81; 16]));
+    let mut payload = FullPayload::default();
+    payload.details.uuid = key.clone();
+    payload.data = vec![17; 4096];
+    let mut transaction = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
+    transaction.uuid = key.clone();
+    let raw = DB::from_path(directory.path()).unwrap();
+    let db = HyperlaneRocksDB::new(&domain, raw.clone());
+    assert!(db.retrieve_payload_by_uuid(&key).await.unwrap().is_none());
+    assert!(db
+        .retrieve_payload_index_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_transaction_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_transaction_index_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+
+    // Seed keys through the unchanged canonical Encode API, as existing databases do.
+    db.store_value_by_key("payload_by_uuid_", &key, &payload)
+        .unwrap();
+    db.store_value_by_key("transaction_by_uuid_", &key, &transaction)
+        .unwrap();
+    db.store_value_by_key("payload_index_by_uuid_", &key, &42u32)
+        .unwrap();
+    db.store_value_by_key("tx_index_by_uuid_", &key, &84u32)
+        .unwrap();
+    let other = HyperlaneRocksDB::new(&KnownHyperlaneDomain::Ethereum.into(), raw.clone());
+    assert!(other
+        .retrieve_payload_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+    drop(other);
+    macro_rules! compare {
+        ($method:ident, $prefix:literal, $value:expr, $ty:ty) => {
+            assert_eq!(db.$method(&key).await.unwrap(), Some($value.clone()));
+            let encoded_key = [
+                b"arbitrum_".as_slice(),
+                $prefix.as_bytes(),
+                &Encode::to_vec(&key),
+            ]
+            .concat();
+            raw.store(&encoded_key, &[255]).unwrap();
+            let old_error = db
+                .retrieve_value_by_key::<_, $ty>($prefix, &key)
+                .unwrap_err();
+            let new_error = db.$method(&key).await.unwrap_err();
+            assert_eq!(new_error.to_string(), old_error.to_string());
+            db.store_value_by_key($prefix, &key, &$value).unwrap();
+            assert_eq!(db.$method(&key).await.unwrap(), Some($value.clone()));
+        };
+    }
+    compare!(
+        retrieve_payload_by_uuid,
+        "payload_by_uuid_",
+        payload,
+        FullPayload
+    );
+    compare!(
+        retrieve_transaction_by_uuid,
+        "transaction_by_uuid_",
+        transaction,
+        Transaction
+    );
+    compare!(
+        retrieve_payload_index_by_uuid,
+        "payload_index_by_uuid_",
+        42u32,
+        u32
+    );
+    compare!(
+        retrieve_transaction_index_by_uuid,
+        "tx_index_by_uuid_",
+        84u32,
+        u32
+    );
+    drop(db);
+    drop(raw);
+    let db = HyperlaneRocksDB::new(&domain, DB::from_path(directory.path()).unwrap());
+    assert_eq!(
+        db.retrieve_payload_by_uuid(&key).await.unwrap(),
+        Some(payload)
+    );
+    assert_eq!(
+        db.retrieve_transaction_by_uuid(&key).await.unwrap(),
+        Some(transaction)
+    );
+    assert_eq!(
+        db.retrieve_payload_index_by_uuid(&key).await.unwrap(),
+        Some(42)
+    );
+    assert_eq!(
+        db.retrieve_transaction_index_by_uuid(&key).await.unwrap(),
+        Some(84)
+    );
+}

--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -151,7 +151,7 @@ impl PayloadDb for HyperlaneRocksDB {
         &self,
         payload_uuid: &PayloadUuid,
     ) -> DbResult<Option<FullPayload>> {
-        self.retrieve_value_by_key(PAYLOAD_BY_UUID_STORAGE_PREFIX, payload_uuid)
+        self.retrieve_decodable(PAYLOAD_BY_UUID_STORAGE_PREFIX, payload_uuid.as_bytes())
     }
 
     async fn store_payload_by_uuid(&self, payload: &FullPayload) -> DbResult<()> {
@@ -231,7 +231,10 @@ impl PayloadDb for HyperlaneRocksDB {
         &self,
         payload_uuid: &PayloadUuid,
     ) -> DbResult<Option<u32>> {
-        self.retrieve_value_by_key(PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX, payload_uuid)
+        self.retrieve_decodable(
+            PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX,
+            payload_uuid.as_bytes(),
+        )
     }
 
     async fn store_payload_index_by_uuid(
@@ -413,6 +416,14 @@ impl Decode for FullPayload {
     {
         // Deserialize from JSON and read from the reader, to avoid having to implement the encoding / decoding manually
         serde_json::from_reader(reader).map_err(|err| {
+            HyperlaneProtocolError::IoError(std::io::Error::other(format!(
+                "Failed to deserialize. Error: {err}"
+            )))
+        })
+    }
+
+    fn read_from_slice(bytes: &[u8]) -> Result<Self, HyperlaneProtocolError> {
+        serde_json::from_slice(bytes).map_err(|err| {
             HyperlaneProtocolError::IoError(std::io::Error::other(format!(
                 "Failed to deserialize. Error: {err}"
             )))

--- a/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
+++ b/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
@@ -75,7 +75,7 @@ impl TransactionDb for HyperlaneRocksDB {
         &self,
         tx_uuid: &TransactionUuid,
     ) -> DbResult<Option<Transaction>> {
-        self.retrieve_value_by_key(TRANSACTION_BY_UUID_STORAGE_PREFIX, tx_uuid)
+        self.retrieve_decodable(TRANSACTION_BY_UUID_STORAGE_PREFIX, tx_uuid.as_bytes())
     }
 
     async fn store_transaction_by_uuid(&self, tx: &Transaction) -> DbResult<()> {
@@ -99,7 +99,7 @@ impl TransactionDb for HyperlaneRocksDB {
         &self,
         tx_uuid: &TransactionUuid,
     ) -> DbResult<Option<u32>> {
-        self.retrieve_value_by_key(TRANSACTION_INDEX_BY_UUID_STORAGE_PREFIX, tx_uuid)
+        self.retrieve_decodable(TRANSACTION_INDEX_BY_UUID_STORAGE_PREFIX, tx_uuid.as_bytes())
     }
 
     async fn store_transaction_index_by_uuid(
@@ -161,6 +161,14 @@ impl Decode for Transaction {
     {
         // Deserialize from JSON and read from the reader, to avoid having to implement the encoding / decoding manually
         serde_json::from_reader(reader).map_err(|err| {
+            HyperlaneProtocolError::IoError(std::io::Error::other(format!(
+                "Failed to deserialize. Error: {err}"
+            )))
+        })
+    }
+
+    fn read_from_slice(bytes: &[u8]) -> Result<Self, HyperlaneProtocolError> {
+        serde_json::from_slice(bytes).map_err(|err| {
             HyperlaneProtocolError::IoError(std::io::Error::other(format!(
                 "Failed to deserialize. Error: {err}"
             )))


### PR DESCRIPTION
Stack: follows #9472.

## Problem

Checkpoint signing/JSON output and typed database operations create temporary buffers that are immediately hashed, copied or decoded. Lander JSON reads use a reader parser despite already owning the complete input, and canonical message output repeatedly grows its buffer.

## Solution

Use fixed EIP-191/signature buffers, synchronously decode pinned RocksDB values, provide slice decoding with a behavior-preserving default and two owned Lander JSON overrides, move boxed prefix values, borrow canonical UUID key bytes, and reserve the exact message encoding capacity. Keep public wire formats, canonical writers, signing/recovery inputs, database options, owned return values and eager prefix/error ordering unchanged.

Consolidates #9489, #9492, #9495, #9505, #9513 and #9526. These shared paths benefit validator, relayer and Lander; they stay on the existing validator storage stack.

## Numerical evidence

| Path | Evidence |
|---|---|
| EIP-191 envelope preparation | Exact-source allocation probe: 3 → 0 calls, 182 → 0 requested bytes; same 60 hash-input bytes and one Keccak. Not ECC/recovery CPU. |
| Signature JSON field | Full synthetic signed-checkpoint serde output remains exactly 644 bytes; 7 → 4 allocation/reallocation calls, 2,186 → 1,920 requested bytes. Output-buffer allocations remain. |
| Typed RocksDB input | Actual local DB Merkle insertion: 2 → 1 Rust allocations, 52 → 16 requested bytes. A 4-KiB message: 3 → 2, 8,285 → 4,112. Native RocksDB allocations excluded; decoded body/key allocations remain. |
| FullPayload slice JSON parser | Optimized 45-pair measurement: 4-KiB data fixture reader median 52,852ns → slice median 34,240ns; median paired reduction 35.2%. At 64KiB: 804,213ns → 528,135ns, paired reduction 34.5%. Includes decode/allocation/drop, excludes fixture creation. Ratios of displayed medians differ from median paired reductions. |
| JSON parser allocation | Separate fixture probe removes 5 allocations / 248 requested bytes. Transaction compatibility tested but performance unbenchmarked. |
| UUID key preparation | Four actual Lander point-read paths remove 1 allocation / 16 requested bytes per read; separate from encoded-input/parser savings. |
| Canonical message output | Actual message type with a source-equivalent reservation helper linked to the frozen pre-change library: empty body 4 → 1 allocations, 147 → 77 requested bytes; 4-KiB body 5 → 1, 4,320 → 4,173. Canonical output unchanged. |

Each row isolates a different mechanism and may share surrounding work with another probe; do not sum rows into an end-to-end CPU/RSS estimate. Prefix Box::into_vec separately removes one encoded-value copy per pending-payload startup record; the full eager encoded collection still exists, and this startup saving is excluded from parser timings.

## Validation and compatibility

At the reordered boundary, fresh full library suites passed: core 76, base 100 and Lander 355; four existing tests were ignored, with zero failures. Tests used the emitted binaries and the primary checkout cwd for the existing core/base .git fixture. Qualified package Clippy passed: core used the existing cfg(dev) declaration and manual Filter::Default allowance; base used the dev/serde cfg declarations and lifetime-syntax allowance; Lander allowed the existing cloned_ref_to_slice_refs warning (its cleanup belongs to the relayer stack). These are baseline-qualified checks, with no source suppressions. Normal commit hooks and both Rust workspace formatting checks passed. Existing tests cover 512 EIP-191 vectors; 21 exact compact/pretty signature-JSON cases; missing/malformed/domain-isolated DB reads and ownership across close/reopen; default binary trailing/short-input behavior; actual point/prefix override dispatch and ordered errors; a 126-case FullPayload/CosmWasm/EIP-1559 JSON oracle; UUID legacy-key writes/readbacks; and 36 message writer/owned-encoding/decoder boundary fixtures.

JSON acceptance, error category and existing wrapper remain compatible; diagnostic positions can differ (one duplicate-field fixture: reader column199 versus slice198). Fixed-length binary decoders retain their original trailing-byte behavior. Public Encode::write_to and raw DB read API remain unchanged.

External composition: relayer #9496 Lander Encode overrides share two files with these Decode/UUID edits; integration uses pairwise merge-tree results. Relayer #9469 (formerly #9493) streams message ID directly to Keccak, so exact-capacity gains apply only to remaining owned Encode/RawFrom calls after that change; do not double-count eliminated hashing buffers. The final test-local Encode import merges cleanly with those ID tests. #9448 snapshots reduce read count, while pin/slice gains apply to remaining reads. No pooling, polling or signing-authority change.

The committed final three-group tree exactly equals original validator head 58ea432c127226057bdde65bb3431f12a883da42; consolidation changes commit grouping only.

### 7 September restack

Rebased unchanged onto #9472 at `dc207c0145`; exact-head `git diff --check` and Rust formatting passed. CI is rerunning for the rewritten head.