### PR TITLE
perf(scraper): batch fallback payment replacement deletes

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -7900,6 +7900,8 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
+ "testcontainers",
+ "testcontainers-modules",
  "time",
  "tokio",
  "tracing",

--- a/rust/main/agents/scraper/migration/Cargo.toml
+++ b/rust/main/agents/scraper/migration/Cargo.toml
@@ -59,3 +59,11 @@ path = "bin/create_raw_dispatch_native_sequence_index.rs"
 
 [features]
 default = []
+
+[[bin]]
+name = "create-event-scope-indexes"
+path = "bin/create_event_scope_indexes.rs"
+
+[dev-dependencies]
+testcontainers.workspace = true
+testcontainers-modules.workspace = true

--- a/rust/main/agents/scraper/migration/README.md
+++ b/rust/main/agents/scraper/migration/README.md
@@ -39,3 +39,64 @@
   ```sh
   cargo run -- status
   ```
+
+## Event scope indexes
+
+`store_dispatched_messages` and `store_deliveries` compute a scoped `MAX(id)` before
+writing, then count rows above that ID. Existing mailbox/nonce and mailbox-only
+indexes cannot directly seek the highest ID or the new-ID range within a scope.
+
+Inspect `pg_indexes` for equivalent indexes installed outside migrations before
+adding these B-tree indexes with the operational binary:
+
+- `message_origin_mailbox_id_idx`: `message(origin, origin_mailbox, id)`
+- `delivered_message_domain_mailbox_id_idx`:
+  `delivered_message(domain, destination_mailbox, id)`
+
+From `rust/main`, with `DATABASE_URL` set to the intended database:
+
+```sh
+cargo run --release -p migration --bin create-event-scope-indexes
+```
+
+Run this separately from SeaORM migrations: PostgreSQL forbids `CREATE INDEX
+CONCURRENTLY` inside a transaction. The binary builds each index sequentially,
+retains existing indexes, and verifies that both are valid, ready, nonpartial
+B-trees with the expected table and three keys. Reruns accept matching valid
+indexes. If an interrupted concurrent build leaves an invalid index, or its name
+belongs to another definition, the command fails instead of treating `IF NOT
+EXISTS` as success. Inspect `pg_index` and `pg_get_indexdef` and repair the named
+index explicitly before retrying; the command never drops indexes. If the second
+build fails, the first remains installed and a rerun verifies it before proceeding.
+
+Concurrent builds permit normal writes but consume database I/O, CPU, disk and
+WAL, and can wait for existing transactions. Schedule the build accordingly and
+inspect its progress through `pg_stat_progress_create_index`. The two additional
+indexes also add ongoing insert/update maintenance and storage cost.
+
+### Local plan evidence
+
+For a reproducible synthetic probe, run the SQL below **only in an empty,
+disposable PostgreSQL database**; it creates two million total rows:
+
+```sh
+psql "$LOCAL_DATABASE_URL" -v ON_ERROR_STOP=1 -f agents/scraper/migration/benchmarks/event_scope_indexes.sql
+```
+
+The fixture has one million rows per table, a 32-byte mailbox and 256-byte payload.
+The target scope owns the oldest 100,000 rows, followed by 900,000 rows from another
+scope. It models an inactive/backfill scope behind a busy scope. This is a reduced
+schema containing the query-relevant existing indexes, not a production copy.
+
+On local PostgreSQL 16, before adding the indexes, both `MAX` queries scanned the
+primary key backwards and filtered out 900,000 rows, touching 42,422 shared buffers.
+Afterward, each used a scoped index-only seek returning one row with four shared
+buffers. Counting IDs above 99,000 changed from scanning 100,000 scoped entries and
+filtering 99,000 to scanning only the 1,000 matching entries. Each additional index
+occupied approximately 65 MiB in this fixture. These are synthetic plan/operation measurements,
+not production latency or storage predictions. Index-only heap access also depends
+on visibility-map coverage; ongoing writes may require heap fetches.
+
+Slow production logs motivated this work, but logs alone do not prove an index
+caused those latencies. Verify installed definitions, query plans and live behavior
+separately after any authorized rollout.

--- a/rust/main/agents/scraper/migration/benchmarks/event_scope_indexes.sql
+++ b/rust/main/agents/scraper/migration/benchmarks/event_scope_indexes.sql
@@ -1,0 +1,27 @@
+CREATE TABLE message (id bigint PRIMARY KEY, origin int NOT NULL, origin_mailbox bytea NOT NULL, nonce int NOT NULL, payload bytea NOT NULL);
+CREATE UNIQUE INDEX message_scope_nonce ON message(origin,origin_mailbox,nonce);
+INSERT INTO message SELECT n, CASE WHEN n<=100000 THEN 1 ELSE 2 END, decode(repeat('01',32),'hex'), n, decode(repeat('ab',256),'hex') FROM generate_series(1,1000000) n;
+CREATE TABLE delivered_message (id bigint PRIMARY KEY, domain int NOT NULL, destination_mailbox bytea NOT NULL, payload bytea NOT NULL);
+CREATE INDEX delivery_scope ON delivered_message(domain,destination_mailbox);
+INSERT INTO delivered_message SELECT id,origin,origin_mailbox,payload FROM message;
+VACUUM ANALYZE message;
+VACUUM ANALYZE delivered_message;
+\echo BEFORE MESSAGE MAX
+EXPLAIN (ANALYZE, BUFFERS) SELECT MAX(id) FROM message WHERE origin=1 AND origin_mailbox=decode(repeat('01',32),'hex');
+\echo BEFORE MESSAGE COUNT
+EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM message WHERE origin=1 AND origin_mailbox=decode(repeat('01',32),'hex') AND id>99000;
+\echo BEFORE DELIVERY MAX
+EXPLAIN (ANALYZE, BUFFERS) SELECT MAX(id) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex');
+\echo BEFORE DELIVERY COUNT
+EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex') AND id>99000;
+CREATE INDEX CONCURRENTLY message_origin_mailbox_id_idx ON message(origin,origin_mailbox,id);
+CREATE INDEX CONCURRENTLY delivered_message_domain_mailbox_id_idx ON delivered_message(domain,destination_mailbox,id);
+\echo AFTER MESSAGE MAX
+EXPLAIN (ANALYZE, BUFFERS) SELECT MAX(id) FROM message WHERE origin=1 AND origin_mailbox=decode(repeat('01',32),'hex');
+\echo AFTER MESSAGE COUNT
+EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM message WHERE origin=1 AND origin_mailbox=decode(repeat('01',32),'hex') AND id>99000;
+\echo AFTER DELIVERY MAX
+EXPLAIN (ANALYZE, BUFFERS) SELECT MAX(id) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex');
+\echo AFTER DELIVERY COUNT
+EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM delivered_message WHERE domain=1 AND destination_mailbox=decode(repeat('01',32),'hex') AND id>99000;
+SELECT relname,pg_size_pretty(pg_relation_size(oid)) FROM pg_class WHERE relname IN ('message_origin_mailbox_id_idx','delivered_message_domain_mailbox_id_idx');

