### PR TITLE
perf(validator): decode typed database values without copying

### DIFF
--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -114,6 +114,11 @@ impl DB {
         Ok(self.0.get(key)?)
     }
 
+    // Keep the native value pinned only while the typed layer decodes it.
+    fn retrieve_pinned(&self, key: &[u8]) -> Result<Option<rocksdb::DBPinnableSlice<'_>>> {
+        Ok(self.0.get_pinned(key)?)
+    }
+
     /// Retrieve all values stored under a key prefix.
     pub fn retrieve_values_by_prefix(&self, prefix: &[u8]) -> Result<Vec<Vec<u8>>> {
         let mut values = Vec::new();

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -67,8 +67,8 @@ impl TypedDB {
         key: impl AsRef<[u8]>,
     ) -> Result<Option<V>> {
         self.db
-            .retrieve(&self.prefixed_key(prefix.as_ref(), key.as_ref()))?
-            .map(|v| V::read_from(&mut v.as_slice()))
+            .retrieve_pinned(&self.prefixed_key(prefix.as_ref(), key.as_ref()))?
+            .map(|v| V::read_from(&mut v.as_ref()))
             .transpose()
             .map_err(Into::into)
     }
@@ -181,5 +181,108 @@ impl TypedDbBatch {
     /// Atomically commit this batch.
     pub fn commit(self) -> Result<()> {
         self.batch.commit()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperlane_core::{HyperlaneMessage, KnownHyperlaneDomain, MerkleTreeInsertion, H256};
+
+    #[test]
+    fn pinned_typed_reads_preserve_values_and_domain_isolation() {
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let typed = TypedDB::new(&domain, db.clone());
+        let other = TypedDB::new(
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+            db.clone(),
+        );
+        let insertion = MerkleTreeInsertion::new(42, H256::repeat_byte(0x12));
+        typed
+            .store_keyed_encodable(b"leaf_", &42u32, &insertion)
+            .unwrap();
+        assert_eq!(
+            typed
+                .retrieve_keyed_decodable::<_, MerkleTreeInsertion>(b"leaf_", &42u32)
+                .unwrap(),
+            Some(insertion)
+        );
+        assert!(other
+            .retrieve_keyed_decodable::<_, MerkleTreeInsertion>(b"leaf_", &42u32)
+            .unwrap()
+            .is_none());
+        for length in [0, 1, 4096] {
+            let message = HyperlaneMessage {
+                body: vec![0xab; length],
+                ..Default::default()
+            };
+            typed
+                .store_encodable(b"message_", b"key", &message)
+                .unwrap();
+            let encoded = db
+                .retrieve(&typed.prefixed_key(b"message_", b"key"))
+                .unwrap()
+                .unwrap();
+            let legacy = HyperlaneMessage::read_from(&mut encoded.as_slice()).unwrap();
+            let pinned: HyperlaneMessage = typed
+                .retrieve_decodable(b"message_", b"key")
+                .unwrap()
+                .unwrap();
+            assert_eq!(pinned, legacy);
+            assert_eq!(pinned, message);
+        }
+    }
+
+    #[test]
+    fn pinned_typed_reads_propagate_decode_errors_and_release_the_value() {
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let typed = TypedDB::new(
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+            db.clone(),
+        );
+        assert!(typed
+            .retrieve_decodable::<HyperlaneMessage>(b"message_", b"key")
+            .unwrap()
+            .is_none());
+        let key = typed.prefixed_key(b"message_", b"key");
+        db.store(&key, &[1, 2]).unwrap();
+        let error = typed
+            .retrieve_decodable::<HyperlaneMessage>(b"message_", b"key")
+            .unwrap_err();
+        assert!(matches!(error, DbError::HyperlaneError(_)));
+
+        let message = HyperlaneMessage {
+            body: vec![0xab; 4096],
+            ..Default::default()
+        };
+        typed
+            .store_encodable(b"message_", b"key", &message)
+            .unwrap();
+        let decoded: HyperlaneMessage = typed
+            .retrieve_decodable(b"message_", b"key")
+            .unwrap()
+            .unwrap();
+        let replacement = HyperlaneMessage {
+            body: vec![0xcd; 32],
+            ..Default::default()
+        };
+        typed
+            .store_encodable(b"message_", b"key", &replacement)
+            .unwrap();
+        assert_eq!(
+            typed
+                .retrieve_decodable::<HyperlaneMessage>(b"message_", b"key")
+                .unwrap(),
+            Some(replacement)
+        );
+        drop(typed);
+        drop(db);
+        // The decoded object owns its body; no native database pin escapes.
+        assert_eq!(decoded, message);
+        let reopened = DB::from_path(directory.path()).unwrap();
+        assert!(reopened.retrieve(&key).unwrap().is_some());
     }
 }


### PR DESCRIPTION
Consolidated into #9489 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Every typed RocksDB read copies the complete encoded value into a Rust Vec and immediately decodes it. Validator Merkle replay pays this copy for every insertion; relayer reads also copy entire encoded message and transaction records before allocating their decoded fields.

## Solution

Decode directly from RocksDB's pinned value inside the synchronous typed-read helper. Release the pin before returning the owned decoded object or an error. Keep the public raw-byte read API, key encoding, default column family, read options and error propagation unchanged.

## Numerical impact

Synthetic local RocksDB probe, actual typed reads and core decoders, 100 warmup plus 100 measured reads per case:

| Record | Encoded bytes | Rust allocation calls | Requested Rust allocation bytes |
|---|---:|---:|---:|
| Merkle insertion | 36 | 2 → 1 | 52 → 16 |
| Message with 4 KiB body | 4,173 | 3 → 2 | 8,285 → 4,112 |
| Message with 64 KiB body | 65,613 | 3 → 2 | 131,165 → 65,552 |

One complete encoded-input allocation/copy is removed per found typed read. Decoded objects still own their data: the 4 KiB example retains its 4,096-byte body allocation and 16-byte scoped key. Counts exclude native RocksDB/C++ allocations. No disk-read, RPC, latency, RSS or fleet percentage improvement is claimed.

## Verification and scope

- **6 RocksDB tests passed**, including two new tests covering missing/malformed values, domain isolation, canonical decode equivalence, read-after-write replacement and decoded data surviving database close/reopen.
- `cargo +1.93.0 test -p hyperlane-base db::rocks --locked` from `rust/main`.
- Scoped strict base Clippy passed with the established baseline cfg/lifetime flags; the unqualified baseline has four unrelated diagnostics. No source suppression.
- Root and independent relayer review found no blockers; formatting and diff checks passed. Normal commit hooks passed.
- Locked rocksdb 0.24 implements `get` through the same pinned read plus `.to_vec()`, so this removes that final copy without changing database read semantics.
- Existing snapshot, cursor persistence, log retention and checkpoint-pooling PRs do not cover this per-read copy. No signing, verification or quorum changes.

Stack: follows #9492. Shared typed reads benefit relayer and validator; kept with the validator storage stack.
