### PR TITLE
perf(relayer): hash canonical messages without a temporary buffer

### DIFF
--- a/rust/main/hyperlane-core/src/types/message.rs
+++ b/rust/main/hyperlane-core/src/types/message.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
-use sha3::{digest::Update, Digest, Keccak256};
+use sha3::{Digest, Keccak256};
 
 use crate::{
     utils::{fmt_address_for_domain, fmt_domain},
@@ -163,14 +163,67 @@ impl Decode for HyperlaneMessage {
 impl HyperlaneMessage {
     /// Convert the message to a message id
     pub fn id(&self) -> H256 {
-        H256::from_slice(Keccak256::new().chain(self.to_vec()).finalize().as_slice())
+        let mut hasher = Keccak256::new();
+        // The digest writer consumes the canonical encoding without allocating
+        // an intermediate message buffer. Its writes are infallible.
+        self.write_to(&mut hasher)
+            .expect("Writing to Keccak256 cannot fail");
+        H256::from_slice(hasher.finalize().as_slice())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{HyperlaneMessage, RawHyperlaneMessage, HYPERLANE_MESSAGE_PREFIX_LEN};
-    use crate::{Decode, H256};
+    use crate::{Decode, Encode, H256};
+    use sha3::{Digest, Keccak256};
+
+    #[test]
+    fn id_matches_known_message_vector() {
+        // Existing vectors/message.json fixture, with its independently specified ID.
+        let mut sender = [0; 32];
+        sender[12..].fill(0x11);
+        let mut recipient = [0; 32];
+        recipient[12..].fill(0x22);
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce: 0,
+            origin: 1000,
+            sender: sender.into(),
+            destination: 2000,
+            recipient: recipient.into(),
+            body: vec![0x12, 0x34],
+        };
+        let expected = H256::from([
+            0xf8, 0xa6, 0x6f, 0x8a, 0xad, 0xee, 0x75, 0x1d, 0x84, 0x26, 0x16, 0xfe, 0xe0, 0xed,
+            0x14, 0xa3, 0xad, 0x6d, 0xa1, 0xe1, 0x35, 0x64, 0x92, 0x03, 0x64, 0xee, 0x0a, 0xd3,
+            0x5a, 0x02, 0x70, 0x3f,
+        ]);
+        assert_eq!(message.id(), expected);
+    }
+
+    #[test]
+    fn streamed_id_matches_canonical_encoding_at_hash_block_boundaries() {
+        for length in [0, 1, 58, 59, 60, 135, 136, 137, 271, 272, 4096, 65536] {
+            for version in [0, 3, u8::MAX] {
+                for nonce in [0, 1, u32::MAX] {
+                    let message = HyperlaneMessage {
+                        version,
+                        nonce,
+                        origin: nonce.rotate_left(7),
+                        sender: H256::repeat_byte(version),
+                        destination: nonce ^ 0xa5a5_a5a5,
+                        recipient: H256::repeat_byte(!version),
+                        body: (0..length).map(|i| (i % 256) as u8).collect(),
+                    };
+                    let encoded = message.to_vec();
+                    assert_eq!(encoded.len(), HYPERLANE_MESSAGE_PREFIX_LEN + length);
+                    let expected = H256::from_slice(Keccak256::digest(&encoded).as_slice());
+                    assert_eq!(message.id(), expected);
+                }
+            }
+        }
+    }
 
     fn sample_message() -> HyperlaneMessage {
         HyperlaneMessage {


### PR DESCRIPTION
Consolidated into #9469 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

HyperlaneMessage::id serializes the complete message into a temporary Vec before hashing it. Required IDs therefore copy the entire body and grow a heap buffer even though Keccak can consume the canonical encoding directly.

## Solution

Use the existing Encode::write_to implementation with Keccak256's infallible std::io::Write adapter. Keep one canonical encoder and identical message IDs; no duplicated field layout or new cache.

## Numerical impact

Actual old/new ID methods in a counting-allocator probe; outputs identical:

| Body size | Allocation/reallocation calls | Requested allocation bytes |
|---|---:|---:|
| 4 KiB | 5 → 0 | 4,320 → 0 |
| 64 KiB | 5 → 0 | 65,760 → 0 |

100 warmup plus 100 measured calls. Header/body bytes and Keccak work remain unchanged. This eliminates temporary serialization storage, not hashing CPU or RPC requests. No timing/RSS/fleet claim.

This is incremental to #9469: routes that already avoid computing an ID gain nothing further. Required-ID routes now avoid the remaining hash buffer, so the two PRs' allocation estimates must not be added independently.

## Verification and scope

- Default and agent message suites each passed **6 tests**, with one existing ignored test. Includes an independently specified known ID and **108** canonical-encoding comparisons around Keccak block boundaries, empty bodies and large bodies.
- Matching suite **9/9 passed**.
- Strict core Clippy reports the same five baseline diagnostics; none on changed lines. Formatting, spellcheck and normal commit hooks passed.
- Root and independent validator reviews found no blockers; supplementary Muse review found no material hashing issue.
- No wire format, public API, signing or validation change.

Stack: follows #9490 and the relayer stack rooted at #9469.
