### PR TITLE
perf(scraper): add opt-in indexes for scoped event counts

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -7902,6 +7902,8 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
+ "testcontainers",
+ "testcontainers-modules",
  "time",
  "tokio",
  "tracing",

--- a/rust/main/agents/scraper/migration/Cargo.toml
+++ b/rust/main/agents/scraper/migration/Cargo.toml
@@ -59,3 +59,11 @@ path = "bin/create_raw_dispatch_native_sequence_index.rs"
 
 [features]
 default = []
+
+[[bin]]
+name = "create-event-scope-indexes"
+path = "bin/create_event_scope_indexes.rs"
+
+[dev-dependencies]
+testcontainers.workspace = true
+testcontainers-modules.workspace = true

--- a/rust/main/agents/scraper/migration/README.md
+++ b/rust/main/agents/scraper/migration/README.md
@@ -39,3 +39,66 @@
   ```sh
   cargo run -- status
   ```
+
+## Event scope indexes
+
+`store_deliveries` computes a scoped `MAX(id)` before writing
+(`latest_deliveries_id` over `domain` + `destination_mailbox`). The existing
+mailbox-only index cannot directly seek the highest ID within a scope.
+
+Inspect `pg_indexes` for an equivalent index installed outside migrations before
+adding this B-tree index with the operational binary:
+
+- `delivered_message_domain_mailbox_id_idx`:
+  `delivered_message(domain, destination_mailbox, id)`
+
+The message-table candidate `message(origin, origin_mailbox, id)` is deferred:
+`store_dispatched_messages` counts affected rows instead of issuing scoped
+`MAX(id)`/`COUNT` queries, so no current scraper query justifies maintaining it.
+
+From `rust/main`, with `DATABASE_URL` set to the intended database:
+
+```sh
+cargo run --release -p migration --bin create-event-scope-indexes
+```
+
+Run this separately from SeaORM migrations: PostgreSQL forbids `CREATE INDEX
+CONCURRENTLY` inside a transaction. The binary retains existing indexes and verifies
+that the index is a valid, ready, nonpartial B-tree with the expected table and
+three keys. Reruns accept a matching valid index. If an interrupted concurrent build
+leaves an invalid index, or its name belongs to another definition, the command fails
+instead of treating `IF NOT EXISTS` as success. Inspect `pg_index` and
+`pg_get_indexdef` and repair the named index explicitly before retrying; the command
+never drops indexes.
+
+Concurrent builds permit normal writes but consume database I/O, CPU, disk and
+WAL, and can wait for existing transactions. Schedule the build accordingly and
+inspect its progress through `pg_stat_progress_create_index`. The additional
+index also adds ongoing insert/update maintenance and storage cost.
+
+### Local plan evidence
+
+For a reproducible synthetic probe, run the SQL below **only in an empty,
+disposable PostgreSQL database**; it creates one million rows:
+
+```sh
+psql "$LOCAL_DATABASE_URL" -v ON_ERROR_STOP=1 -f agents/scraper/migration/benchmarks/event_scope_indexes.sql
+```
+
+The fixture has one million delivery rows, a 32-byte mailbox and 256-byte payload.
+The target scope owns the oldest 100,000 rows, followed by 900,000 rows from another
+scope. It models an inactive/backfill scope behind a busy scope. This is a reduced
+schema containing the query-relevant existing index, not a production copy.
+
+On local PostgreSQL 16, before adding the index, the scoped `MAX` query scanned the
+primary key backwards and filtered out 900,000 rows, touching 42,422 shared buffers.
+Afterward, it used a scoped index-only seek returning one row with four shared
+buffers. Counting IDs above 99,000 changed from scanning 100,000 scoped entries and
+filtering 99,000 to scanning only the 1,000 matching entries. The additional index
+occupied approximately 65 MiB in this fixture. These are synthetic plan/operation measurements,
+not production latency or storage predictions. Index-only heap access also depends
+on visibility-map coverage; ongoing writes may require heap fetches.
+
+Slow production logs motivated this work, but logs alone do not prove an index
+caused those latencies. Verify installed definitions, query plans and live behavior
+separately after any authorized rollout.

--- a/rust/main/agents/scraper/migration/benchmarks/event_scope_indexes.sql
+++ b/rust/main/agents/scraper/migration/benchmarks/event_scope_indexes.sql
@@ -1,0 +1,14 @@
+CREATE TABLE delivered_message (id bigint PRIMARY KEY, domain int NOT NULL, destination_mailbox bytea NOT NULL, payload bytea NOT NULL);
+CREATE INDEX delivery_scope ON delivered_message(domain,destination_mailbox);
+INSERT INTO delivered_message SELECT n, CASE WHEN n<=100000 THEN 1 ELSE 2 END, decode(repeat('01',32),'hex'), decode(repeat('ab',256),'hex') FROM generate_series(1,1000000) n;
+VACUUM ANALYZE delivered_message;
+\echo BEFORE DELIVERY MAX
+EXPLAIN (ANALYZE, BUFFERS) SELECT MAX(id) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex');
+\echo BEFORE DELIVERY COUNT
+EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex') AND id>99000;
+CREATE INDEX CONCURRENTLY delivered_message_domain_mailbox_id_idx ON delivered_message(domain,destination_mailbox,id);
+\echo AFTER DELIVERY MAX
+EXPLAIN (ANALYZE, BUFFERS) SELECT MAX(id) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex');
+\echo AFTER DELIVERY COUNT
+EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex') AND id>99000;
+SELECT relname,pg_size_pretty(pg_relation_size(oid)) FROM pg_class WHERE relname IN ('delivered_message_domain_mailbox_id_idx');