--- a/rust/main/agents/scraper/migration/bin/create_event_scope_indexes.rs
+++ b/rust/main/agents/scraper/migration/bin/create_event_scope_indexes.rs
@@ -1,0 +1,121 @@
+//! Build scope/id indexes for event write accounting outside migration transactions.
+
+use eyre::{ensure, Context};
+use migration::sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+
+mod common;
+
+const INDEXES: [(&str, &str, &str, &str); 2] = [
+    (
+        "message_origin_mailbox_id_idx",
+        "message",
+        "origin",
+        "origin_mailbox",
+    ),
+    (
+        "delivered_message_domain_mailbox_id_idx",
+        "delivered_message",
+        "domain",
+        "destination_mailbox",
+    ),
+];
+
+async fn create_indexes(db: &DatabaseConnection) -> eyre::Result<()> {
+    for (name, table, domain, mailbox) in INDEXES {
+        db.execute_unprepared(&format!(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table} ({domain}, {mailbox}, id)"
+        ))
+        .await
+        .wrap_err_with(|| {
+            format!("Creating {name}; inspect its validity before retrying an interrupted build")
+        })?;
+
+        // IF NOT EXISTS also skips invalid or differently defined indexes. Never
+        // report those as successfully installed, and never drop them automatically.
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+            SELECT i.indisvalid AND i.indisready
+                AND NOT i.indisunique
+                AND i.indnkeyatts = 3 AND i.indnatts = 3
+                AND i.indpred IS NULL AND i.indexprs IS NULL
+                AND i.indrelid = $2::regclass AND am.amname = 'btree'
+                AND pg_get_indexdef(i.indexrelid, 1, true) = $3
+                AND pg_get_indexdef(i.indexrelid, 2, true) = $4
+                AND pg_get_indexdef(i.indexrelid, 3, true) = 'id'
+                AS expected_index
+            FROM pg_index i
+            JOIN pg_class c ON c.oid = i.indexrelid
+            JOIN pg_am am ON am.oid = c.relam
+            WHERE i.indexrelid = to_regclass($1)
+            "#,
+                [name.into(), table.into(), domain.into(), mailbox.into()],
+            ))
+            .await?;
+        let valid = row
+            .map(|row| row.try_get::<bool>("", "expected_index"))
+            .transpose()?
+            .unwrap_or(false);
+        ensure!(valid, "Index {name} is invalid or has an unexpected definition; inspect pg_index and pg_get_indexdef, repair it explicitly, then rerun this command");
+        tracing::info!(index = name, "Verified event scope index");
+    }
+    Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> eyre::Result<()> {
+    create_indexes(&common::init().await?).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use migration::sea_orm::Database;
+    use migration::{Migrator, MigratorTrait};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    #[tokio::test]
+    async fn event_scope_indexes_build_rerun_and_reject_wrong_definition() -> eyre::Result<()> {
+        let postgres = Postgres::default().start().await?;
+        let port = postgres.get_host_port_ipv4(5432).await?;
+        let db = Database::connect(format!(
+            "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+        ))
+        .await?;
+        Migrator::up(&db, None).await?;
+        create_indexes(&db).await?;
+        create_indexes(&db).await?;
+        db.execute_unprepared("DROP INDEX message_origin_mailbox_id_idx")
+            .await?;
+        db.execute_unprepared(
+            "CREATE INDEX message_origin_mailbox_id_idx ON message (origin, origin_mailbox, nonce)",
+        )
+        .await?;
+        assert!(create_indexes(&db)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("unexpected definition"));
+        db.execute_unprepared("DROP INDEX message_origin_mailbox_id_idx")
+            .await?;
+        db.execute_unprepared(
+            "INSERT INTO message (time_created,msg_id,origin,destination,nonce,sender,recipient,origin_mailbox) SELECT now(),decode(repeat('01',32),'hex'),1,1,n,decode(repeat('01',20),'hex'),decode(repeat('01',20),'hex'),decode(repeat('01',20),'hex') FROM generate_series(0,1) n"
+        ).await?;
+        // A failed concurrent unique build leaves a real invalid index behind.
+        assert!(db.execute_unprepared(
+            "CREATE UNIQUE INDEX CONCURRENTLY message_origin_mailbox_id_idx ON message(origin,origin_mailbox)"
+        ).await.is_err());
+        let validity = db.query_one(Statement::from_string(DbBackend::Postgres,
+            "SELECT indisvalid FROM pg_index WHERE indexrelid='message_origin_mailbox_id_idx'::regclass"
+        )).await?.unwrap();
+        assert!(!validity.try_get::<bool>("", "indisvalid")?);
+        assert!(create_indexes(&db)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("invalid"));
+        Ok(())
+    }
+}

--- a/rust/main/agents/scraper/src/db/block.rs
+++ b/rust/main/agents/scraper/src/db/block.rs
@@ -1,8 +1,8 @@
 use eyre::{Context, Result};
 use migration::OnConflict;
 use sea_orm::{
-    prelude::*, ActiveValue::*, DbErr, EntityTrait, FromQueryResult, Insert, QueryResult,
-    QuerySelect,
+    prelude::*, sea_query::SelectStatement, ActiveValue::*, DbErr, EntityTrait, FromQueryResult,
+    Insert, QueryResult, QuerySelect,
 };
 use tracing::{debug, trace};
 
@@ -11,7 +11,7 @@ use hyperlane_core::{h256_to_bytes, BlockInfo, H256};
 use crate::date_time;
 use crate::db::ScraperDb;
 
-use super::generated::block;
+use super::generated::{block, transaction};
 
 /// A stripped down block model. This is so we can get just the information
 /// needed if the block is present in the Db already to inject into other
@@ -33,23 +33,21 @@ impl FromQueryResult for BasicBlock {
 }
 
 impl ScraperDb {
-    /// Retrieves the block number for a given block database ID
-    pub async fn retrieve_block_number(&self, block_id: i64) -> Result<Option<u64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Height,
-        }
-        let block_height = block::Entity::find()
-            .filter(block::Column::Id.eq(block_id))
+    /// Resolve a query selecting one event transaction id to its block height in
+    /// one database round trip. NULL/missing relations produce no height.
+    pub(super) async fn retrieve_block_number_by_tx_query(
+        &self,
+        tx_id_query: SelectStatement,
+    ) -> Result<Option<u64>> {
+        let height = transaction::Entity::find()
+            .filter(transaction::Column::Id.in_subquery(tx_id_query))
+            .inner_join(block::Entity)
             .select_only()
-            .column_as(block::Column::Height, QueryAs::Height)
-            .into_values::<i64, QueryAs>()
+            .column(block::Column::Height)
+            .into_tuple::<i64>()
             .one(&self.0)
             .await?;
-        match block_height {
-            Some(height) => Ok(Some(height.try_into()?)),
-            None => Ok(None),
-        }
+        height.map(u64::try_from).transpose().map_err(Into::into)
     }
 
     /// Get basic block data that can be used to insert a transaction or

--- a/rust/main/agents/scraper/src/db/block.rs
+++ b/rust/main/agents/scraper/src/db/block.rs
@@ -1,4 +1,5 @@
 use eyre::{Context, Result};
+use itertools::Itertools;
 use migration::OnConflict;
 use sea_orm::{
     prelude::*, sea_query::SelectStatement, ActiveValue::*, DbErr, EntityTrait, FromQueryResult,
@@ -57,17 +58,24 @@ impl ScraperDb {
         &self,
         hashes: impl Iterator<Item = &H256>,
     ) -> Result<Vec<BasicBlock>> {
-        // check database to see which blocks we already know and fetch their IDs
-        let blocks = block::Entity::find()
-            .filter(block::Column::Hash.is_in(hashes.map(h256_to_bytes)))
-            .select_only()
-            // these must align with the custom impl of FromQueryResult
-            .column_as(block::Column::Id, "id")
-            .column_as(block::Column::Hash, "hash")
-            .into_model::<BasicBlock>()
-            .all(&self.0)
-            .await
-            .context("When querying blocks")?;
+        let hashes = hashes.unique().collect_vec();
+        let mut blocks = Vec::new();
+        for hashes in hashes.chunks(Self::HASH_LOOKUP_CHUNK_SIZE) {
+            blocks.extend(
+                block::Entity::find()
+                    .filter(
+                        block::Column::Hash.is_in(hashes.iter().map(|hash| h256_to_bytes(hash))),
+                    )
+                    .select_only()
+                    // These must align with the custom impl of FromQueryResult.
+                    .column_as(block::Column::Id, "id")
+                    .column_as(block::Column::Hash, "hash")
+                    .into_model::<BasicBlock>()
+                    .all(&self.0)
+                    .await
+                    .context("When querying blocks")?,
+            );
+        }
 
         trace!(blocks = blocks.len(), "Queried block info for hashes");
         Ok(blocks)

--- a/rust/main/agents/scraper/src/db/block/tests.rs
+++ b/rust/main/agents/scraper/src/db/block/tests.rs
@@ -158,3 +158,47 @@ async fn test_store_blocks_real_postgres() -> Result<(), DbErr> {
 
     Ok(())
 }
+
+/// Resolved sequence lookups execute exactly one statement each. Invalid SQL
+/// heights and database failures must remain errors rather than missing data.
+#[tokio::test]
+async fn sequence_block_lookups_use_one_query_and_propagate_errors() {
+    use sea_orm::{DatabaseBackend, MockDatabase, RuntimeErr, Value};
+    use std::collections::BTreeMap;
+
+    let rows = [0_i64, 42, i64::MAX, -1]
+        .map(|height| [BTreeMap::from([("height", Value::BigInt(Some(height)))])]);
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(rows)
+        .append_query_errors([DbErr::Query(RuntimeErr::Internal("unavailable".to_owned()))])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    let address = H256::from_low_u64_be(1);
+    assert_eq!(
+        db.retrieve_dispatched_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        db.retrieve_delivered_message_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(42)
+    );
+    assert_eq!(
+        db.retrieve_payment_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(u64::try_from(i64::MAX).unwrap())
+    );
+    assert!(db
+        .retrieve_dispatched_block_number(1, &address, 7)
+        .await
+        .is_err());
+    assert!(db
+        .retrieve_payment_block_number(1, &address, 7)
+        .await
+        .is_err());
+    assert_eq!(db.0.into_transaction_log().len(), 5);
+}

--- a/rust/main/agents/scraper/src/db/lookup_batches.rs
+++ b/rust/main/agents/scraper/src/db/lookup_batches.rs
@@ -1,0 +1,95 @@
+//! Hash lookup bounds, deduplication and error propagation.
+use std::collections::BTreeMap;
+
+use hyperlane_core::{h256_to_bytes, h512_to_bytes, H256, H512};
+use sea_orm::{DatabaseBackend, DbErr, MockDatabase, Value};
+
+use super::ScraperDb;
+
+fn row(id: usize, hash: Vec<u8>) -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        ("id".to_owned(), Value::BigInt(Some(id as i64))),
+        ("hash".to_owned(), Value::Bytes(Some(Box::new(hash)))),
+    ])
+}
+
+#[tokio::test]
+async fn hash_lookups_bound_large_inputs_and_deduplicate_across_chunks() {
+    let blocks: Vec<_> = (0..66_000).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..66_000).map(H512::from_low_u64_be).collect();
+    let mut responses = Vec::new();
+    for chunk in blocks.chunks(ScraperDb::HASH_LOOKUP_CHUNK_SIZE) {
+        responses.push(vec![row(responses.len(), h256_to_bytes(&chunk[0]))]);
+    }
+    for chunk in txns.chunks(ScraperDb::HASH_LOOKUP_CHUNK_SIZE) {
+        responses.push(vec![row(responses.len(), h512_to_bytes(&chunk[0]))]);
+    }
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(responses)
+            .into_connection(),
+    );
+    let found_blocks = db
+        .get_block_basic(blocks.iter().chain(blocks[..1].iter()))
+        .await
+        .unwrap();
+    let found_txns = db
+        .get_txn_ids(txns.iter().chain(txns[..1].iter()))
+        .await
+        .unwrap();
+    assert_eq!(found_blocks.len(), 2);
+    assert_eq!(found_txns.len(), 2);
+    for index in 0..2 {
+        assert_eq!(found_blocks[index].hash, blocks[index * 65_000]);
+        assert_eq!(found_blocks[index].id, index as i64);
+        assert_eq!(found_txns[&txns[index * 65_000]], (index + 2) as i64);
+    }
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 4);
+    for (index, query) in log.iter().enumerate() {
+        let statement = &query.statements()[0];
+        let values = &statement.values.as_ref().unwrap().0;
+        assert_eq!(values.len(), if index % 2 == 1 { 1_000 } else { 65_000 });
+    }
+}
+
+#[tokio::test]
+async fn empty_hash_lookups_skip_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert!(db
+        .get_block_basic(std::iter::empty())
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(db.get_txn_ids(std::iter::empty()).await.unwrap().is_empty());
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn hash_lookups_propagate_failed_tail_without_partial_results() {
+    let blocks: Vec<_> = (0..65_001).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..65_001).map(H512::from_low_u64_be).collect();
+    for is_block in [true, false] {
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![row(
+                    1,
+                    if is_block {
+                        h256_to_bytes(&blocks[0])
+                    } else {
+                        h512_to_bytes(&txns[0])
+                    },
+                )]])
+                .append_query_errors([DbErr::Custom("lookup tail failed".to_owned())])
+                .into_connection(),
+        );
+        let error = if is_block {
+            db.get_block_basic(blocks.iter()).await.unwrap_err()
+        } else {
+            db.get_txn_ids(txns.iter()).await.unwrap_err()
+        };
+        assert!(format!("{error:#}").contains("lookup tail failed"));
+        assert_eq!(db.0.into_transaction_log().len(), 2);
+    }
+}

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
@@ -1,6 +1,10 @@
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use migration::OnConflict;
-use sea_orm::{ActiveValue::*, ColumnTrait, EntityTrait, Insert, QueryFilter};
+use sea_orm::{
+    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, TransactionTrait,
+};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, MerkleTreeInsertion, H256};
 
