### PR TITLE
perf(validator): serialize signature hex from a fixed buffer

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -489,17 +489,53 @@ impl ValidatorSubmitter {
         Ok(true)
     }
 
+    /// Publishes availability only after the highest checkpoint itself is durable.
+    async fn publish_latest_checkpoint_index(&self, index: u32) {
+        call_and_retry_indefinitely(|| {
+            let self_clone = self.clone();
+            Box::pin(async move {
+                let start = Instant::now();
+                let result = self_clone
+                    .checkpoint_syncer
+                    .update_latest_index(index)
+                    .await;
+                match result {
+                    Ok(()) => self_clone
+                        .readiness
+                        .mark_operation_ready("checkpoint_latest_index"),
+                    Err(error) => {
+                        let snapshot = self_clone
+                            .readiness
+                            .mark_operation_blocked("checkpoint_latest_index");
+                        warn!(
+                            operation = "checkpoint_latest_index",
+                            consecutive_failures = snapshot.consecutive_failures,
+                            failure_duration_ms = snapshot.failure_duration_ms,
+                            signing_blocked = snapshot.signing_blocked,
+                            "Validator latest checkpoint index update is blocked"
+                        );
+                        return Err(error.into());
+                    }
+                }
+                tracing::trace!(
+                    elapsed=?start.elapsed(),
+                    "Updated latest index",
+                );
+                Ok(())
+            })
+        })
+        .await;
+    }
+
     /// Signs and submits any previously unsubmitted checkpoints.
     async fn sign_and_submit_checkpoints(&self, mut checkpoints: Vec<CheckpointWithMessageId>) {
         // The checkpoints are ordered by index, so the last one is the highest index.
-        let last_checkpoint_index = match checkpoints.last() {
-            Some(c) => c.index,
+        let mut latest_index_to_publish = match checkpoints.last() {
+            Some(c) => Some(c.index),
             None => return,
         };
 
         let arc_self = Arc::new(self.clone());
-
-        let mut first_chunk = true;
 
         while !checkpoints.is_empty() {
             let start = Instant::now();
@@ -509,8 +545,7 @@ impl ValidatorSubmitter {
             // since those are the most likely to make messages become processable.
             // A side effect is that new checkpoints will also be submitted in reverse order.
 
-            // This logic is a bit awkward, but we want control over the chunks so we can also
-            // write the latest index to the checkpoint storage after the first chunk is successful.
+            // Keep bounded chunks so a storage/signing burst is paced before the next chunk.
             let mut chunk = Vec::with_capacity(self.max_sign_concurrency);
             for _ in 0..self.max_sign_concurrency {
                 if let Some(cp) = checkpoints.pop() {
@@ -524,41 +559,53 @@ impl ValidatorSubmitter {
 
             let futures = chunk.into_iter().map(|checkpoint| {
                 let self_clone = arc_self.clone();
-                let operation = format!("checkpoint_submission[{}]", checkpoint.index);
-                call_and_retry_indefinitely(move || {
-                    let self_clone = self_clone.clone();
-                    let operation = operation.clone();
-                    Box::pin(async move {
-                        let start = Instant::now();
-                        let checkpoint_index = checkpoint.index;
-                        let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
-                        let wrote_checkpoint = match result {
-                            Ok(wrote_checkpoint) => {
-                                self_clone.readiness.mark_operation_ready(&operation);
-                                wrote_checkpoint
-                            }
-                            Err(error) => {
-                                let snapshot =
-                                    self_clone.readiness.mark_operation_blocked(&operation);
-                                warn!(
-                                    operation,
-                                    consecutive_failures = snapshot.consecutive_failures,
-                                    failure_duration_ms = snapshot.failure_duration_ms,
-                                    signing_blocked = snapshot.signing_blocked,
-                                    "Validator checkpoint submission is blocked"
-                                );
-                                return Err(error);
-                            }
-                        };
-                        tracing::info!(
-                            index = checkpoint_index,
-                            wrote_checkpoint,
-                            elapsed=?start.elapsed(),
-                            "Processed checkpoint",
-                        );
-                        Ok(wrote_checkpoint)
+                // The first popped checkpoint alone owns publication, even if a caller
+                // supplied the same maximum index more than once.
+                let latest_index = latest_index_to_publish.take();
+                async move {
+                    let operation = format!("checkpoint_submission[{}]", checkpoint.index);
+                    let wrote_checkpoint = call_and_retry_indefinitely(|| {
+                        let self_clone = self_clone.clone();
+                        let operation = operation.clone();
+                        Box::pin(async move {
+                            let start = Instant::now();
+                            let checkpoint_index = checkpoint.index;
+                            let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
+                            let wrote_checkpoint = match result {
+                                Ok(wrote_checkpoint) => {
+                                    self_clone.readiness.mark_operation_ready(&operation);
+                                    wrote_checkpoint
+                                }
+                                Err(error) => {
+                                    let snapshot =
+                                        self_clone.readiness.mark_operation_blocked(&operation);
+                                    warn!(
+                                        operation,
+                                        consecutive_failures = snapshot.consecutive_failures,
+                                        failure_duration_ms = snapshot.failure_duration_ms,
+                                        signing_blocked = snapshot.signing_blocked,
+                                        "Validator checkpoint submission is blocked"
+                                    );
+                                    return Err(error);
+                                }
+                            };
+                            tracing::info!(
+                                index = checkpoint_index,
+                                wrote_checkpoint,
+                                elapsed=?start.elapsed(),
+                                "Processed checkpoint",
+                            );
+                            Ok(wrote_checkpoint)
+                        })
                     })
-                })
+                    .await;
+                    // Lower checkpoints may still be retrying. The latest index is an upper
+                    // bound, not a claim that every historical checkpoint has been uploaded.
+                    if let Some(index) = latest_index {
+                        self_clone.publish_latest_checkpoint_index(index).await;
+                    }
+                    wrote_checkpoint
+                }
             });
 
             let wrote_checkpoint = join_all(futures).await.into_iter().any(|wrote| wrote);
@@ -569,45 +616,6 @@ impl ValidatorSubmitter {
                 remaining_checkpoints = checkpoints.len(),
                 "Signed and submitted checkpoint chunk",
             );
-
-            // If it's the first chunk, update the latest index
-            if first_chunk {
-                call_and_retry_indefinitely(|| {
-                    let self_clone = self.clone();
-                    Box::pin(async move {
-                        let start = Instant::now();
-                        let result = self_clone
-                            .checkpoint_syncer
-                            .update_latest_index(last_checkpoint_index)
-                            .await;
-                        match result {
-                            Ok(()) => self_clone
-                                .readiness
-                                .mark_operation_ready("checkpoint_latest_index"),
-                            Err(error) => {
-                                let snapshot = self_clone
-                                    .readiness
-                                    .mark_operation_blocked("checkpoint_latest_index");
-                                warn!(
-                                    operation = "checkpoint_latest_index",
-                                    consecutive_failures = snapshot.consecutive_failures,
-                                    failure_duration_ms = snapshot.failure_duration_ms,
-                                    signing_blocked = snapshot.signing_blocked,
-                                    "Validator latest checkpoint index update is blocked"
-                                );
-                                return Err(error.into());
-                            }
-                        }
-                        tracing::trace!(
-                            elapsed=?start.elapsed(),
-                            "Updated latest index",
-                        );
-                        Ok(())
-                    })
-                })
-                .await;
-                first_chunk = false;
-            }
 
             // Pace storage/signing bursts between chunks without delaying the latest-index
             // update, throttling all-existing backfills, or adding a final-chunk tail.

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -100,6 +100,183 @@ fn dummy_readiness() -> Arc<ValidatorReadiness> {
     Arc::new(ValidatorReadiness::default())
 }
 
+fn submission_test_submitter(
+    syncer: MockCheckpointSyncer,
+    readiness: Arc<ValidatorReadiness>,
+) -> ValidatorSubmitter {
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        2,
+        Arc::new(MockReorgReporter::new()),
+        readiness,
+    )
+}
+
+fn submission_checkpoint(index: u32) -> CheckpointWithMessageId {
+    CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index,
+        },
+        message_id: H256::zero(),
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_waits_for_newest_checkpoint_but_not_older_siblings() {
+    for failing_index in [7, 8] {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let failures = Arc::new(AtomicUsize::new(0));
+        let newest_written = Arc::new(AtomicBool::new(false));
+        let published = Arc::new(AtomicBool::new(false));
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_fetch_checkpoint()
+            .times(3)
+            .returning(|_| Ok(None));
+        syncer.expect_write_checkpoint().times(3).returning({
+            let attempts = Arc::clone(&attempts);
+            let failures = Arc::clone(&failures);
+            let newest_written = Arc::clone(&newest_written);
+            move |checkpoint| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                if checkpoint.value.index == failing_index
+                    && failures.fetch_add(1, Ordering::SeqCst) == 0
+                {
+                    return Err(eyre::eyre!("transient checkpoint upload failure"));
+                }
+                if checkpoint.value.index == 8 {
+                    newest_written.store(true, Ordering::SeqCst);
+                }
+                Ok(())
+            }
+        });
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq(8))
+            .once()
+            .returning({
+                let newest_written = Arc::clone(&newest_written);
+                let published = Arc::clone(&published);
+                move |_| {
+                    assert!(newest_written.load(Ordering::SeqCst));
+                    published.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            });
+        let readiness = dummy_readiness();
+        let submitter = submission_test_submitter(syncer, Arc::clone(&readiness));
+        let task = tokio::spawn(async move {
+            submitter
+                .sign_and_submit_checkpoints(vec![
+                    submission_checkpoint(7),
+                    submission_checkpoint(8),
+                ])
+                .await;
+        });
+        while attempts.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(published.load(Ordering::SeqCst), failing_index == 7);
+        assert!(
+            !task.is_finished(),
+            "the failed sibling must still be retried"
+        );
+        assert_eq!(
+            readiness.snapshot().blocked_operations,
+            vec![format!("checkpoint_submission[{failing_index}]")]
+        );
+        tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+        task.await.unwrap();
+        assert!(published.load(Ordering::SeqCst));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_retry_does_not_repeat_checkpoint_upload() {
+    let updates = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer
+        .expect_fetch_checkpoint()
+        .once()
+        .returning(|_| Ok(None));
+    syncer
+        .expect_write_checkpoint()
+        .once()
+        .returning(|_| Ok(()));
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(8))
+        .times(2)
+        .returning({
+            let updates = Arc::clone(&updates);
+            move |_| {
+                if updates.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(eyre::eyre!("latest index unavailable"))
+                } else {
+                    Ok(())
+                }
+            }
+        });
+    let readiness = dummy_readiness();
+    let submitter = submission_test_submitter(syncer, Arc::clone(&readiness));
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(vec![submission_checkpoint(8)])
+            .await;
+    });
+    while updates.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        readiness.snapshot().blocked_operations,
+        vec!["checkpoint_latest_index"]
+    );
+    tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+    task.await.unwrap();
+    assert_eq!(updates.load(Ordering::SeqCst), 2);
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+}
+
+#[tokio::test(start_paused = true)]
+async fn only_first_checkpoint_publishes_batch_maximum() {
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer
+        .expect_fetch_checkpoint()
+        .times(3)
+        .returning(|_| Ok(None));
+    syncer
+        .expect_write_checkpoint()
+        .times(3)
+        .returning(|_| Ok(()));
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(8))
+        .once()
+        .returning(|_| Ok(()));
+    let submitter = submission_test_submitter(syncer, dummy_readiness());
+    submitter
+        .sign_and_submit_checkpoints(vec![
+            submission_checkpoint(7),
+            submission_checkpoint(8),
+            submission_checkpoint(8),
+        ])
+        .await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn single_checkpoint_chunk_has_no_throttle_tail() {
     let checkpoint = CheckpointWithMessageId {

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -528,24 +528,26 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     /// `latest_checkpoint_at_block()`, so there's a single place that ever calls
     /// `quorum_hooks` for a pinned-height root read.
     async fn tree_at_block_via_quorum(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
-        let results = join_all(
-            self.quorum_hooks
-                .iter()
-                .cloned()
-                .map(|(label, hook)| async move {
-                    (
-                        label,
-                        Self::with_call_timeout(hook.tree_at_block(height)).await,
-                    )
-                }),
-        )
-        .await;
-        let quorum_result = self.select_quorum_result(
-            results,
-            |a, b| a.tree == b.tree,
-            "Failed to reach quorum for merkle tree",
-        )?;
-        let base_result = self.base_hook.tree_at_block(height).await?;
+        // Both reads use the same explicit height and independently gate the result. Start
+        // them together so the base pool's latency does not follow the quorum's latency.
+        // Keep the futures owned here: an error or caller cancellation drops the other
+        // read, without leaving a background RPC task running.
+        let quorum_read = async {
+            let results = join_all(self.quorum_hooks.iter().map(|(label, hook)| async move {
+                (
+                    label.clone(),
+                    Self::with_call_timeout(hook.tree_at_block(height)).await,
+                )
+            }))
+            .await;
+            self.select_quorum_result(
+                results,
+                |a, b| a.tree == b.tree,
+                "Failed to reach quorum for merkle tree",
+            )
+        };
+        let (quorum_result, base_result) =
+            futures_util::try_join!(quorum_read, self.base_hook.tree_at_block(height),)?;
         Self::require_base_hook_agreement(
             &quorum_result,
             &base_result,
@@ -594,11 +596,11 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             return self.tree_at_block_via_quorum(height).await;
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
+        let results = join_all(self.quorum_hooks.iter().map(|(label, hook)| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    label,
+                    label.clone(),
                     Self::with_call_timeout(hook.tree(&reorg_period)).await,
                 )
             }
@@ -2079,6 +2081,159 @@ mod tests {
 
     fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> (String, Arc<dyn MerkleTreeHook>) {
         (label.to_string(), Arc::new(hook) as Arc<dyn MerkleTreeHook>)
+    }
+
+    /// Delays a mock response without blocking the executor, and tracks owned RPC futures.
+    #[derive(Debug)]
+    struct DelayedPinnedHook {
+        inner: MockMerkleTreeHook,
+        delay: Duration,
+        active: Arc<AtomicUsize>,
+    }
+
+    impl HyperlaneChain for DelayedPinnedHook {
+        fn domain(&self) -> &HyperlaneDomain {
+            self.inner.domain()
+        }
+
+        fn provider(&self) -> Box<dyn HyperlaneProvider> {
+            self.inner.provider()
+        }
+    }
+
+    impl HyperlaneContract for DelayedPinnedHook {
+        fn address(&self) -> H256 {
+            self.inner.address()
+        }
+    }
+
+    #[async_trait]
+    impl MerkleTreeHook for DelayedPinnedHook {
+        async fn tree(&self, period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
+            self.inner.tree(period).await
+        }
+
+        async fn count(&self, period: &ReorgPeriod) -> ChainResult<u32> {
+            self.inner.count(period).await
+        }
+
+        async fn latest_checkpoint(&self, period: &ReorgPeriod) -> ChainResult<CheckpointAtBlock> {
+            self.inner.latest_checkpoint(period).await
+        }
+
+        async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
+            self.inner.latest_checkpoint_at_block(height).await
+        }
+
+        async fn tree_at_block(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
+            struct ActiveRead<'a>(&'a AtomicUsize);
+            impl Drop for ActiveRead<'_> {
+                fn drop(&mut self) {
+                    self.0.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+            self.active.fetch_add(1, Ordering::SeqCst);
+            let _active = ActiveRead(&self.active);
+            sleep(self.delay).await;
+            self.inner.tree_at_block(height).await
+        }
+    }
+
+    fn delayed_pinned_hook(
+        seconds: u64,
+        fail: bool,
+        active: &Arc<AtomicUsize>,
+    ) -> Arc<dyn MerkleTreeHook> {
+        let mut inner = MockMerkleTreeHook::new();
+        // Cancellation can prevent the delayed response from being reached.
+        inner
+            .expect_tree_at_block()
+            .times(0..=1)
+            .with(mockall::predicate::eq(42))
+            .return_once(move |height| {
+                if fail {
+                    Err(ChainCommunicationError::from_other_str("RPC unavailable"))
+                } else {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree: tree_with_count(5),
+                        block_height: Some(height),
+                    })
+                }
+            });
+        Arc::new(DelayedPinnedHook {
+            inner,
+            delay: Duration::from_secs(seconds),
+            active: Arc::clone(active),
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pinned_base_and_quorum_reads_overlap() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: delayed_pinned_hook(7, false, &active),
+            quorum_hooks: vec![
+                ("rpc-a".into(), delayed_pinned_hook(5, false, &active)),
+                ("rpc-b".into(), delayed_pinned_hook(5, false, &active)),
+                ("rpc-c".into(), delayed_pinned_hook(5, false, &active)),
+            ],
+        };
+        let start = Instant::now();
+        let tree = hook.tree_at_block_via_quorum(42).await.unwrap();
+        assert_eq!(tree.tree, tree_with_count(5));
+        assert_eq!(tree.block_height, Some(42));
+        assert_eq!(start.elapsed(), Duration::from_secs(7));
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pinned_read_failure_cancels_the_other_read_group() {
+        for base_fails in [false, true] {
+            let active = Arc::new(AtomicUsize::new(0));
+            let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+                base_hook: delayed_pinned_hook(
+                    if base_fails { 2 } else { 10 },
+                    base_fails,
+                    &active,
+                ),
+                quorum_hooks: vec![
+                    (
+                        "rpc-a".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                    (
+                        "rpc-b".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                    (
+                        "rpc-c".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                ],
+            };
+            let start = Instant::now();
+            assert!(hook.tree_at_block_via_quorum(42).await.is_err());
+            assert_eq!(start.elapsed(), Duration::from_secs(2));
+            assert_eq!(active.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelling_pinned_read_drops_both_read_groups() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: delayed_pinned_hook(10, false, &active),
+            quorum_hooks: ["rpc-a", "rpc-b", "rpc-c"]
+                .into_iter()
+                .map(|label| (label.into(), delayed_pinned_hook(10, false, &active)))
+                .collect(),
+        };
+        assert!(
+            timeout(Duration::from_secs(1), hook.tree_at_block_via_quorum(42))
+                .await
+                .is_err()
+        );
+        assert_eq!(active.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -1,4 +1,8 @@
-use std::{fmt, sync::OnceLock, time::Duration};
+use std::{
+    fmt,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use aws_config::{timeout::TimeoutConfig, BehaviorVersion, ConfigLoader, Region};
@@ -45,10 +49,15 @@ pub struct S3Storage {
 /// We've seen freshly created S3 clients make expensive DNS / TCP
 /// requests when creating them. This cache allows us to reuse
 /// anonymous clients across the entire agent.
-static ANONYMOUS_CLIENT_CACHE: OnceLock<DashMap<Region, OnceCell<Client>>> = OnceLock::new();
+static ANONYMOUS_CLIENT_CACHE: OnceLock<DashMap<Region, Arc<OnceCell<Client>>>> = OnceLock::new();
 
-fn get_anonymous_client_cache() -> &'static DashMap<Region, OnceCell<Client>> {
-    ANONYMOUS_CLIENT_CACHE.get_or_init(DashMap::new)
+fn anonymous_client_cell(region: Region) -> Arc<OnceCell<Client>> {
+    let cell = ANONYMOUS_CLIENT_CACHE
+        .get_or_init(DashMap::new)
+        .entry(region)
+        .or_default();
+    // Release the synchronous shard guard before the caller awaits initialization.
+    Arc::clone(&cell)
 }
 
 /// Reads a `ByteStream` chunk by chunk, aborting as soon as the cumulative size reaches
@@ -150,9 +159,7 @@ impl S3Storage {
     /// S3 bucket's AWS account. Additionally, this allows relayer operators to not
     /// require AWS credentials.
     async fn anonymous_client(&self) -> Client {
-        let cell = get_anonymous_client_cache()
-            .entry(self.region.clone())
-            .or_default();
+        let cell = anonymous_client_cell(self.region.clone());
 
         cell.get_or_init(|| async {
             let config = self
@@ -483,6 +490,82 @@ mod tests {
             serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
             serde_json::from_slice::<serde_json::Value>(&pretty).unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn anonymous_client_initialization_releases_cache_lock_and_coalesces_waiters() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use dashmap::try_result::TryResult;
+        use futures::{future::join_all, poll};
+        use tokio::sync::Notify;
+
+        let region = Region::new("test-coalesced-client-initialization");
+        let first_cell = anonymous_client_cell(region.clone());
+        let initialized = AtomicUsize::new(0);
+        let release = Notify::new();
+        let address = ([127, 0, 0, 1], 1).into();
+        let mut first = Box::pin(first_cell.get_or_init(|| async {
+            initialized.fetch_add(1, Ordering::SeqCst);
+            release.notified().await;
+            test_client(address)
+        }));
+        assert!(poll!(first.as_mut()).is_pending());
+
+        // A suspended initializer must hold zero synchronous map guards. This check
+        // cannot block the executor, even if the lock-release invariant regresses.
+        let cache = ANONYMOUS_CLIENT_CACHE.get().unwrap();
+        assert!(matches!(cache.try_get_mut(&region), TryResult::Present(_)));
+        let cells: Vec<_> = (0..20)
+            .map(|_| anonymous_client_cell(region.clone()))
+            .collect();
+        assert!(cells.iter().all(|cell| Arc::ptr_eq(cell, &first_cell)));
+        let mut waiters = Box::pin(join_all(cells.iter().map(|cell| {
+            cell.get_or_init(|| async {
+                initialized.fetch_add(1, Ordering::SeqCst);
+                test_client(address)
+            })
+        })));
+        assert!(poll!(waiters.as_mut()).is_pending());
+        assert_eq!(initialized.load(Ordering::SeqCst), 1);
+        assert!(matches!(cache.try_get_mut(&region), TryResult::Present(_)));
+
+        release.notify_one();
+        let first_client = first.await;
+        let clients = waiters.await;
+        assert_eq!(clients.len(), 20);
+        assert!(clients
+            .iter()
+            .all(|client| std::ptr::eq(*client, first_client)));
+        assert_eq!(initialized.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn anonymous_client_initialization_can_retry_after_cancellation() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures::poll;
+
+        let region = Region::new("test-cancelled-client-initialization");
+        let first_cell = anonymous_client_cell(region.clone());
+        let initialized = AtomicUsize::new(0);
+        let mut cancelled = Box::pin(first_cell.get_or_init(|| async {
+            initialized.fetch_add(1, Ordering::SeqCst);
+            std::future::pending::<Client>().await
+        }));
+        assert!(poll!(cancelled.as_mut()).is_pending());
+        drop(cancelled);
+
+        let next_cell = anonymous_client_cell(region);
+        assert!(Arc::ptr_eq(&first_cell, &next_cell));
+        next_cell
+            .get_or_init(|| async {
+                initialized.fetch_add(1, Ordering::SeqCst);
+                test_client(([127, 0, 0, 1], 1).into())
+            })
+            .await;
+        assert_eq!(initialized.load(Ordering::SeqCst), 2);
+        assert!(first_cell.get().is_some());
     }
 
     /// Reads a mock HTTP server's request off `socket` up to the end of the headers. The

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -96,13 +96,13 @@ impl fmt::Debug for S3Storage {
 }
 
 impl S3Storage {
-    async fn write_to_bucket(&self, key: String, body: &str) -> Result<()> {
+    async fn write_to_bucket(&self, key: String, body: Vec<u8>) -> Result<()> {
         self.authenticated_client()
             .await
             .put_object()
             .bucket(self.bucket.clone())
             .key(self.get_composite_key(key))
-            .body(Vec::from(body).into())
+            .body(body.into())
             .content_type("application/json")
             .send()
             .await?;
@@ -233,8 +233,8 @@ impl CheckpointSyncer for S3Storage {
     }
 
     async fn write_latest_index(&self, index: u32) -> Result<()> {
-        let serialized_index = serde_json::to_string(&index)?;
-        self.write_to_bucket(S3Storage::latest_index_key(), &serialized_index)
+        let serialized_index = serde_json::to_vec(&index)?;
+        self.write_to_bucket(S3Storage::latest_index_key(), serialized_index)
             .await?;
         Ok(())
     }
@@ -251,24 +251,27 @@ impl CheckpointSyncer for S3Storage {
         &self,
         signed_checkpoint: &SignedCheckpointWithMessageId,
     ) -> Result<()> {
-        let serialized_checkpoint = serde_json::to_string_pretty(signed_checkpoint)?;
+        let serialized_checkpoint = serde_json::to_vec(signed_checkpoint)?;
         self.write_to_bucket(
             S3Storage::checkpoint_key(signed_checkpoint.value.index),
-            &serialized_checkpoint,
+            serialized_checkpoint,
         )
         .await?;
         Ok(())
     }
 
     async fn write_metadata(&self, serialized_metadata: &str) -> Result<()> {
-        self.write_to_bucket(S3Storage::metadata_key(), serialized_metadata)
-            .await?;
+        self.write_to_bucket(
+            S3Storage::metadata_key(),
+            serialized_metadata.as_bytes().to_vec(),
+        )
+        .await?;
         Ok(())
     }
 
     async fn write_announcement(&self, signed_announcement: &SignedAnnouncement) -> Result<()> {
-        let serialized_announcement = serde_json::to_string_pretty(signed_announcement)?;
-        self.write_to_bucket(S3Storage::announcement_key(), &serialized_announcement)
+        let serialized_announcement = serde_json::to_vec_pretty(signed_announcement)?;
+        self.write_to_bucket(S3Storage::announcement_key(), serialized_announcement)
             .await?;
         Ok(())
     }
@@ -283,14 +286,14 @@ impl CheckpointSyncer for S3Storage {
     }
 
     async fn write_reorg_status(&self, reorged_event: &ReorgEvent) -> Result<()> {
-        let serialized_reorg = serde_json::to_string(reorged_event)?;
-        self.write_to_bucket(S3Storage::reorg_flag_key(), &serialized_reorg)
+        let serialized_reorg = serde_json::to_vec(reorged_event)?;
+        self.write_to_bucket(S3Storage::reorg_flag_key(), serialized_reorg)
             .await?;
         Ok(())
     }
 
     async fn write_reorg_rpc_responses(&self, reorg_log: String) -> Result<()> {
-        self.write_to_bucket(S3Storage::reorg_rpc_responses_key(), &reorg_log)
+        self.write_to_bucket(S3Storage::reorg_rpc_responses_key(), reorg_log.into_bytes())
             .await?;
         Ok(())
     }
@@ -393,6 +396,93 @@ mod tests {
             .credentials_provider(aws_sdk_s3::config::Credentials::for_tests())
             .build();
         Client::from_conf(config)
+    }
+
+    #[tokio::test]
+    async fn checkpoint_upload_uses_compact_json_and_preserves_signed_fields() {
+        use std::sync::Arc;
+
+        use hyper::{service::service_fn, Body, Response};
+        use hyperlane_core::{Checkpoint, CheckpointWithMessageId, HyperlaneSignerExt, H256};
+        use hyperlane_ethereum::Signers;
+
+        let signer: Signers = "01"
+            .repeat(32)
+            .parse::<ethers::signers::LocalWallet>()
+            .unwrap()
+            .into();
+        let checkpoint = signer
+            .sign(CheckpointWithMessageId {
+                checkpoint: Checkpoint {
+                    merkle_tree_hook_address: H256::repeat_byte(0x11),
+                    mailbox_domain: 42161,
+                    root: H256::repeat_byte(0x22),
+                    index: 2_500_000,
+                },
+                message_id: H256::repeat_byte(0x33),
+            })
+            .await
+            .unwrap();
+        let expected = serde_json::to_vec(&checkpoint).unwrap();
+        let pretty = serde_json::to_vec_pretty(&checkpoint).unwrap();
+        assert!(expected.len() < pretty.len());
+        println!(
+            "checkpoint bytes: pretty={}, compact={}",
+            pretty.len(),
+            expected.len()
+        );
+        let received = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_received = Arc::clone(&received);
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            hyper::server::conn::Http::new()
+                .serve_connection(
+                    socket,
+                    service_fn(move |request: hyper::Request<Body>| {
+                        let received = Arc::clone(&server_received);
+                        async move {
+                            assert_eq!(request.method(), hyper::Method::PUT);
+                            assert_eq!(
+                                request.uri().path(),
+                                "/test-bucket/checkpoint_2500000_with_id.json"
+                            );
+                            assert_eq!(
+                                request.headers()[hyper::header::CONTENT_TYPE],
+                                "application/json"
+                            );
+                            let body = hyper::body::to_bytes(request.into_body()).await.unwrap();
+                            *received.lock().unwrap() = body.to_vec();
+                            Ok::<_, std::convert::Infallible>(
+                                Response::builder()
+                                    .header(hyper::header::CONNECTION, "close")
+                                    .body(Body::empty())
+                                    .unwrap(),
+                            )
+                        }
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+        let storage = S3Storage::new("test-bucket".into(), None, Region::new("us-east-1"), None);
+        storage
+            .authenticated_client
+            .set(test_client(address))
+            .unwrap();
+        storage.write_checkpoint(&checkpoint).await.unwrap();
+        server.await.unwrap();
+        let body = received.lock().unwrap();
+        assert_eq!(*body, expected);
+        let decoded: SignedCheckpointWithMessageId = serde_json::from_slice(&body).unwrap();
+        assert_eq!(decoded.value, checkpoint.value);
+        assert_eq!(decoded.signature, checkpoint.signature);
+        assert_eq!(decoded.recover().unwrap(), checkpoint.recover().unwrap());
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+            serde_json::from_slice::<serde_json::Value>(&pretty).unwrap()
+        );
     }
 
     /// Reads a mock HTTP server's request off `socket` up to the end of the headers. The

--- a/rust/main/hyperlane-core/src/traits/signing.rs
+++ b/rust/main/hyperlane-core/src/traits/signing.rs
@@ -135,52 +135,46 @@ impl<T: Signable + Debug> Debug for SignedType<T> {
     }
 }
 
-// Copied from https://github.com/hyperlane-xyz/ethers-rs/blob/hyperlane/ethers-core/src/utils/hash.rs
-// so that we can get EIP-191 hashing without the `ethers` feature
+// EIP-191 hashing without the `ethers` feature.
 mod hashes {
-    const PREFIX: &str = "\x19Ethereum Signed Message:\n";
     use crate::H256;
     use tiny_keccak::{Hasher, Keccak};
 
-    /// Hash a message according to EIP-191.
-    ///
-    /// The data is a UTF-8 encoded string and will enveloped as follows:
-    /// `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed
-    /// using keccak256.
-    pub fn hash_message<S>(message: S) -> H256
-    where
-        S: AsRef<[u8]>,
-    {
-        let message = message.as_ref();
-
-        let mut eth_message = format!("{PREFIX}{}", message.len()).into_bytes();
-        eth_message.extend_from_slice(message);
-        keccak256(&eth_message).into()
-    }
-
-    /// Compute the Keccak-256 hash of input bytes.
-    // TODO: Add Solidity Keccak256 packing support
-    pub fn keccak256<S>(bytes: S) -> [u8; 32]
-    where
-        S: AsRef<[u8]>,
-    {
+    /// Wrap a signing hash in EIP-191. Signable always supplies exactly 32 bytes.
+    pub fn hash_message(message: H256) -> H256 {
         let mut output = [0u8; 32];
         let mut hasher = Keccak::v256();
-        hasher.update(bytes.as_ref());
+        hasher.update(b"\x19Ethereum Signed Message:\n32");
+        hasher.update(message.as_ref());
         hasher.finalize(&mut output);
-        output
+        output.into()
     }
 
     #[test]
-    #[cfg(feature = "ethers")]
-    fn ensure_signed_hashes_match() {
-        assert_eq!(
-            ethers_core::utils::hash_message(b"gm crypto!"),
-            hash_message(b"gm crypto!").into()
-        );
-        assert_eq!(
-            ethers_core::utils::hash_message(b"hyperlane"),
-            hash_message(b"hyperlane").into()
-        );
+    fn signed_hashes_match_legacy_envelope() {
+        // Compare the streamed implementation with the original concatenated
+        // envelope for every repeated byte and every single-bit position.
+        let values = (0..=u8::MAX)
+            .map(H256::repeat_byte)
+            .chain((0..256).map(|bit| {
+                let mut bytes = [0; 32];
+                bytes[bit / 8] = 1 << (bit % 8);
+                H256::from(bytes)
+            }));
+        for value in values {
+            let mut envelope =
+                format!("\x19Ethereum Signed Message:\n{}", value.as_bytes().len()).into_bytes();
+            envelope.extend_from_slice(value.as_bytes());
+            let mut expected = [0; 32];
+            let mut hasher = Keccak::v256();
+            hasher.update(&envelope);
+            hasher.finalize(&mut expected);
+            assert_eq!(hash_message(value), H256::from(expected));
+            #[cfg(feature = "ethers")]
+            assert_eq!(
+                hash_message(value),
+                H256::from(ethers_core::utils::hash_message(value.as_bytes()).0)
+            );
+        }
     }
 }

--- a/rust/main/hyperlane-core/src/traits/signing.rs
+++ b/rust/main/hyperlane-core/src/traits/signing.rs
@@ -3,11 +3,10 @@ use std::fmt::{Debug, Formatter};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use serde::{
-    ser::{SerializeStruct, Serializer},
+    ser::{Error, SerializeStruct, Serializer},
     Deserialize, Serialize,
 };
 
-use crate::utils::bytes_to_hex;
 use crate::{Signature, H160, H256};
 
 /// An error incurred by a signer
@@ -100,7 +99,13 @@ impl<T: Signable + Serialize> Serialize for SignedType<T> {
         state.serialize_field("value", &self.value)?;
         state.serialize_field("signature", &self.signature)?;
         let sig: [u8; 65] = self.signature.into();
-        state.serialize_field("serialized_signature", &bytes_to_hex(&sig))?;
+        // The prefixed hex representation has a fixed size. Serialize it directly
+        // from the stack instead of allocating an intermediate hex String.
+        let mut encoded = [0u8; 132];
+        encoded[..2].copy_from_slice(b"0x");
+        hex::encode_to_slice(sig, &mut encoded[2..]).map_err(S::Error::custom)?;
+        let encoded = std::str::from_utf8(&encoded).map_err(S::Error::custom)?;
+        state.serialize_field("serialized_signature", encoded)?;
         state.end()
     }
 }
@@ -175,6 +180,60 @@ mod hashes {
                 hash_message(value),
                 H256::from(ethers_core::utils::hash_message(value.as_bytes()).0)
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Checkpoint, CheckpointWithMessageId, U256};
+
+    struct LegacySigned<'a>(&'a SignedType<CheckpointWithMessageId>);
+
+    impl Serialize for LegacySigned<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("SignedType", 3)?;
+            state.serialize_field("value", &self.0.value)?;
+            state.serialize_field("signature", &self.0.signature)?;
+            let sig: [u8; 65] = self.0.signature.into();
+            state.serialize_field("serialized_signature", &crate::utils::bytes_to_hex(&sig))?;
+            state.end()
+        }
+    }
+
+    #[test]
+    fn signed_json_preserves_signature_encoding_and_roundtrip() {
+        for v in [0, 1, 27, 28, 255, 256, u64::MAX] {
+            for limb in [U256::zero(), U256::one(), U256::MAX] {
+                let signed = SignedType {
+                    value: CheckpointWithMessageId {
+                        checkpoint: Checkpoint {
+                            merkle_tree_hook_address: H256::repeat_byte(0x11),
+                            mailbox_domain: 42161,
+                            root: H256::repeat_byte(0x22),
+                            index: 2_500_000,
+                        },
+                        message_id: H256::repeat_byte(0x33),
+                    },
+                    signature: Signature {
+                        r: limb,
+                        s: limb,
+                        v,
+                    },
+                };
+                let json = serde_json::to_vec(&signed).unwrap();
+                assert_eq!(json, serde_json::to_vec(&LegacySigned(&signed)).unwrap());
+                assert_eq!(
+                    serde_json::to_vec_pretty(&signed).unwrap(),
+                    serde_json::to_vec_pretty(&LegacySigned(&signed)).unwrap()
+                );
+                let decoded: SignedType<CheckpointWithMessageId> =
+                    serde_json::from_slice(&json).unwrap();
+                assert_eq!(decoded, signed);
+                let json: serde_json::Value = serde_json::from_slice(&json).unwrap();
+                assert_eq!(json["serialized_signature"].as_str().unwrap().len(), 132);
+            }
         }
     }
 }


### PR DESCRIPTION
Consolidated into #9489 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Every signed checkpoint JSON serialization allocates temporary hex and prefixed strings for serialized_signature before copying that field into the output. This applies to S3, GCS and local checkpoint writes, plus announcements.

## Solution

Keep the existing Signature-to-65-byte conversion. Encode the prefixed hexadecimal representation into a fixed 132-byte stack buffer and serialize its borrowed string. Preserve JSON field order, casing, structured signature, recovery-ID conversion and other serializer behavior.

## Numerical impact

Full serde_json::to_vec of the same synthetic signed checkpoint; byte-identical 644-byte output:

| Work | Before → after | Evidence |
|---|---|---|
| Allocation/reallocation calls | 7 → 4 (42.86% fewer) | Actual serializer counting-allocator probe, 100 warmup + 100 measured calls |
| Requested allocation bytes | 2,186 → 1,920 (266 bytes / 12.17% less) | Same probe |
| Temporary signature-field allocations | 3 → 0 | Fixed-buffer encoding |

Output-buffer allocations remain. Upload bytes, object names and request counts are unchanged. Synthetic r/s boundary values establish encoding, not valid signatures; the separate locally signed upload test verifies recovery. No timing, RSS or fleet estimate is claimed.

## Verification and scope

- **21 variants** compare exact compact/pretty JSON and typed roundtrips with the legacy serializer: seven v values × three r/s values. Passes agent and default-without-ethers configurations.
- Actual production S3 writer passes local HTTP upload and valid-checkpoint signer recovery.
- Qualified core strict Clippy passes with the previously documented baseline cfg(dev) allowance; no source suppression. Formatting, spellcheck and normal hooks pass.
- Root and independent relayer reviews found no blockers; supplementary Muse source review also found no material serialization issue.
- Public bytes_to_hex and signing authority are unchanged. Distinct from #9472's upload payload ownership and #9489's hash envelope.

Stack: follows #9489 and the validator stack rooted at #9471.