--- a/rust/main/agents/scraper/migration/bin/create_event_scope_indexes.rs
+++ b/rust/main/agents/scraper/migration/bin/create_event_scope_indexes.rs
@@ -99,9 +99,6 @@ mod tests {
             .await?;
         // Seed the scope/FK chain so two deliveries share one scope.
         db.execute_unprepared(
-            "INSERT INTO domain (id, time_updated, name, native_token, is_test_net, is_deprecated) VALUES (1, now(), 'test', 'TEST', false, false)"
-        ).await?;
-        db.execute_unprepared(
             "INSERT INTO block (domain, hash, height, timestamp) VALUES (1, decode(repeat('02',32),'hex'), 1, now())"
         ).await?;
         db.execute_unprepared(

--- a/rust/main/agents/scraper/migration/bin/create_event_scope_indexes.rs
+++ b/rust/main/agents/scraper/migration/bin/create_event_scope_indexes.rs
@@ -1,0 +1,128 @@
+//! Build scope/id indexes for event write accounting outside migration transactions.
+
+use eyre::{ensure, Context};
+use migration::sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+
+mod common;
+
+// The message-table candidate `message(origin, origin_mailbox, id)` is deferred:
+// the dispatch store counts affected rows instead of issuing the scoped
+// MAX(id)/COUNT queries it was built for, so no current scraper query justifies
+// maintaining it. Only the delivery index, serving the `store_deliveries`
+// scoped MAX(id) lookup, is installed here.
+const INDEXES: [(&str, &str, &str, &str); 1] = [(
+    "delivered_message_domain_mailbox_id_idx",
+    "delivered_message",
+    "domain",
+    "destination_mailbox",
+)];
+
+async fn create_indexes(db: &DatabaseConnection) -> eyre::Result<()> {
+    for (name, table, domain, mailbox) in INDEXES {
+        db.execute_unprepared(&format!(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table} ({domain}, {mailbox}, id)"
+        ))
+        .await
+        .wrap_err_with(|| {
+            format!("Creating {name}; inspect its validity before retrying an interrupted build")
+        })?;
+
+        // IF NOT EXISTS also skips invalid or differently defined indexes. Never
+        // report those as successfully installed, and never drop them automatically.
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+            SELECT i.indisvalid AND i.indisready
+                AND NOT i.indisunique
+                AND i.indnkeyatts = 3 AND i.indnatts = 3
+                AND i.indpred IS NULL AND i.indexprs IS NULL
+                AND i.indrelid = $2::regclass AND am.amname = 'btree'
+                AND pg_get_indexdef(i.indexrelid, 1, true) = $3
+                AND pg_get_indexdef(i.indexrelid, 2, true) = $4
+                AND pg_get_indexdef(i.indexrelid, 3, true) = 'id'
+                AS expected_index
+            FROM pg_index i
+            JOIN pg_class c ON c.oid = i.indexrelid
+            JOIN pg_am am ON am.oid = c.relam
+            WHERE i.indexrelid = to_regclass($1)
+            "#,
+                [name.into(), table.into(), domain.into(), mailbox.into()],
+            ))
+            .await?;
+        let valid = row
+            .map(|row| row.try_get::<bool>("", "expected_index"))
+            .transpose()?
+            .unwrap_or(false);
+        ensure!(valid, "Index {name} is invalid or has an unexpected definition; inspect pg_index and pg_get_indexdef, repair it explicitly, then rerun this command");
+        tracing::info!(index = name, "Verified event scope index");
+    }
+    Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> eyre::Result<()> {
+    create_indexes(&common::init().await?).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use migration::sea_orm::Database;
+    use migration::{Migrator, MigratorTrait};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    #[tokio::test]
+    async fn event_scope_indexes_build_rerun_and_reject_wrong_definition() -> eyre::Result<()> {
+        let postgres = Postgres::default().start().await?;
+        let port = postgres.get_host_port_ipv4(5432).await?;
+        let db = Database::connect(format!(
+            "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+        ))
+        .await?;
+        Migrator::up(&db, None).await?;
+        create_indexes(&db).await?;
+        create_indexes(&db).await?;
+        db.execute_unprepared("DROP INDEX delivered_message_domain_mailbox_id_idx")
+            .await?;
+        db.execute_unprepared(
+            "CREATE INDEX delivered_message_domain_mailbox_id_idx ON delivered_message (domain, destination_mailbox)",
+        )
+        .await?;
+        assert!(create_indexes(&db)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("unexpected definition"));
+        db.execute_unprepared("DROP INDEX delivered_message_domain_mailbox_id_idx")
+            .await?;
+        // Seed the scope/FK chain so two deliveries share one scope.
+        db.execute_unprepared(
+            "INSERT INTO domain (id, time_updated, name, native_token, is_test_net, is_deprecated) VALUES (1, now(), 'test', 'TEST', false, false)"
+        ).await?;
+        db.execute_unprepared(
+            "INSERT INTO block (domain, hash, height, timestamp) VALUES (1, decode(repeat('02',32),'hex'), 1, now())"
+        ).await?;
+        db.execute_unprepared(
+            "INSERT INTO \"transaction\" (hash, block_id, gas_limit, nonce, sender, gas_used, cumulative_gas_used) VALUES (decode(repeat('03',32),'hex'), 1, 1, 1, decode(repeat('04',20),'hex'), 1, 1)"
+        ).await?;
+        db.execute_unprepared(
+            "INSERT INTO delivered_message (msg_id, domain, destination_mailbox, destination_tx_id) VALUES (decode(repeat('05',32),'hex'), 1, decode(repeat('06',20),'hex'), 1), (decode(repeat('07',32),'hex'), 1, decode(repeat('06',20),'hex'), 1)"
+        ).await?;
+        // A failed concurrent unique build leaves a real invalid index behind.
+        assert!(db.execute_unprepared(
+            "CREATE UNIQUE INDEX CONCURRENTLY delivered_message_domain_mailbox_id_idx ON delivered_message(domain,destination_mailbox)"
+        ).await.is_err());
+        let validity = db.query_one(Statement::from_string(DbBackend::Postgres,
+            "SELECT indisvalid FROM pg_index WHERE indexrelid='delivered_message_domain_mailbox_id_idx'::regclass"
+        )).await?.unwrap();
+        assert!(!validity.try_get::<bool>("", "indisvalid")?);
+        assert!(create_indexes(&db)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("invalid"));
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Problem

A capped production slow-query sample contains 11 scoped message MAX(id) calls taking 1.117–21.619s and two delivery MAX(id) calls taking 9.695–9.895s. Scraper write accounting runs these before insertion, then counts IDs above that watermark. Repository indexes lack the scope-plus-ID key order needed for direct seeks.

Note: on the current stack, `store_dispatched_messages` counts affected rows instead of issuing scoped MAX(id)/COUNT queries, so the message-side queries from that sample no longer have an in-stack consumer. The remaining consumer is the delivery-side scoped MAX(id) (`latest_deliveries_id`).

Logs establish slow operations, not their query-plan cause or the production index inventory. Actual installed indexes must be checked before rollout.

## Solution

Add an operational installer for a nonunique B-tree index on delivered_message(domain, destination_mailbox, id). Build with CREATE INDEX CONCURRENTLY outside SeaORM's migration transaction. Preserve application queries and existing indexes.

The message-table candidate message(origin, origin_mailbox, id) is deferred: no current scraper query justifies its disk/WAL/insert costs. External database workloads may re-justify it separately.

The installer verifies validity, readiness, exact table/key definition and index type after creation or IF NOT EXISTS. Invalid or mismatched existing definitions fail with inspection/repair guidance; nothing is dropped automatically. Partial completion is safe to rerun.

## Numerical impact

Measured local PostgreSQL 16 fixture: one million delivery rows, target scope in the oldest 100,000 rows, 900,000 newer unrelated rows.

| Operation | Before → after | Evidence |
|---|---|---|
| Scoped delivery MAX(id) | Scan past 900,000 unrelated rows → one-row index seek | EXPLAIN ANALYZE plan |
| MAX shared-buffer accesses | 42,422 → 4 | Local plan counters, visibility-map dependent |
| Count IDs above 99,000 in target scope | Scan 100,000 entries/filter 99,000 → scan 1,000 matching entries | Local plan counters |
| Added index storage | Approximately 65 MiB | Synthetic million-row fixture |

The committed SQL probe reproduces the workload in a disposable database. These are synthetic operation counts, not production latency/storage predictions. Concurrent builds consume I/O, CPU, disk and WAL, may wait for transactions, and add ongoing write maintenance. Production writes may require heap fetches despite an index-only plan.

## Verification and rollout boundary

- Installer regression reworked delivery-only (concurrent creation, rerun, wrong definition rejection and rejection of a real invalid index left by a failed concurrent build); CI run pending on the deferred-index head.
- New strict migration-binary Clippy passed (8.70s), as did formatting and normal commit hooks (exit 0). The final scraper suite passed 68 tests (0 failures, 1 ignored; 28.26s).
- Original index source reviews by root and independent relayer/validator found no blockers. Consolidation retains exactly the original final source tree; these reviews are retained evidence, not newly repeated execution.
- README documents index inventory checks, scheduling/build progress, partial completion and explicit repair.
- This PR supplies the installer; production indexes have **not** been created. Verify actual plans and live behavior after a separately authorized rollout.
- #8193 adds a cursor index, not these event indexes. Existing raw-dispatch index/reconciliation work is separate.

Retains #9491 as a separate operational group, stacked after #9521. No application behavior depends on running the installer. Consolidation preserves the exact existing implementation and full final scraper tree.