@@ -11,6 +15,10 @@ pub struct StorableMerkleTreeInsertion<'a> {
     pub block_number: u64,
 }
 
+// Each row binds five columns; conflict updates reference EXCLUDED and add no
+// parameters. Keep each statement below PostgreSQL's 65,535-parameter limit.
+const INSERT_CHUNK_SIZE: usize = 13_000;
+
 impl ScraperDb {
     pub async fn store_merkle_tree_insertions(
         &self,
@@ -19,35 +27,50 @@ impl ScraperDb {
         insertions: impl Iterator<Item = StorableMerkleTreeInsertion<'_>>,
     ) -> Result<u64> {
         let merkle_tree_hook = address_to_bytes(merkle_tree_hook);
+        // A single PostgreSQL upsert rejects repeated conflict keys. Preserve
+        // that rejection even when repeated leaves fall into different chunks.
+        let mut leaf_indices = HashSet::new();
         let models = insertions
-            .map(|row| merkle_tree_insertion::ActiveModel {
-                id: NotSet,
-                domain: Unchanged(domain as i32),
-                merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
-                leaf_index: Unchanged(row.insertion.index() as i32),
-                message_id: Set(h256_to_bytes(&row.insertion.message_id())),
-                block_number: Set(row.block_number as i64),
+            .map(|row| {
+                ensure!(
+                    leaf_indices.insert(row.insertion.index()),
+                    "Duplicate Merkle tree leaf index {} in one batch",
+                    row.insertion.index()
+                );
+                Ok(merkle_tree_insertion::ActiveModel {
+                    id: NotSet,
+                    domain: Unchanged(domain as i32),
+                    merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
+                    leaf_index: Unchanged(row.insertion.index() as i32),
+                    message_id: Set(h256_to_bytes(&row.insertion.message_id())),
+                    block_number: Set(row.block_number as i64),
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
+        drop(leaf_indices);
         let count = models.len() as u64;
         if models.is_empty() {
             return Ok(0);
         }
 
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([
-                    merkle_tree_insertion::Column::Domain,
-                    merkle_tree_insertion::Column::MerkleTreeHook,
-                    merkle_tree_insertion::Column::LeafIndex,
-                ])
-                .update_columns([
-                    merkle_tree_insertion::Column::MessageId,
-                    merkle_tree_insertion::Column::BlockNumber,
-                ])
-                .to_owned(),
-            )
-            .exec(&self.0)
+        if models.len() <= INSERT_CHUNK_SIZE {
+            insert_query(models).exec(&self.0).await?;
+            return Ok(count);
+        }
+
+        // A failed later chunk must roll back earlier writes: ContractSync can
+        // advance its cursor only after the entire fetched range is durable.
+        self.0
+            .transaction::<_, (), DbErr>(|txn| {
+                Box::pin(async move {
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models.by_ref().take(INSERT_CHUNK_SIZE).collect();
+                        insert_query(chunk).exec(txn).await?;
+                    }
+                    Ok(())
+                })
+            })
             .await?;
         Ok(count)
     }
@@ -76,3 +99,23 @@ impl ScraperDb {
         }))
     }
 }
+
+fn insert_query(
+    models: Vec<merkle_tree_insertion::ActiveModel>,
+) -> Insert<merkle_tree_insertion::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([
+            merkle_tree_insertion::Column::Domain,
+            merkle_tree_insertion::Column::MerkleTreeHook,
+            merkle_tree_insertion::Column::LeafIndex,
+        ])
+        .update_columns([
+            merkle_tree_insertion::Column::MessageId,
+            merkle_tree_insertion::Column::BlockNumber,
+        ])
+        .to_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, PaginatorTrait, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+
+// Matches the observed 86,580-bind range: five parameters per insertion.
+const ROW_COUNT: u32 = 17_316;
+const DOMAIN: u32 = 1;
+
+fn insertions() -> Vec<MerkleTreeInsertion> {
+    (0..ROW_COUNT)
+        .map(|index| MerkleTreeInsertion::new(index, H256::from_low_u64_be(u64::from(index))))
+        .collect()
+}
+
+fn rows(
+    insertions: &[MerkleTreeInsertion],
+) -> impl Iterator<Item = StorableMerkleTreeInsertion<'_>> {
+    insertions
+        .iter()
+        .map(|insertion| StorableMerkleTreeInsertion {
+            insertion,
+            block_number: 20_000,
+        })
+}
+
+#[tokio::test]
+async fn merkle_insert_statements_stay_below_postgres_bind_limit() {
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([
+            [BTreeMap::from([("id", Value::BigInt(Some(1)))])],
+            [BTreeMap::from([("id", Value::BigInt(Some(2)))])],
+        ])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions()))
+            .await
+            .unwrap(),
+        u64::from(ROW_COUNT)
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1, "all chunks must share a transaction");
+    let statements = transactions[0].statements();
+    assert_eq!(statements.first().unwrap().sql, "BEGIN");
+    assert_eq!(statements.last().unwrap().sql, "COMMIT");
+    assert_eq!(statements.len(), 4);
+    let bind_counts: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("INSERT"))
+        .map(|statement| statement.values.as_ref().unwrap().0.len())
+        .collect();
+    assert_eq!(bind_counts, [65_000, 21_580]);
+    assert!(bind_counts
+        .iter()
+        .all(|count| *count <= usize::from(u16::MAX)));
+}
+
+#[tokio::test]
+async fn merkle_small_insert_keeps_one_statement_and_empty_insert_skips_sql() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[BTreeMap::from([("id", Value::BigInt(Some(1)))])]])
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[]))
+            .await
+            .unwrap(),
+        0
+    );
+    let insertion = MerkleTreeInsertion::new(1, H256::zero());
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[insertion]))
+            .await
+            .unwrap(),
+        1
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1);
+    let statements = transactions[0].statements();
+    assert_eq!(statements.len(), 1);
+    assert!(statements[0].sql.starts_with("INSERT"));
+    assert_eq!(statements[0].values.as_ref().unwrap().0.len(), 5);
+}
+
+#[tokio::test]
+async fn merkle_duplicate_leaf_across_chunks_is_rejected_before_writes() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    let mut insertions = insertions();
+    insertions.push(insertions[0]);
+    let error = db
+        .store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions))
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Duplicate Merkle tree leaf index 0"));
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn merkle_bulk_insert_is_replayable_and_rolls_back_failed_tail() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let hook = H256::from_low_u64_be(1);
+    let insertions = insertions();
+
+    for _ in 0..2 {
+        assert_eq!(
+            db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+                .await?,
+            u64::from(ROW_COUNT)
+        );
+        assert_eq!(
+            merkle_tree_insertion::Entity::find().count(&db.0).await?,
+            u64::from(ROW_COUNT),
+            "replay must not duplicate rows"
+        );
+    }
+    for index in [0, 12_999, 13_000, ROW_COUNT - 1] {
+        assert_eq!(
+            db.retrieve_merkle_tree_insertion(DOMAIN, &hook, index)
+                .await?,
+            Some((insertions[usize::try_from(index)?], 20_000))
+        );
+    }
+
+    // Retain one existing row, then fail the first row of the second chunk.
+    // Both first-chunk inserts and updates must roll back with the failure.
+    db.0.execute_unprepared("TRUNCATE merkle_tree_insertion")
+        .await?;
+    let original = MerkleTreeInsertion::new(0, H256::repeat_byte(0xff));
+    db.store_merkle_tree_insertions(
+        DOMAIN,
+        &hook,
+        [StorableMerkleTreeInsertion {
+            insertion: &original,
+            block_number: 10_000,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    db.0.execute_unprepared(
+        "ALTER TABLE merkle_tree_insertion ADD CONSTRAINT reject_test_tail CHECK (leaf_index <> 13000)"
+    ).await?;
+    assert!(db
+        .store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+        .await
+        .is_err());
+    assert_eq!(merkle_tree_insertion::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((original, 10_000)),
+        "failed tail must also roll back updates to earlier existing rows"
+    );
+
+    db.0.execute_unprepared("ALTER TABLE merkle_tree_insertion DROP CONSTRAINT reject_test_tail")
+        .await?;
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+            .await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        merkle_tree_insertion::Entity::find().count(&db.0).await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((insertions[0], 20_000))
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -346,8 +346,13 @@ impl ScraperDb {
                 Box::pin(async move {
                     // insert messages in chunks, to not run into
                     // "Too many arguments" error
-                    for chunk in models.chunks(Self::STORE_MESSAGE_CHUNK_SIZE) {
-                        Insert::many(chunk.to_vec())
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models
+                            .by_ref()
+                            .take(Self::STORE_MESSAGE_CHUNK_SIZE)
+                            .collect();
+                        Insert::many(chunk)
                             .on_conflict(
                                 OnConflict::columns([
                                     message::Column::Origin,

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -3,7 +3,8 @@
 use eyre::Result;
 use itertools::Itertools;
 use sea_orm::{
-    prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, TransactionTrait,
+    prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, QueryTrait,
+    TransactionTrait,
 };
 use tracing::{debug, instrument, trace};
 
@@ -75,30 +76,28 @@ impl ScraperDb {
         }
     }
 
-    /// Get the tx id of a delivered message associated with a sequence.
+    /// Get the block height of a delivered message associated with a sequence.
     /// Also returns `None` for deliveries stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_delivered_message_tx_id(
+    pub async fn retrieve_delivered_message_block_number(
         &self,
         destination_domain: u32,
         destination_mailbox: &H256,
         sequence: u32,
-    ) -> Result<Option<i64>> {
-        if let Some(delivery) = delivered_message::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = delivered_message::Entity::find()
             .filter(delivered_message::Column::Domain.eq(destination_domain))
             .filter(
                 delivered_message::Column::DestinationMailbox
                     .eq(address_to_bytes(destination_mailbox)),
             )
             .filter(delivered_message::Column::Sequence.eq(sequence))
-            .one(&self.0)
-            .await?
-        {
-            Ok(delivery.destination_tx_id)
-        } else {
-            Ok(None)
-        }
+            .select_only()
+            .column(delivered_message::Column::DestinationTxId)
+            .limit(1)
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     async fn latest_deliveries_id(&self, domain: u32, destination_mailbox: Vec<u8>) -> Result<i64> {
@@ -237,34 +236,25 @@ impl ScraperDb {
         }
     }
 
-    /// Get the tx id associated with a dispatched message.
+    /// Get the block height associated with a dispatched message.
     /// Also returns `None` for messages stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_dispatched_tx_id(
+    pub async fn retrieve_dispatched_block_number(
         &self,
         origin_domain: u32,
         origin_mailbox: &H256,
         nonce: u32,
-    ) -> Result<Option<i64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Nonce,
-        }
-
-        let tx_id = message::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = message::Entity::find()
             .filter(message::Column::Origin.eq(origin_domain))
             .filter(message::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)))
             .filter(message::Column::Nonce.eq(nonce))
             .select_only()
-            .column_as(message::Column::OriginTxId.max(), QueryAs::Nonce)
+            .column_as(message::Column::OriginTxId.max(), "tx_id")
             .group_by(message::Column::Origin)
-            // `origin_tx_id` is nullable (unresolvable on-chain transaction),
-            // so the MAX aggregate can be NULL even when a message row exists.
-            .into_values::<Option<i64>, QueryAs>()
-            .one(&self.0)
-            .await?;
-        Ok(tx_id.flatten())
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     async fn latest_dispatched_id(&self, domain: u32, origin_mailbox: Vec<u8>) -> Result<i64> {

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)] // TODO: `rustc` 1.80.1 clippy issue
 
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, QueryTrait,
@@ -50,6 +52,9 @@ impl ScraperDb {
     /// u16::MAX (65_535u16) is the maximum amount of parameters we can
     /// have for Postgres. So 65000 / 20 = 3250
     const STORE_MESSAGE_CHUNK_SIZE: usize = 3250;
+
+    // Six bound columns per delivery; conflict expressions add no parameters.
+    const STORE_DELIVERY_CHUNK_SIZE: usize = 10_000;
 
     /// Get the delivered message associated with a sequence.
     #[instrument(skip(self))]
@@ -142,54 +147,57 @@ impl ScraperDb {
         deliveries: impl Iterator<Item = StorableDelivery<'_>>,
     ) -> Result<u64> {
         let destination_mailbox = address_to_bytes(&destination_mailbox);
-        let latest_id_before = self
-            .latest_deliveries_id(domain, destination_mailbox.clone())
-            .await?;
         // we have a race condition where a message may not have been scraped yet even
         // though we have received news of delivery on this chain, so the
         // message IDs are looked up in a separate "thread".
-        let models: Vec<delivered_message::ActiveModel> = deliveries
-            .map(|delivery| delivered_message::ActiveModel {
-                id: NotSet,
-                time_created: Set(date_time::now()),
-                msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
-                domain: Unchanged(domain as i32),
-                destination_mailbox: Unchanged(destination_mailbox.clone()),
-                destination_tx_id: Set(delivery.txn_id),
-                sequence: Set(delivery.sequence),
+        let mut message_ids = HashSet::new();
+        let models = deliveries
+            .map(|delivery| {
+                // Preserve single-upsert rejection across chunk boundaries.
+                ensure!(
+                    message_ids.insert(delivery.message_id),
+                    "Duplicate delivery message id in one batch"
+                );
+                Ok(delivered_message::ActiveModel {
+                    id: NotSet,
+                    time_created: Set(date_time::now()),
+                    msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
+                    domain: Unchanged(domain as i32),
+                    destination_mailbox: Unchanged(destination_mailbox.clone()),
+                    destination_tx_id: Set(delivery.txn_id),
+                    sequence: Set(delivery.sequence),
+                })
             })
-            .collect_vec();
+            .collect::<Result<Vec<_>>>()?;
+        drop(message_ids);
+        if models.is_empty() {
+            return Ok(0);
+        }
+        let latest_id_before = self
+            .latest_deliveries_id(domain, destination_mailbox.clone())
+            .await?;
 
         trace!(?models, "Writing delivered messages to database");
 
-        if models.is_empty() {
-            debug!("Wrote zero new delivered messages to database");
-            return Ok(0);
+        if models.len() <= Self::STORE_DELIVERY_CHUNK_SIZE {
+            delivery_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_DELIVERY_CHUNK_SIZE)
+                                .collect();
+                            delivery_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
+                })
+                .await?;
         }
-
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([delivered_message::Column::MsgId])
-                    // A fallback replay must not discard transaction metadata
-                    // that was resolved by an earlier scrape. This still lets
-                    // a later resolved scrape enrich an existing NULL row.
-                    .value(
-                        delivered_message::Column::DestinationTxId,
-                        Func::if_null(
-                            Expr::col((
-                                Alias::new("excluded"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                            Expr::col((
-                                Alias::new("delivered_message"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                        ),
-                    )
-                    .to_owned(),
-            )
-            .exec(&self.0)
-            .await?;
 
         let new_deliveries_count = self
             .deliveries_count_since_id(domain, destination_mailbox, latest_id_before)
@@ -300,10 +308,6 @@ impl ScraperDb {
     ) -> Result<u64> {
         let origin_mailbox = address_to_bytes(origin_mailbox);
 
-        let latest_id_before = self
-            .latest_dispatched_id(domain, origin_mailbox.clone())
-            .await?;
-
         // we have a race condition where a message may not have been scraped yet even
         let models = messages
             .map(|storable| message::ActiveModel {
@@ -327,12 +331,14 @@ impl ScraperDb {
             })
             .collect_vec();
 
-        trace!(?models, "Writing messages to database");
-
         if models.is_empty() {
-            debug!("Wrote zero new messages to database");
             return Ok(0);
         }
+        let latest_id_before = self
+            .latest_dispatched_id(domain, origin_mailbox.clone())
+            .await?;
+
+        trace!(?models, "Writing messages to database");
 
         // ensure all chunks are inserted or none at all
         self.0
@@ -389,6 +395,31 @@ impl ScraperDb {
         );
         Ok(new_dispatch_count)
     }
+}
+
+fn delivery_insert_query(
+    models: Vec<delivered_message::ActiveModel>,
+) -> Insert<delivered_message::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([delivered_message::Column::MsgId])
+            // A fallback replay must not discard transaction metadata
+            // that was resolved by an earlier scrape. This still lets
+            // a later resolved scrape enrich an existing NULL row.
+            .value(
+                delivered_message::Column::DestinationTxId,
+                Func::if_null(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                    Expr::col((
+                        Alias::new("delivered_message"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                ),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -29,6 +29,9 @@ mod txn;
 pub struct ScraperDb(DbConn);
 
 impl ScraperDb {
+    // Hash lookups bind one parameter per hash; stay below PostgreSQL's 65,535 limit.
+    const HASH_LOOKUP_CHUNK_SIZE: usize = 65_000;
+
     #[instrument]
     pub async fn connect(url: &str) -> Result<Self> {
         let db = Database::connect(url).await?;
@@ -65,3 +68,6 @@ impl Clone for ScraperDb {
 
 #[cfg(test)]
 mod write_batches;
+
+#[cfg(test)]
+mod lookup_batches;

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -62,3 +62,6 @@ impl Clone for ScraperDb {
         Self(conn)
     }
 }
+
+#[cfg(test)]
+mod write_batches;

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -9,7 +9,7 @@ use sea_orm::{
 use tracing::{debug, instrument};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, InterchainGasPayment, LogMeta, H256};
-use migration::OnConflict;
+use migration::{Expr, OnConflict};
 
 use crate::conversions::{decimal_to_u256, u256_to_decimal};
 use crate::date_time;
@@ -185,6 +185,7 @@ impl ScraperDb {
             .collect();
 
         let mut models = Vec::with_capacity(payments.len());
+        let mut fallback_replacements = Vec::new();
         for storable in payments {
             let identity = payment_identity(storable);
             if storable.txn_id.is_none() {
@@ -198,17 +199,7 @@ impl ScraperDb {
             } else if existing_null_payments.remove(&identity) {
                 // Replace an earlier fallback row instead of keeping both
                 // variants and double-counting it.
-                gas_payment::Entity::delete_many()
-                    .filter(gas_payment::Column::Domain.eq(domain))
-                    .filter(
-                        gas_payment::Column::InterchainGasPaymaster
-                            .eq(interchain_gas_paymaster.clone()),
-                    )
-                    .filter(gas_payment::Column::MsgId.eq(identity.0.clone()))
-                    .filter(gas_payment::Column::LogIndex.eq(identity.1))
-                    .filter(gas_payment::Column::TxId.is_null())
-                    .exec(&txn)
-                    .await?;
+                fallback_replacements.push(identity);
             }
 
             models.push(payment_model(
@@ -216,6 +207,32 @@ impl ScraperDb {
                 interchain_gas_paymaster.clone(),
                 storable,
             ));
+        }
+
+        let mut fallback_replacements = fallback_replacements.into_iter();
+        while !fallback_replacements.as_slice().is_empty() {
+            // Two parameters per identity plus domain/IGP scope. Keep deletion
+            // inside the same transaction as the replacement inserts.
+            let identities: Vec<_> = fallback_replacements
+                .by_ref()
+                .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                .collect();
+            gas_payment::Entity::delete_many()
+                .filter(gas_payment::Column::Domain.eq(domain))
+                .filter(
+                    gas_payment::Column::InterchainGasPaymaster
+                        .eq(interchain_gas_paymaster.clone()),
+                )
+                .filter(gas_payment::Column::TxId.is_null())
+                .filter(
+                    Expr::tuple([
+                        Expr::col(gas_payment::Column::MsgId).into(),
+                        Expr::col(gas_payment::Column::LogIndex).into(),
+                    ])
+                    .in_tuples(identities),
+                )
+                .exec(&txn)
+                .await?;
         }
 
         debug!(?models, "Writing gas payments to database");

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use eyre::Result;
 use itertools::Itertools;
 use sea_orm::{
-    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, Statement, TransactionTrait,
+    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, QueryTrait, Statement,
+    TransactionTrait,
 };
 use tracing::{debug, instrument};
 
@@ -60,30 +61,28 @@ impl ScraperDb {
         }
     }
 
-    /// Get the transaction id of the gas payment associated with a sequence.
+    /// Get the block height of the gas payment associated with a sequence.
     /// Also returns `None` for payments stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_payment_tx_id(
+    pub async fn retrieve_payment_block_number(
         &self,
         origin: u32,
         interchain_gas_paymaster: &H256,
         sequence: u32,
-    ) -> Result<Option<i64>> {
-        if let Some(payment) = gas_payment::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = gas_payment::Entity::find()
             .filter(gas_payment::Column::Origin.eq(origin))
             .filter(
                 gas_payment::Column::InterchainGasPaymaster
                     .eq(address_to_bytes(interchain_gas_paymaster)),
             )
             .filter(gas_payment::Column::Sequence.eq(sequence))
-            .one(&self.0)
-            .await?
-        {
-            Ok(payment.tx_id)
-        } else {
-            Ok(None)
-        }
+            .select_only()
+            .column(gas_payment::Column::TxId)
+            .limit(1)
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     #[instrument(skip_all)]

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use eyre::Result;
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, QueryTrait, Statement,
@@ -29,6 +29,9 @@ pub struct StorablePayment<'a> {
 }
 
 impl ScraperDb {
+    // Eleven parameters per inserted row; reads add two scope parameters.
+    const PAYMENT_STORE_CHUNK_SIZE: usize = 5_000;
+
     const PAYMENT_STORE_LOCK_NAMESPACE: i32 = 0x4859_504C;
 
     /// Get the payment associated with a sequence.
@@ -92,6 +95,25 @@ impl ScraperDb {
         interchain_gas_paymaster: &H256,
         payments: &[StorablePayment<'_>],
     ) -> Result<u64> {
+        if payments.is_empty() {
+            return Ok(0);
+        }
+        // PostgreSQL rejects repeated non-NULL conflict keys in one upsert.
+        // Retain that rejection even if keys would land in different chunks.
+        let mut resolved_keys = HashSet::new();
+        for payment in payments {
+            if let Some(tx_id) = payment.txn_id {
+                ensure!(
+                    resolved_keys.insert((
+                        payment.payment.message_id,
+                        payment.meta.log_index.as_u64(),
+                        tx_id,
+                    )),
+                    "Duplicate resolved gas payment in one batch"
+                );
+            }
+        }
+        drop(resolved_keys);
         let interchain_gas_paymaster = address_to_bytes(interchain_gas_paymaster);
 
         // Postgres unique indexes treat NULLs as distinct, so the
@@ -127,20 +149,22 @@ impl ScraperDb {
         let payment_msg_ids = payments
             .iter()
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
+            .unique()
             .collect_vec();
-        let existing_payments = if payment_msg_ids.is_empty() {
-            Vec::new()
-        } else {
-            gas_payment::Entity::find()
-                .filter(gas_payment::Column::Domain.eq(domain))
-                .filter(
-                    gas_payment::Column::InterchainGasPaymaster
-                        .eq(interchain_gas_paymaster.clone()),
-                )
-                .filter(gas_payment::Column::MsgId.is_in(payment_msg_ids))
-                .all(&txn)
-                .await?
-        };
+        let mut existing_payments = Vec::new();
+        for message_ids in payment_msg_ids.chunks(Self::PAYMENT_STORE_CHUNK_SIZE) {
+            existing_payments.extend(
+                gas_payment::Entity::find()
+                    .filter(gas_payment::Column::Domain.eq(domain))
+                    .filter(
+                        gas_payment::Column::InterchainGasPaymaster
+                            .eq(interchain_gas_paymaster.clone()),
+                    )
+                    .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
+                    .all(&txn)
+                    .await?,
+            );
+        }
         let mut seen_fallback_payments: HashSet<(Vec<u8>, i64)> = existing_payments
             .iter()
             .map(|payment| (payment.msg_id.clone(), payment.log_index))
@@ -196,27 +220,34 @@ impl ScraperDb {
             debug!("Wrote zero new gas payments to database");
             0
         } else {
-            Insert::many(models)
-                .on_conflict(
-                    OnConflict::columns([
-                        // don't need domain because TxId includes it
-                        gas_payment::Column::MsgId,
-                        gas_payment::Column::TxId,
-                        gas_payment::Column::LogIndex,
-                    ])
-                    .update_columns([
-                        gas_payment::Column::TimeCreated,
-                        gas_payment::Column::Payment,
-                        gas_payment::Column::GasAmount,
-                        gas_payment::Column::Origin,
-                        gas_payment::Column::Destination,
-                        gas_payment::Column::InterchainGasPaymaster,
-                        gas_payment::Column::Sequence,
-                    ])
-                    .to_owned(),
-                )
-                .exec(&txn)
-                .await?;
+            let mut models = models.into_iter();
+            while !models.as_slice().is_empty() {
+                let chunk = models
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect::<Vec<_>>();
+                Insert::many(chunk)
+                    .on_conflict(
+                        OnConflict::columns([
+                            // don't need domain because TxId includes it
+                            gas_payment::Column::MsgId,
+                            gas_payment::Column::TxId,
+                            gas_payment::Column::LogIndex,
+                        ])
+                        .update_columns([
+                            gas_payment::Column::TimeCreated,
+                            gas_payment::Column::Payment,
+                            gas_payment::Column::GasAmount,
+                            gas_payment::Column::Origin,
+                            gas_payment::Column::Destination,
+                            gas_payment::Column::InterchainGasPaymaster,
+                            gas_payment::Column::Sequence,
+                        ])
+                        .to_owned(),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
 
             gas_payment::Entity::find()
                 .filter(gas_payment::Column::Domain.eq(domain))

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -151,29 +151,33 @@ impl ScraperDb {
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
             .unique()
             .collect_vec();
-        let mut existing_payments = Vec::new();
+        let mut seen_fallback_payments = HashSet::new();
+        let mut existing_null_payments = HashSet::new();
         for message_ids in payment_msg_ids.chunks(Self::PAYMENT_STORE_CHUNK_SIZE) {
-            existing_payments.extend(
-                gas_payment::Entity::find()
-                    .filter(gas_payment::Column::Domain.eq(domain))
-                    .filter(
-                        gas_payment::Column::InterchainGasPaymaster
-                            .eq(interchain_gas_paymaster.clone()),
-                    )
-                    .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
-                    .all(&txn)
-                    .await?,
-            );
+            let existing_payments = gas_payment::Entity::find()
+                .select_only()
+                .columns([
+                    gas_payment::Column::MsgId,
+                    gas_payment::Column::LogIndex,
+                    gas_payment::Column::TxId,
+                ])
+                .filter(gas_payment::Column::Domain.eq(domain))
+                .filter(
+                    gas_payment::Column::InterchainGasPaymaster
+                        .eq(interchain_gas_paymaster.clone()),
+                )
+                .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
+                .into_tuple::<(Vec<u8>, i64, Option<i64>)>()
+                .all(&txn)
+                .await?;
+            for (msg_id, log_index, tx_id) in existing_payments {
+                let identity = (msg_id, log_index);
+                if tx_id.is_none() {
+                    existing_null_payments.insert(identity.clone());
+                }
+                seen_fallback_payments.insert(identity);
+            }
         }
-        let mut seen_fallback_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .iter()
-            .map(|payment| (payment.msg_id.clone(), payment.log_index))
-            .collect();
-        let mut existing_null_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .into_iter()
-            .filter(|payment| payment.tx_id.is_none())
-            .map(|payment| (payment.msg_id, payment.log_index))
-            .collect();
         let resolved_batch_payments: HashSet<(Vec<u8>, i64)> = payments
             .iter()
             .filter(|storable| storable.txn_id.is_some())

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -140,8 +140,13 @@ impl ScraperDb {
                 Box::pin(async move {
                     // Insert raw message dispatches in chunks, to not run into
                     // "Too many arguments" error
-                    for chunk in models.chunks(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE) {
-                        Insert::many(chunk.to_vec())
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models
+                            .by_ref()
+                            .take(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE)
+                            .collect();
+                        Insert::many(chunk)
                             .on_conflict(
                                 OnConflict::column(raw_message_dispatch::Column::MsgId)
                                     .update_columns([

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -22,21 +22,6 @@ pub struct StorableTxn {
 }
 
 impl ScraperDb {
-    pub async fn retrieve_block_id(&self, tx_id: i64) -> Result<Option<i64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            BlockId,
-        }
-        let block_id = transaction::Entity::find()
-            .filter(transaction::Column::Id.eq(tx_id))
-            .select_only()
-            .column_as(transaction::Column::BlockId, QueryAs::BlockId)
-            .into_values::<i64, QueryAs>()
-            .one(&self.0)
-            .await?;
-        Ok(block_id)
-    }
-
     /// Lookup transactions and find their ids. Any transactions which are not
     /// found be excluded from the hashmap.
     pub async fn get_txn_ids(

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -86,7 +86,7 @@ impl ScraperDb {
                     recipient: Set(txn.recipient.as_ref().map(address_to_bytes)),
                     max_fee_per_gas: Set(txn.max_fee_per_gas.map(u256_to_decimal)),
                     cumulative_gas_used: Set(u256_to_decimal(receipt.cumulative_gas_used)),
-                    raw_input_data: Set(txn.raw_input_data.clone()),
+                    raw_input_data: Set(txn.info.raw_input_data),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use derive_more::Deref;
 use eyre::{eyre, Context, Result};
+use itertools::Itertools;
 use sea_orm::{
     prelude::*, sea_query::OnConflict, ActiveValue::*, DeriveColumn, EnumIter, Insert, NotSet,
     QuerySelect,
@@ -34,19 +35,25 @@ impl ScraperDb {
             Hash,
         }
 
-        // check database to see which txns we already know and fetch their IDs
-        let txns = transaction::Entity::find()
-            .filter(transaction::Column::Hash.is_in(hashes.map(h512_to_bytes)))
-            .select_only()
-            .column_as(transaction::Column::Id, QueryAs::Id)
-            .column_as(transaction::Column::Hash, QueryAs::Hash)
-            .into_values::<(i64, Vec<u8>), QueryAs>()
-            .all(&self.0)
-            .await
-            .context("When querying transactions")?
-            .into_iter()
-            .map(|(id, hash)| Ok((bytes_to_h512(&hash), id)))
-            .collect::<Result<HashMap<_, _>>>()?;
+        let hashes = hashes.unique().collect_vec();
+        let mut txns = HashMap::new();
+        for hashes in hashes.chunks(Self::HASH_LOOKUP_CHUNK_SIZE) {
+            let rows = transaction::Entity::find()
+                .filter(
+                    transaction::Column::Hash.is_in(hashes.iter().map(|hash| h512_to_bytes(hash))),
+                )
+                .select_only()
+                .column_as(transaction::Column::Id, QueryAs::Id)
+                .column_as(transaction::Column::Hash, QueryAs::Hash)
+                .into_values::<(i64, Vec<u8>), QueryAs>()
+                .all(&self.0)
+                .await
+                .context("When querying transactions")?;
+            txns.extend(
+                rows.into_iter()
+                    .map(|(id, hash)| (bytes_to_h512(&hash), id)),
+            );
+        }
 
         trace!(?txns, "Queried transaction info for hashes");
         Ok(txns)

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -431,3 +431,42 @@ async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn hash_lookups_read_both_chunks_without_duplicate_results_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let first_tx = seed_transaction(&db, 0).await?;
+    let tail_tx = seed_transaction(&db, 65_000).await?;
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash: H256::from_low_u64_be(65_055),
+            timestamp: 1_700_000_001,
+            number: 501,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let blocks: Vec<_> = (0..66_000).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..66_000).map(H512::from_low_u64_be).collect();
+    let found_blocks = db
+        .get_block_basic(blocks.iter().chain(blocks[55..56].iter()))
+        .await?;
+    assert_eq!(found_blocks.len(), 2);
+    assert!(found_blocks.iter().any(|row| row.hash == blocks[55]));
+    assert!(found_blocks.iter().any(|row| row.hash == blocks[65_055]));
+    let found_txns = db
+        .get_txn_ids(txns.iter().chain(txns[66..67].iter()))
+        .await?;
+    assert_eq!(found_txns.len(), 2);
+    assert_eq!(found_txns[&txns[66]], first_tx);
+    assert_eq!(found_txns[&txns[65_066]], tail_tx);
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -378,3 +378,56 @@ async fn bulk_events_replay_and_rollback_failed_tail_in_postgres() -> eyre::Resu
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let rows = || {
+        (0..3_251u32).map(|nonce| super::StorableMessage {
+            msg: hyperlane_core::HyperlaneMessage {
+                nonce,
+                origin: DOMAIN,
+                destination: DOMAIN,
+                body: if nonce == 0 {
+                    vec![]
+                } else {
+                    vec![(nonce % 251) as u8; 1_024]
+                },
+                ..Default::default()
+            },
+            meta: &meta,
+            txn_id: None,
+            id_override: None,
+        })
+    };
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        3_251
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = super::generated::message::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), 3_251);
+    for row in stored {
+        let expected = if row.nonce == 0 {
+            None
+        } else {
+            Some(vec![(row.nonce % 251) as u8; 1_024])
+        };
+        assert_eq!(row.msg_body, expected);
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -571,3 +571,151 @@ async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Re
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn payment_fallback_deletes_use_bounded_tuple_keys() {
+    let payments = payments(6_000);
+    let meta = LogMeta::default();
+    let mut results = vec![result("max_id", 0)];
+    for chunk in payments.chunks(5_000) {
+        // MockDatabase reads tuples by sorted-key position, not SQL column name.
+        results.push(
+            chunk
+                .iter()
+                .map(|payment| {
+                    BTreeMap::from([
+                        (
+                            "0".to_owned(),
+                            Value::Bytes(Some(Box::new(hyperlane_core::h256_to_bytes(
+                                &payment.message_id,
+                            )))),
+                        ),
+                        ("1".to_owned(), Value::BigInt(Some(0))),
+                        ("2".to_owned(), Value::BigInt(None)),
+                    ])
+                })
+                .collect(),
+        );
+    }
+    results.extend([result("id", 1), result("id", 2), result("num_items", 6_000)]);
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results((0..3).map(|_| MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }))
+            .append_query_results(results)
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap(),
+        6_000
+    );
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 1);
+    let statements = log[0].statements();
+    assert_eq!(statements.len(), 11);
+    let deletes: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("DELETE"))
+        .collect();
+    assert_eq!(deletes.len(), 2);
+    assert_eq!(deletes[0].values.as_ref().unwrap().0.len(), 10_002);
+    assert_eq!(deletes[1].values.as_ref().unwrap().0.len(), 2_002);
+    for statement in deletes {
+        assert!(statement.sql.contains("\"tx_id\" IS NULL"));
+        assert!(statement.sql.contains("(\"msg_id\", \"log_index\") IN"));
+    }
+}
+
+#[tokio::test]
+async fn payment_fallback_deletes_preserve_neighbors_and_rollback_in_postgres() -> eyre::Result<()>
+{
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let mut neighbor_meta = LogMeta::default();
+    neighbor_meta.log_index = U256::one();
+    let address = H256::from_low_u64_be(1);
+    let other_address = H256::from_low_u64_be(2);
+    let payments = payments(6_000);
+    let mut fallback = payment_rows(&payments, &meta, None);
+    for row in fallback.iter_mut().skip(1).step_by(2) {
+        row.meta = &neighbor_meta;
+    }
+    db.store_payments(DOMAIN, &address, &fallback).await?;
+    db.store_payments(DOMAIN, &other_address, &fallback[..1])
+        .await?;
+    db.store_payments(
+        DOMAIN,
+        &address,
+        &payment_rows(&payments[..1], &neighbor_meta, None),
+    )
+    .await?;
+    let other_domain = super::generated::domain::Entity::find()
+        .filter(super::generated::domain::Column::Id.gt(1))
+        .one(&db.0)
+        .await?
+        .unwrap()
+        .id;
+    db.store_payments(u32::try_from(other_domain)?, &address, &fallback[..1])
+        .await?;
+    let other_tx_id = seed_transaction(&db, 1).await?;
+    db.0.execute(sea_orm::Statement::from_sql_and_values(DatabaseBackend::Postgres,
+        "INSERT INTO gas_payment (time_created,domain,msg_id,payment,gas_amount,tx_id,log_index,origin,destination,interchain_gas_paymaster,sequence) SELECT time_created,domain,msg_id,payment,gas_amount,$1,log_index,origin,destination,interchain_gas_paymaster,sequence FROM gas_payment ORDER BY id LIMIT 1",
+        [other_tx_id.into()],
+    )).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let mut resolved = payment_rows(&payments, &meta, Some(tx_id));
+    for row in resolved.iter_mut().skip(1).step_by(2) {
+        row.meta = &neighbor_meta;
+    }
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_repair_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_004);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        6_003
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_repair_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_004);
+    let neighbors = gas_payment::Entity::find()
+        .filter(gas_payment::Column::TxId.is_null())
+        .all(&db.0)
+        .await?;
+    assert_eq!(neighbors.len(), 3);
+    assert!(neighbors.iter().any(
+        |row| row.interchain_gas_paymaster == hyperlane_core::address_to_bytes(&other_address)
+    ));
+    assert!(neighbors.iter().any(|row| row.log_index == 1));
+    assert!(neighbors.iter().any(|row| row.domain == other_domain));
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.eq(other_tx_id))
+            .count(&db.0)
+            .await?,
+        1
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -1,0 +1,380 @@
+//! Regression tests for PostgreSQL statement bounds and atomic event writes.
+
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, Database, DatabaseBackend, EntityTrait, MockDatabase,
+    MockExecResult, PaginatorTrait, QueryFilter, Value,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use hyperlane_core::{
+    BlockInfo, InterchainGasPayment, LogMeta, TxnInfo, TxnReceiptInfo, H256, H512, U256,
+};
+
+use super::{
+    generated::{delivered_message, gas_payment},
+    ScraperDb, StorableDelivery, StorablePayment, StorableTxn,
+};
+
+const DOMAIN: u32 = 1;
+
+fn result(key: &str, value: i64) -> Vec<BTreeMap<String, Value>> {
+    vec![BTreeMap::from([(
+        key.to_owned(),
+        Value::BigInt(Some(value)),
+    )])]
+}
+
+fn payments(count: u32) -> Vec<InterchainGasPayment> {
+    (0..count)
+        .map(|index| InterchainGasPayment {
+            message_id: H256::from_low_u64_be(u64::from(index)),
+            destination: DOMAIN,
+            payment: U256::from(1000),
+            gas_amount: U256::from(12345),
+        })
+        .collect()
+}
+
+fn payment_rows<'a>(
+    payments: &'a [InterchainGasPayment],
+    meta: &'a LogMeta,
+    txn_id: Option<i64>,
+) -> Vec<StorablePayment<'a>> {
+    payments
+        .iter()
+        .enumerate()
+        .map(|(index, payment)| StorablePayment {
+            payment,
+            sequence: Some(i64::try_from(index).unwrap()),
+            meta,
+            txn_id,
+        })
+        .collect()
+}
+
+fn deliveries(count: u32, meta: &LogMeta) -> impl Iterator<Item = StorableDelivery<'_>> {
+    (0..count).map(|index| StorableDelivery {
+        message_id: H256::from_low_u64_be(u64::from(index)),
+        sequence: Some(i64::from(index)),
+        meta,
+        txn_id: None,
+    })
+}
+
+#[tokio::test]
+async fn empty_event_writes_do_not_access_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert_eq!(
+        db.store_deliveries(DOMAIN, H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &H256::zero(), &[]).await.unwrap(),
+        0
+    );
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn delivery_batches_bound_binds_and_preserve_small_fast_path() {
+    for count in [1, 12_000] {
+        let chunks = if count == 1 { 1 } else { 2 };
+        let mut results = vec![result("max_id", 0)];
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(results)
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_deliveries(DOMAIN, H256::zero(), deliveries(count, &LogMeta::default()))
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        let statements: Vec<_> = log
+            .iter()
+            .flat_map(|transaction| transaction.statements())
+            .collect();
+        let binds: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .map(|statement| statement.values.as_ref().unwrap().0.len())
+            .collect();
+        assert_eq!(
+            binds,
+            if count == 1 {
+                vec![6]
+            } else {
+                vec![60_000, 12_000]
+            }
+        );
+        assert_eq!(statements.len(), if count == 1 { 3 } else { 6 });
+        if count > 1 {
+            assert_eq!(log[1].statements().first().unwrap().sql, "BEGIN");
+            assert_eq!(log[1].statements().last().unwrap().sql, "COMMIT");
+        }
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
+    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERTs.
+    for count in [5_000_u32, 66_000] {
+        let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
+        let mut results = vec![result("max_id", 0)];
+        results.extend((0..chunks).map(|_| Vec::new()));
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results(results)
+                .into_connection(),
+        );
+        let mut payments = payments(count);
+        payments.push(payments[0].clone()); // Prefetch and NULL-row identity must dedupe this.
+        let meta = LogMeta::default();
+        let rows = payment_rows(&payments, &meta, None);
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &rows)
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        assert_eq!(
+            log.len(),
+            1,
+            "one transaction must retain the advisory lock throughout"
+        );
+        let statements = log[0].statements();
+        assert_eq!(statements.first().unwrap().sql, "BEGIN");
+        assert_eq!(statements.last().unwrap().sql, "COMMIT");
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| statement.sql.contains("pg_advisory_xact_lock"))
+                .count(),
+            1
+        );
+        let reads: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.contains(" IN ("))
+            .collect();
+        assert_eq!(reads.len(), chunks);
+        assert!(reads
+            .iter()
+            .all(|statement| statement.values.as_ref().unwrap().0.len() <= 5_002));
+        let inserts: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .collect();
+        assert_eq!(inserts.len(), chunks);
+        assert_eq!(inserts[0].values.as_ref().unwrap().0.len(), 55_000);
+        assert!(statements.iter().all(|statement| statement
+            .values
+            .as_ref()
+            .map_or(true, |values| values.0.len() <= usize::from(u16::MAX))));
+    }
+}
+
+#[tokio::test]
+async fn duplicate_keys_across_chunks_are_rejected() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([result("max_id", 0)])
+            .into_connection(),
+    );
+    let meta = LogMeta::default();
+    let rows = deliveries(12_000, &meta).chain(deliveries(1, &meta));
+    assert!(db
+        .store_deliveries(DOMAIN, H256::zero(), rows)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate delivery"));
+    let mut payments = payments(6_000);
+    payments.push(payments[0].clone());
+    assert!(db
+        .store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate resolved gas payment"));
+    let log = db.0.into_transaction_log();
+    assert!(log.is_empty());
+}
+
+async fn seed_transaction(db: &ScraperDb, index: u64) -> eyre::Result<i64> {
+    let hash = H256::from_low_u64_be(55);
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash,
+            timestamp: 1_700_000_000,
+            number: 500,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let block_id = db.get_block_basic([&hash].into_iter()).await?[0].id;
+    let tx_hash = H512::from_low_u64_be(66 + index);
+    db.store_txns(
+        [StorableTxn {
+            block_id,
+            info: TxnInfo {
+                hash: tx_hash,
+                gas_limit: U256::one(),
+                max_priority_fee_per_gas: None,
+                max_fee_per_gas: None,
+                gas_price: None,
+                nonce: 0,
+                sender: H256::zero(),
+                recipient: None,
+                receipt: Some(TxnReceiptInfo {
+                    gas_used: U256::one(),
+                    cumulative_gas_used: U256::one(),
+                    effective_gas_price: None,
+                }),
+                raw_input_data: None,
+            },
+        }]
+        .into_iter(),
+    )
+    .await?;
+    Ok(db.get_txn_ids([&tx_hash].into_iter()).await?[&tx_hash])
+}
+
+#[tokio::test]
+async fn bulk_events_replay_and_rollback_failed_tail_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        12_000
+    );
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        0
+    );
+    assert_eq!(
+        delivered_message::Entity::find().count(&db.0).await?,
+        12_000
+    );
+    db.0.execute_unprepared("TRUNCATE delivered_message")
+        .await?;
+    let original_tx = seed_transaction(&db, 0).await?;
+    let replacement_tx = seed_transaction(&db, 1).await?;
+    db.store_deliveries(
+        DOMAIN,
+        address,
+        deliveries(1, &meta).map(|mut row| {
+            row.txn_id = Some(original_tx);
+            row
+        }),
+    )
+    .await?;
+    db.0.execute_unprepared("ALTER TABLE delivered_message ADD CONSTRAINT reject_delivery_tail CHECK (sequence <> 10000)").await?;
+    assert!(db
+        .store_deliveries(
+            DOMAIN,
+            address,
+            deliveries(12_000, &meta).map(|mut row| {
+                row.txn_id = Some(replacement_tx);
+                row
+            })
+        )
+        .await
+        .is_err());
+    assert_eq!(delivered_message::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        delivered_message::Entity::find()
+            .one(&db.0)
+            .await?
+            .unwrap()
+            .destination_tx_id,
+        Some(original_tx)
+    );
+    db.0.execute_unprepared("ALTER TABLE delivered_message DROP CONSTRAINT reject_delivery_tail")
+        .await?;
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        11_999
+    );
+
+    let payments = payments(6_000);
+    let fallback = payment_rows(&payments, &meta, None);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    db.0.execute_unprepared("TRUNCATE gas_payment").await?;
+    db.store_payments(DOMAIN, &address, &fallback[..1]).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let resolved = payment_rows(&payments, &meta, Some(tx_id));
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_payment_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        1,
+        "failed tail must restore the deleted NULL fallback row"
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_payment_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &address, &fallback).await?,
+        0,
+        "later fallback replay must preserve resolved rows"
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -134,7 +134,7 @@ async fn delivery_batches_bound_binds_and_preserve_small_fast_path() {
 
 #[tokio::test]
 async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
-    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERTs.
+    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERT statements.
     for count in [5_000_u32, 66_000] {
         let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
         let mut results = vec![result("max_id", 0)];

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -470,3 +470,101 @@ async fn hash_lookups_read_both_chunks_without_duplicate_results_in_postgres() -
     assert_eq!(found_txns[&txns[65_066]], tail_tx);
     Ok(())
 }
+
+#[tokio::test]
+async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Result<()> {
+    use super::generated::{raw_message_dispatch, transaction};
+    use super::StorableRawMessageDispatch;
+    use hyperlane_core::HyperlaneMessage;
+
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let messages: Vec<_> = (0..2_955u32)
+        .map(|nonce| HyperlaneMessage {
+            nonce,
+            origin: DOMAIN,
+            destination: DOMAIN,
+            body: if nonce == 0 {
+                vec![]
+            } else {
+                vec![(nonce % 251) as u8; 1_024]
+            },
+            ..Default::default()
+        })
+        .collect();
+    let rows = || {
+        messages
+            .iter()
+            .map(|msg| StorableRawMessageDispatch { msg, meta: &meta })
+    };
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        2_955
+    );
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = raw_message_dispatch::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), messages.len());
+    for row in stored {
+        assert_eq!(
+            row.msg_body.as_ref(),
+            Some(&messages[row.nonce as usize].body)
+        );
+    }
+
+    seed_transaction(&db, 0).await?;
+    let block_id = db
+        .get_block_basic([&H256::from_low_u64_be(55)].into_iter())
+        .await?[0]
+        .id;
+    let inputs = [None, Some(vec![]), Some(vec![0xab; 4_096])];
+    let transactions = || {
+        inputs
+            .iter()
+            .enumerate()
+            .map(|(index, raw_input_data)| StorableTxn {
+                block_id,
+                info: TxnInfo {
+                    hash: H512::from_low_u64_be(100 + index as u64),
+                    gas_limit: U256::one(),
+                    max_priority_fee_per_gas: None,
+                    max_fee_per_gas: None,
+                    gas_price: None,
+                    nonce: 0,
+                    sender: H256::zero(),
+                    recipient: None,
+                    receipt: Some(TxnReceiptInfo {
+                        gas_used: U256::one(),
+                        cumulative_gas_used: U256::one(),
+                        effective_gas_price: None,
+                    }),
+                    raw_input_data: raw_input_data.clone(),
+                },
+            })
+    };
+    db.store_txns(transactions()).await?;
+    db.store_txns(transactions()).await?;
+    for (index, expected) in inputs.iter().enumerate() {
+        let row = transaction::Entity::find()
+            .filter(transaction::Column::Hash.eq(hyperlane_core::h512_to_bytes(
+                &H512::from_low_u64_be(100 + index as u64),
+            )))
+            .one(&db.0)
+            .await?
+            .unwrap();
+        assert_eq!(&row.raw_input_data, expected);
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -181,6 +181,9 @@ async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
             .filter(|statement| statement.sql.contains(" IN ("))
             .collect();
         assert_eq!(reads.len(), chunks);
+        assert!(reads.iter().all(|statement| statement.sql.starts_with(
+            "SELECT \"gas_payment\".\"msg_id\", \"gas_payment\".\"log_index\", \"gas_payment\".\"tx_id\" FROM"
+        )));
         assert!(reads
             .iter()
             .all(|statement| statement.values.as_ref().unwrap().0.len() <= 5_002));

--- a/rust/main/agents/scraper/src/store/deliveries.rs
+++ b/rust/main/agents/scraper/src/store/deliveries.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 use eyre::Result;
 
 use hyperlane_core::{
-    unwrap_or_none_result, Delivery, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader,
-    Indexed, LogMeta, H512,
+    Delivery, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
 };
 
 use crate::db::StorableDelivery;
@@ -67,12 +66,12 @@ impl HyperlaneSequenceAwareIndexerStoreReader<Delivery> for HyperlaneDbStore {
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_delivered_message_tx_id(self.domain.id(), &self.mailbox_address, sequence)
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_delivered_message_block_number(
+                self.domain.id(),
+                &self.mailbox_address,
+                sequence,
+            )
+            .await
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use eyre::Result;
 use hyperlane_core::{
-    unwrap_or_none_result, HyperlaneLogStore, HyperlaneMessage,
-    HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
+    HyperlaneLogStore, HyperlaneMessage, HyperlaneSequenceAwareIndexerStoreReader, Indexed,
+    LogMeta, H512,
 };
 use time::OffsetDateTime;
 use tracing::warn;
@@ -329,13 +329,9 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneDbS
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_dispatched_tx_id(self.domain.id(), &self.mailbox_address, sequence)
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_dispatched_block_number(self.domain.id(), &self.mailbox_address, sequence)
+            .await
     }
 }
 

--- a/rust/main/agents/scraper/src/store/payments.rs
+++ b/rust/main/agents/scraper/src/store/payments.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use tracing::debug;
 
 use hyperlane_core::{
-    unwrap_or_none_result, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed,
-    InterchainGasPayment, LogMeta, H512,
+    HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed, InterchainGasPayment,
+    LogMeta, H512,
 };
 
 use crate::db::StorablePayment;
@@ -88,16 +88,12 @@ impl HyperlaneSequenceAwareIndexerStoreReader<InterchainGasPayment> for Hyperlan
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_payment_tx_id(
-                    self.domain.id(),
-                    &self.interchain_gas_paymaster_address,
-                    sequence,
-                )
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_payment_block_number(
+                self.domain.id(),
+                &self.interchain_gas_paymaster_address,
+                sequence,
+            )
+            .await
     }
 }

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -110,7 +110,7 @@ impl HyperlaneDbStore {
             .map(|(txn_hash, block_id)| TxnWithBlockId { txn_hash, block_id });
         let txns_with_ids = self.ensure_txns(txn_hash_with_block_ids).await?;
 
-        Ok(txns_with_ids.map(move |TxnWithId { hash, id: txn_id }| TxnWithId { hash, id: txn_id }))
+        Ok(txns_with_ids)
     }
 
     /// Takes a list of transaction hashes and the block id the transaction is

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -7,7 +7,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use eyre::Result;
-use itertools::Itertools;
 use prometheus::IntCounterVec;
 use tracing::{trace, warn};
 
@@ -344,13 +343,60 @@ struct TxnWithBlockId {
     block_id: i64,
 }
 
-fn as_chunks<T>(iter: impl Iterator<Item = T>, chunk_size: usize) -> impl Iterator<Item = Vec<T>> {
-    // the itertools chunks function uses refcell which cannot be used across an
-    // await so this stabilizes the result by putting it into a vec of vecs and
-    // using that for iteration.
-    iter.chunks(chunk_size)
-        .into_iter()
-        .map(|chunk| chunk.into_iter().collect())
-        .collect_vec()
-        .into_iter()
+fn as_chunks<T>(
+    mut iter: impl Iterator<Item = T>,
+    chunk_size: usize,
+) -> impl Iterator<Item = Vec<T>> {
+    assert!(chunk_size > 0, "chunk size must be positive");
+    // Own just the current chunk across await points. itertools::chunks keeps
+    // a RefCell borrowed by each chunk, which cannot be held across awaits.
+    std::iter::from_fn(move || {
+        let chunk: Vec<_> = iter.by_ref().take(chunk_size).collect();
+        (!chunk.is_empty()).then_some(chunk)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::as_chunks;
+
+    #[test]
+    fn enrichment_chunks_only_consume_the_requested_batch() {
+        let consumed = Cell::new(0);
+        let input = (0..1_000).inspect(|_| consumed.set(consumed.get() + 1));
+        let mut chunks = as_chunks(input, 50);
+        assert_eq!(consumed.get(), 0);
+        assert_eq!(chunks.next(), Some((0..50).collect()));
+        assert_eq!(consumed.get(), 50);
+        assert_eq!(chunks.next(), Some((50..100).collect()));
+        assert_eq!(consumed.get(), 100);
+        drop(chunks);
+        assert_eq!(
+            consumed.get(),
+            100,
+            "dropping work must not consume later chunks"
+        );
+    }
+
+    #[test]
+    fn enrichment_chunks_preserve_order_and_partial_tail() {
+        assert_eq!(
+            as_chunks(0..5, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3], vec![4]]
+        );
+        assert_eq!(
+            as_chunks(0..4, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3]]
+        );
+        assert_eq!(as_chunks(0..1, 2).collect::<Vec<_>>(), vec![vec![0]]);
+        assert_eq!(as_chunks(0..0, 2).next(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "chunk size must be positive")]
+    fn enrichment_chunks_reject_zero_chunk_size() {
+        let _ = as_chunks(0..1, 0);
+    }
 }

--- a/rust/main/agents/scraper/src/store/tests.rs
+++ b/rust/main/agents/scraper/src/store/tests.rs
@@ -565,24 +565,60 @@ async fn test_fallback_events_persist_and_survive_restart() -> eyre::Result<()> 
     assert_eq!(
         store
             .db
-            .retrieve_dispatched_tx_id(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
+            .retrieve_dispatched_block_number(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
     assert_eq!(
         store
             .db
-            .retrieve_delivered_message_tx_id(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
+            .retrieve_delivered_message_block_number(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
     assert_eq!(
         store
             .db
-            .retrieve_payment_tx_id(TEST_DOMAIN_ID, &igp, SEQUENCE)
+            .retrieve_payment_block_number(TEST_DOMAIN_ID, &igp, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
+    // Lookup scoping must survive SQL composition: another domain, address,
+    // or sequence cannot borrow this event's resolved block height.
+    for (domain, address, sequence) in [
+        (TEST_DESTINATION_DOMAIN_ID, mailbox, SEQUENCE),
+        (TEST_DOMAIN_ID, H256::from_low_u64_be(9999), SEQUENCE),
+        (TEST_DOMAIN_ID, mailbox, SEQUENCE + 100),
+    ] {
+        assert_eq!(
+            store
+                .db
+                .retrieve_dispatched_block_number(domain, &address, sequence)
+                .await?,
+            None
+        );
+        assert_eq!(
+            store
+                .db
+                .retrieve_delivered_message_block_number(domain, &address, sequence)
+                .await?,
+            None
+        );
+    }
+    for (origin, address, sequence) in [
+        (TEST_DESTINATION_DOMAIN_ID, igp, SEQUENCE),
+        (TEST_DOMAIN_ID, H256::from_low_u64_be(9999), SEQUENCE),
+        (TEST_DOMAIN_ID, igp, SEQUENCE + 100),
+    ] {
+        assert_eq!(
+            store
+                .db
+                .retrieve_payment_block_number(origin, &address, sequence)
+                .await?,
+            None
+        );
+    }
+
     let raw = store
         .db
         .retrieve_raw_message_dispatch_by_id(&message.id())


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

When transaction metadata recovers, payment reconciliation replaces previously stored NULL-transaction fallback rows. It currently issues one DELETE per replaced identity, even though prefetch and replacement inserts are already batched. A 6,000-payment recovery batch therefore issues 6,000 deletion statements while holding its transaction and advisory lock.

## Solution

Collect identities selected by the existing replacement decision, then delete in batches of 5,000 exact `(msg_id, log_index)` tuples. Preserve domain/IGP scope and `tx_id IS NULL`, complete deletions before replacement inserts, and retain the same advisory lock, transaction, global duplicate checks and NULL/resolved precedence.

Stacked on #9491.

## Numerical impact

Code-derived previous counts and locally verified generated SQL for 6,000 fallback replacements:

| Operation | Before | After |
|---|---:|---:|
| DELETE statements | 6,000 | 2 (99.97% fewer) |
| Entire transaction, including reads/inserts/bookends | 6,009 statements | 11 (99.82% fewer) |
| Parameters per DELETE | 4 | 10,002 / 2,002 |

Both bounded tuple statements were executed against local PostgreSQL. No replacement identities still means zero DELETEs; one replacement still means one DELETE. Replacement identities are retained temporarily until the deletion phase. These are repair-path statement counts, not production latency, recovery-volume or memory measurements.

## Verification

- Four focused tests passed with Rust 1.93: exact SQL/bind counts; actual PostgreSQL 5,000-tuple boundary; failed-tail rollback, retry and replay; existing fallback/restart and duplicate-key regressions.
- PostgreSQL test retains wrong cross-pair, other-domain, other-IGP and already-resolved neighboring rows.
- Strict scraper package Clippy (`--no-deps -- -D warnings`), formatting and diff checks passed. Existing dependency warnings remain outside that package-scoped check.
- Independent source review found no blockers. No production database writes or deployment performed.
