### PR TITLE
perf(lander): reduce record and transaction lifecycle copies

### DIFF
--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -394,6 +394,13 @@ impl PayloadDb for HyperlaneRocksDB {
 }
 
 impl Encode for FullPayload {
+    fn to_vec(&self) -> Vec<u8> {
+        // Database writes need the JSON buffer itself, not a copy through write_to.
+        serde_json::to_vec(self)
+            .map_err(|_| std::io::Error::other("Failed to serialize"))
+            .expect("!alloc")
+    }
+
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
         W: Write,
@@ -447,6 +454,39 @@ mod tests {
 
     fn tmp_db() -> Arc<HyperlaneRocksDB> {
         db_in(&tempfile::tempdir().unwrap())
+    }
+
+    #[test]
+    fn payload_owned_encoding_matches_writer_and_roundtrips() {
+        use crate::payload::{DropReason, RetryReason};
+        use hyperlane_core::{Decode, Encode};
+        for length in [0, 1, 4096, 65536] {
+            for status in [
+                PayloadStatus::ReadyToSubmit,
+                PayloadStatus::Retry(RetryReason::Reorged),
+                PayloadStatus::Dropped(DropReason::FailedSimulation),
+                PayloadStatus::InTransaction(TransactionStatus::Included),
+                PayloadStatus::InTransaction(TransactionStatus::Finalized),
+            ] {
+                let payload = FullPayload {
+                    data: (0..length).map(|i| (i % 256) as u8).collect(),
+                    status,
+                    ..FullPayload::default()
+                };
+                let mut legacy = Vec::new();
+                assert_eq!(payload.write_to(&mut legacy).unwrap(), legacy.len());
+                let encoded = payload.to_vec();
+                assert_eq!(encoded, legacy);
+                assert_eq!(
+                    FullPayload::read_from(&mut encoded.as_slice()).unwrap(),
+                    payload
+                );
+                // Preserve the existing arbitrary-writer contract, including short writes.
+                let mut partial = [0; 1];
+                assert_eq!(payload.write_to(&mut partial.as_mut_slice()).unwrap(), 1);
+                assert_eq!(partial[0], encoded[0]);
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
+++ b/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
@@ -142,6 +142,13 @@ impl TransactionDb for HyperlaneRocksDB {
 }
 
 impl Encode for Transaction {
+    fn to_vec(&self) -> Vec<u8> {
+        // Database writes need the JSON buffer itself, not a copy through write_to.
+        serde_json::to_vec(self)
+            .map_err(|_| std::io::Error::other("Failed to serialize"))
+            .expect("!alloc")
+    }
+
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
         W: Write,
@@ -187,6 +194,38 @@ mod tests {
         let domain = KnownHyperlaneDomain::Arbitrum.into();
 
         (Arc::new(HyperlaneRocksDB::new(&domain, db))) as _
+    }
+
+    #[test]
+    fn transaction_owned_encoding_matches_writer_and_roundtrips() {
+        use crate::transaction::{DropReason, Transaction};
+        use hyperlane_core::{Decode, Encode, H512};
+        for length in [0, 1, 4096, 65536] {
+            for status in [
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Mempool,
+                TransactionStatus::Included,
+                TransactionStatus::Finalized,
+                TransactionStatus::Dropped(DropReason::Other("retry \"quoted\" reason".to_owned())),
+            ] {
+                let mut payload = FullPayload::default();
+                payload.details.metadata = "x".repeat(length);
+                payload.details.success_criteria = Some(vec![0, 255, 1]);
+                let mut tx = dummy_tx(vec![payload], status);
+                tx.tx_hashes = vec![H512::repeat_byte(0x12), H512::repeat_byte(0x34)];
+                tx.submission_attempts = u32::MAX;
+                tx.last_submission_attempt = Some(tx.creation_timestamp);
+                tx.last_status_check = Some(tx.creation_timestamp);
+                let mut legacy = Vec::new();
+                assert_eq!(tx.write_to(&mut legacy).unwrap(), legacy.len());
+                let encoded = tx.to_vec();
+                assert_eq!(encoded, legacy);
+                assert_eq!(Transaction::read_from(&mut encoded.as_slice()).unwrap(), tx);
+                let mut partial = [0; 1];
+                assert_eq!(tx.write_to(&mut partial.as_mut_slice()).unwrap(), 1);
+                assert_eq!(partial[0], encoded[0]);
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -52,10 +52,7 @@ impl BuildingStage {
         for tx_building_result in tx_building_results {
             // push payloads that failed to be processed (but didn't fail simulation)
             // to the back of the queue
-            if let Err(err) = self
-                .handle_tx_building_result(tx_building_result.clone())
-                .await
-            {
+            if let Err(err) = self.handle_tx_building_result(&tx_building_result).await {
                 error!(?err, payloads=?tx_building_result.payloads, "Error handling tx building result");
                 let full_payloads =
                     get_full_payloads_from_details(payloads, &tx_building_result.payloads);
@@ -74,7 +71,7 @@ impl BuildingStage {
     )]
     async fn handle_tx_building_result(
         &self,
-        tx_building_result: TxBuildingResult,
+        tx_building_result: &TxBuildingResult,
     ) -> eyre::Result<(), LanderError> {
         let TxBuildingResult { payloads, maybe_tx } = tx_building_result;
         let Some(tx) = maybe_tx else {
@@ -84,18 +81,18 @@ impl BuildingStage {
             );
             self.state
                 .update_status_for_payloads(
-                    &payloads,
+                    payloads,
                     PayloadStatus::Dropped(DropReason::FailedToBuildAsTransaction),
                 )
                 .await;
             return Ok(());
         };
         info!(?tx, "Transaction built successfully");
-        self.state.store_tx(&tx).await;
+        self.state.store_tx(tx).await;
         // Only send tx to inclusion stage after we stored it
         // This prevents TX from dropping in case the send operation fails
         call_until_success_or_nonretryable_error(
-            || self.send_tx_to_inclusion_stage(tx.clone()),
+            || self.send_tx_to_inclusion_stage(tx),
             "Sending transaction to inclusion stage",
             &self.state,
         )
@@ -103,7 +100,7 @@ impl BuildingStage {
         Ok(())
     }
 
-    async fn send_tx_to_inclusion_stage(&self, tx: Transaction) -> eyre::Result<(), LanderError> {
+    async fn send_tx_to_inclusion_stage(&self, tx: &Transaction) -> eyre::Result<(), LanderError> {
         if let Err(err) = self.inclusion_stage_sender.send(tx.clone()).await {
             return Err(LanderError::ChannelSendFailure(Box::new(err)));
         }

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building/tests.rs
@@ -9,6 +9,7 @@ use crate::tests::test_utils::{dummy_tx, initialize_payload_db, tmp_dbs, MockAda
 use crate::transaction::{Transaction, TransactionStatus, TransactionUuid};
 
 use super::{BuildingStage, BuildingStageQueue};
+use crate::LanderError;
 
 #[tokio::test]
 async fn test_empty_queue_no_payloads_processed() {
@@ -389,4 +390,91 @@ async fn assert_db_status_for_payloads(
             .unwrap();
         assert_eq!(payload_from_db.status, expected_status);
     }
+}
+
+#[tokio::test]
+async fn borrowed_build_result_preserves_storage_channel_and_error_ownership() {
+    for closed in [false, true] {
+        let (stage, mut receiver, _) = test_setup(0, true);
+        let mut payload = FullPayload::random();
+        payload.details.success_criteria = Some(vec![7; 4096]);
+        initialize_payload_db(&stage.state.payload_db, &payload).await;
+        let result = dummy_built_tx(vec![payload], true).pop().unwrap();
+        let original = result.clone();
+        let tx = result.maybe_tx.as_ref().unwrap();
+        let pointer = tx.payload_details[0]
+            .success_criteria
+            .as_ref()
+            .unwrap()
+            .as_ptr();
+        if closed {
+            receiver.close();
+        }
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            stage.handle_tx_building_result(&result),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, original);
+        assert_eq!(
+            tx.payload_details[0]
+                .success_criteria
+                .as_ref()
+                .unwrap()
+                .as_ptr(),
+            pointer
+        );
+        let stored = stage
+            .state
+            .tx_db
+            .retrieve_transaction_by_uuid(&tx.uuid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored, *tx);
+        if closed {
+            assert!(matches!(
+                outcome.unwrap_err(),
+                LanderError::NonRetryableError(_)
+            ));
+            match stage.send_tx_to_inclusion_stage(tx).await.unwrap_err() {
+                LanderError::ChannelSendFailure(error) => assert_eq!(error.0, *tx),
+                error => panic!("unexpected error: {error}"),
+            }
+        } else {
+            outcome.unwrap();
+            let received = receiver.try_recv().unwrap();
+            assert_eq!(received, *tx);
+            assert_ne!(
+                received.payload_details[0]
+                    .success_criteria
+                    .as_ref()
+                    .unwrap()
+                    .as_ptr(),
+                pointer
+            );
+            assert!(receiver.try_recv().is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn failed_build_handoff_requeues_exact_payloads_in_order() {
+    let (stage, receiver, queue) = test_setup(1, true);
+    drop(receiver);
+    let mut first = FullPayload::random();
+    first.data = vec![3; 4096];
+    let mut second = FullPayload::random();
+    second.data = vec![4; 4096];
+    let payloads = vec![first, second];
+    for payload in &payloads {
+        initialize_payload_db(&stage.state.payload_db, payload).await;
+    }
+    stage.build_transactions(&payloads).await;
+    let requeued = tokio::time::timeout(std::time::Duration::from_secs(1), queue.pop_n_or_wait(2))
+        .await
+        .unwrap();
+    assert_eq!(requeued, payloads);
+    assert_eq!(queue.len().await, 0);
 }

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -172,10 +172,17 @@ impl FinalityStage {
             buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY).boxed()
         } else {
             let status_batch_concurrency = STATUS_READ_CONCURRENCY.div_ceil(status_batch_size);
-            let status_batches = pool_snapshot
-                .chunks(status_batch_size)
-                .map(<[Transaction]>::to_vec)
+            let batch_count = pool_snapshot.len().div_ceil(status_batch_size);
+            let mut remaining_txs = pool_snapshot.into_iter();
+            let status_batches = (0..batch_count)
+                .map(|_| {
+                    remaining_txs
+                        .by_ref()
+                        .take(status_batch_size)
+                        .collect::<Vec<_>>()
+                })
                 .collect::<Vec<_>>();
+            drop(remaining_txs);
             let status_reads = status_batches.into_iter().map(|batch| {
                 read_transaction_status_batch(
                     state,
@@ -309,9 +316,9 @@ impl FinalityStage {
             }
             TransactionStatus::Dropped(drop_reason) => {
                 Self::handle_dropped_transaction(
-                    tx.clone(),
+                    tx,
                     drop_reason,
-                    building_stage_queue.clone(),
+                    building_stage_queue,
                     state,
                     pool,
                 )
@@ -358,8 +365,7 @@ impl FinalityStage {
             TransactionStatus::Dropped(TxDropReason::DroppedByChain),
         )
         .await?;
-        let payloads = tx.payload_details.clone();
-        for payload in payloads.iter() {
+        for payload in &tx.payload_details {
             if let Some(full_payload) = state
                 .payload_db
                 .retrieve_payload_by_uuid(&payload.uuid)
@@ -369,7 +375,10 @@ impl FinalityStage {
             {
                 // update payload status in db
                 state
-                    .update_status_for_payloads(&[payload.clone()], PayloadStatus::ReadyToSubmit)
+                    .update_status_for_payloads(
+                        std::slice::from_ref(payload),
+                        PayloadStatus::ReadyToSubmit,
+                    )
                     .await;
                 // cannot remove a record from the db, so
                 // just link the payload to the null tx id

--- a/rust/main/lander/src/dispatcher/stages/finality_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage/tests.rs
@@ -460,3 +460,99 @@ async fn assert_payloads_status(
         assert_eq!(payload.status, expected_status.clone());
     }
 }
+
+#[tokio::test]
+async fn dropped_transaction_requeues_available_payloads_in_order_and_skips_bad_records() {
+    use hyperlane_base::db::{HyperlaneRocksDB, DB};
+    use hyperlane_core::KnownHyperlaneDomain;
+
+    let directory = tempfile::tempdir().unwrap();
+    let db = Arc::new(HyperlaneRocksDB::new(
+        &KnownHyperlaneDomain::Arbitrum.into(),
+        DB::from_path(directory.path()).unwrap(),
+    ));
+    let payloads: Vec<_> = (0..4)
+        .map(|index| {
+            let mut payload = FullPayload::default();
+            payload.details.uuid = crate::payload::PayloadUuid::random();
+            payload.details.success_criteria = Some(vec![index; 4096]);
+            payload.data = vec![index; 32];
+            payload.status = PayloadStatus::InTransaction(TransactionStatus::Included);
+            payload
+        })
+        .collect();
+    let tx = dummy_tx(payloads.clone(), TransactionStatus::Included);
+    let tx_uuid = tx.uuid.clone();
+    for index in [0, 3] {
+        db.store_payload_by_uuid(&payloads[index]).await.unwrap();
+        db.store_tx_uuid_by_payload_uuid(&payloads[index].details.uuid, &tx_uuid)
+            .await
+            .unwrap();
+    }
+    // Payload1 is missing; payload2 has an invalid stored JSON value.
+    db.store_value_by_key("payload_by_uuid_", &payloads[2].details.uuid, &u32::MAX)
+        .unwrap();
+    let pool = FinalityStagePool::new();
+    pool.insert(tx.clone()).await;
+    let queue = BuildingStageQueue::new();
+    let existing = FullPayload::default();
+    queue.push_front(existing.clone()).await;
+    let state = DispatcherState::new(
+        db.clone(),
+        db.clone(),
+        Arc::new(MockAdapter::new()),
+        DispatcherMetrics::dummy_instance(),
+        "test".to_owned(),
+    );
+    FinalityStage::try_process_tx_with_next_status(
+        tx,
+        TransactionStatus::Dropped(TxDropReason::DroppedByChain),
+        pool.clone(),
+        queue.clone(),
+        &state,
+    )
+    .await
+    .unwrap();
+    assert!(pool.snapshot().await.is_empty());
+    assert_eq!(
+        db.retrieve_transaction_by_uuid(&tx_uuid)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TransactionStatus::Dropped(TxDropReason::DroppedByChain)
+    );
+    // Existing push_front semantics reverse the visited payload order; queued
+    // values were fetched after Dropped persistence, before ReadyToSubmit persistence.
+    let mut expected_queued = vec![payloads[3].clone(), payloads[0].clone()];
+    for payload in &mut expected_queued {
+        payload.status =
+            PayloadStatus::InTransaction(TransactionStatus::Dropped(TxDropReason::DroppedByChain));
+    }
+    expected_queued.push(existing);
+    assert_eq!(queue.pop_n(4).await, expected_queued);
+    for index in [0, 3] {
+        let uuid = &payloads[index].details.uuid;
+        assert_eq!(
+            db.retrieve_payload_by_uuid(uuid)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            PayloadStatus::ReadyToSubmit
+        );
+        assert_eq!(
+            db.retrieve_tx_uuid_by_payload_uuid(uuid).await.unwrap(),
+            Some(TransactionUuid::default())
+        );
+    }
+    assert!(db
+        .retrieve_payload_by_uuid(&payloads[1].details.uuid)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_payload_by_uuid(&payloads[2].details.uuid)
+        .await
+        .is_err());
+}

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -206,10 +206,17 @@ impl InclusionStage {
             .tx_status_batch_size()
             .clamp(1, STATUS_READ_CONCURRENCY);
         let status_batch_concurrency = STATUS_READ_CONCURRENCY.div_ceil(status_batch_size);
-        let status_batches = eligible_txs
-            .chunks(status_batch_size)
-            .map(<[Transaction]>::to_vec)
+        let batch_count = eligible_txs.len().div_ceil(status_batch_size);
+        let mut remaining_txs = eligible_txs.into_iter();
+        let status_batches = (0..batch_count)
+            .map(|_| {
+                remaining_txs
+                    .by_ref()
+                    .take(status_batch_size)
+                    .collect::<Vec<_>>()
+            })
             .collect::<Vec<_>>();
+        drop(remaining_txs);
         let status_reads = status_batches.into_iter().map(|batch| {
             read_transaction_status_batch(state, batch, FinalizedStatusRead::Query, STAGE_NAME)
         });
@@ -494,7 +501,7 @@ impl InclusionStage {
         tx = Self::estimate_tx(&tx, state).await?;
 
         // Submitting transaction to the node
-        tx = Self::submit_tx(&tx, state).await?;
+        tx = Self::submit_tx(tx, state).await?;
         info!(?tx, "Transaction submitted to node");
 
         state
@@ -514,37 +521,35 @@ impl InclusionStage {
     }
 
     async fn submit_tx(
-        tx: &Transaction,
+        tx: Transaction,
         state: &DispatcherState,
     ) -> Result<Transaction, LanderError> {
-        // create a temporary arcmutex so that submission retries are aware of tx fields (e.g. gas price)
-        // set by previous retries when calling `adapter.submit`
-        let tx_shared = Arc::new(Mutex::new(tx.clone()));
+        // Submission retries retain tx fields (e.g. gas price) set by previous
+        // attempts. The retry future borrows this local mutex until it completes.
+        let tx_shared = Mutex::new(tx);
         // successively calling `submit` will result in escalating gas price until the tx is accepted
         // by the node.
         // at this point, not all VMs return information about whether the tx was reverted.
         // so dropping reverted payloads has to happen in the finality step
-        let submitted_tx = call_until_success_or_nonretryable_error(
-            || {
-                let tx_shared_clone = tx_shared.clone();
-                async move {
-                    let mut tx_guard = tx_shared_clone.lock().await;
-                    let submit_result = state.adapter.submit(&mut tx_guard).await;
+        call_until_success_or_nonretryable_error(
+            || async {
+                let mut tx_guard = tx_shared.lock().await;
+                let submit_result = state.adapter.submit(&mut tx_guard).await;
 
-                    match submit_result {
-                        Ok(()) => Ok(tx_guard.clone()),
-                        Err(err) if matches!(err, LanderError::TxAlreadyExists) => {
-                            warn!(tx=?tx_guard, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
-                            Ok(tx_guard.clone())
-                        }
-                        Err(err) => Err(err),
+                match submit_result {
+                    Ok(()) => Ok(()),
+                    Err(err) if matches!(err, LanderError::TxAlreadyExists) => {
+                        warn!(tx=?tx_guard, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
+                        Ok(())
                     }
+                    Err(err) => Err(err),
                 }
             },
             "Submitting transaction",
             state,
         )
         .await?;
+        let submitted_tx = tx_shared.into_inner();
         state.notify_reprocess_txs_activity();
         Ok(submitted_tx)
     }
@@ -557,7 +562,7 @@ impl InclusionStage {
             || {
                 let tx_clone = tx.clone();
                 async move {
-                    let mut tx_clone_inner = tx_clone.clone();
+                    let mut tx_clone_inner = tx_clone;
                     state.adapter.estimate_tx(&mut tx_clone_inner).await?;
                     Ok(tx_clone_inner)
                 }
@@ -582,7 +587,7 @@ impl InclusionStage {
             || {
                 let tx_clone = tx.clone();
                 async move {
-                    let mut tx_clone_inner = tx_clone.clone();
+                    let mut tx_clone_inner = tx_clone;
                     let failed_payloads = state.adapter.simulate_tx(&mut tx_clone_inner).await?;
                     Ok((tx_clone_inner, failed_payloads))
                 }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -223,7 +223,7 @@ async fn test_successful_submission_notifies_reprocess_poller() {
     let (state, _) = reprocess_test_state(mock_adapter);
     let tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
 
-    InclusionStage::submit_tx(&tx, &state).await.unwrap();
+    InclusionStage::submit_tx(tx, &state).await.unwrap();
 
     tokio::time::timeout(
         Duration::from_millis(10),
@@ -1221,4 +1221,248 @@ fn test_aged_pending_tx_backoff_is_escalated_and_capped() {
         now,
         &fresh
     ));
+}
+
+fn retry_clone_fixture() -> Transaction {
+    let mut payload = FullPayload::default();
+    payload.details.success_criteria = Some(vec![7; 4096]);
+    dummy_tx(vec![payload], TransactionStatus::PendingInclusion)
+}
+
+#[tokio::test(start_paused = true)]
+async fn retry_attempts_start_from_original_and_return_successful_mutations() {
+    for simulate in [false, true] {
+        let tx = retry_clone_fixture();
+        let original = tx.clone();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let attempt_calls = calls.clone();
+        let mutate_attempt = move |tx: &mut Transaction| {
+            assert_eq!(tx.submission_attempts, 0);
+            let bytes = tx.payload_details[0].success_criteria.as_mut().unwrap();
+            assert_eq!(bytes.as_slice(), vec![7; 4096]);
+            let attempt = attempt_calls.fetch_add(1, Ordering::SeqCst);
+            bytes[0] = 9;
+            tx.submission_attempts = 3;
+            if attempt == 0 {
+                Err(LanderError::TxSubmissionError("retry fixture".to_owned()))
+            } else {
+                Ok(())
+            }
+        };
+        let mut adapter = MockAdapter::new();
+        if simulate {
+            adapter.expect_simulate_tx().times(2).returning(move |tx| {
+                mutate_attempt(tx)?;
+                Ok(Vec::new())
+            });
+        } else {
+            adapter
+                .expect_estimate_tx()
+                .times(2)
+                .returning(mutate_attempt);
+        }
+        let (state, _) = reprocess_test_state(adapter);
+        let result = if simulate {
+            InclusionStage::simulate_tx(tx.clone(), &state)
+                .await
+                .unwrap()
+        } else {
+            InclusionStage::estimate_tx(&tx, &state).await.unwrap()
+        };
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(tx, original);
+        assert_eq!(result.submission_attempts, 3);
+        assert_eq!(
+            result.payload_details[0].success_criteria.as_ref().unwrap()[0],
+            9
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn retry_attempt_cancellation_discards_mutation_before_next_attempt() {
+    for simulate in [false, true] {
+        let tx = retry_clone_fixture();
+        let original = tx.clone();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let attempt_calls = calls.clone();
+        let fail_attempt = move |tx: &mut Transaction| {
+            attempt_calls.fetch_add(1, Ordering::SeqCst);
+            tx.payload_details[0].success_criteria.as_mut().unwrap()[0] = 9;
+            Err(LanderError::TxSubmissionError("retry fixture".to_owned()))
+        };
+        let mut adapter = MockAdapter::new();
+        if simulate {
+            adapter.expect_simulate_tx().times(1).returning(move |tx| {
+                fail_attempt(tx)?;
+                Ok(Vec::new())
+            });
+        } else {
+            adapter
+                .expect_estimate_tx()
+                .times(1)
+                .returning(fail_attempt);
+        }
+        let (state, _) = reprocess_test_state(adapter);
+        let timeout = Duration::from_millis(10);
+        if simulate {
+            assert!(
+                tokio::time::timeout(timeout, InclusionStage::simulate_tx(tx.clone(), &state))
+                    .await
+                    .is_err()
+            );
+        } else {
+            assert!(
+                tokio::time::timeout(timeout, InclusionStage::estimate_tx(&tx, &state))
+                    .await
+                    .is_err()
+            );
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(tx, original);
+    }
+}
+
+#[tokio::test]
+async fn retry_attempt_terminal_errors_return_without_retrying() {
+    for simulate in [false, true] {
+        let tx = retry_clone_fixture();
+        let original = tx.clone();
+        let mut adapter = MockAdapter::new();
+        if simulate {
+            adapter.expect_simulate_tx().times(1).returning(|tx| {
+                tx.submission_attempts = 3;
+                Err(LanderError::SimulationFailed(vec!["fixture".to_owned()]))
+            });
+        } else {
+            adapter.expect_estimate_tx().times(1).returning(|tx| {
+                tx.submission_attempts = 3;
+                Err(LanderError::EstimationFailed)
+            });
+        }
+        let (state, _) = reprocess_test_state(adapter);
+        let expected = if simulate {
+            LanderError::SimulationFailed(vec!["fixture".to_owned()])
+        } else {
+            LanderError::EstimationFailed
+        };
+        let expected = LanderError::NonRetryableError(expected.to_string()).to_string();
+        let actual = if simulate {
+            InclusionStage::simulate_tx(tx.clone(), &state)
+                .await
+                .unwrap_err()
+                .to_string()
+        } else {
+            InclusionStage::estimate_tx(&tx, &state)
+                .await
+                .unwrap_err()
+                .to_string()
+        };
+        assert_eq!(actual, expected);
+        assert_eq!(tx, original);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn owned_submission_preserves_retry_mutations_and_notifies_only_on_success() {
+    for already_exists in [false, true] {
+        let tx = retry_clone_fixture();
+        let pointer = tx.payload_details[0]
+            .success_criteria
+            .as_ref()
+            .unwrap()
+            .as_ptr() as usize;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let attempt_calls = calls.clone();
+        let mut adapter = MockAdapter::new();
+        adapter.expect_submit().times(2).returning(move |tx| {
+            let attempt = attempt_calls.fetch_add(1, Ordering::SeqCst);
+            let bytes = tx.payload_details[0].success_criteria.as_mut().unwrap();
+            assert_eq!(bytes.as_ptr() as usize, pointer);
+            assert_eq!(bytes[0], if attempt == 0 { 7 } else { 9 });
+            bytes[0] = if attempt == 0 { 9 } else { 11 };
+            if attempt == 0 {
+                Err(LanderError::TxSubmissionError("retry fixture".to_owned()))
+            } else if already_exists {
+                Err(LanderError::TxAlreadyExists)
+            } else {
+                Ok(())
+            }
+        });
+        let (state, _) = reprocess_test_state(adapter);
+        let task_state = state.clone();
+        let task = tokio::spawn(async move { InclusionStage::submit_tx(tx, &task_state).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first submission attempt must start");
+        assert!(tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity()
+        )
+        .await
+        .is_err());
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let bytes = result.payload_details[0].success_criteria.as_ref().unwrap();
+        assert_eq!(bytes.as_ptr() as usize, pointer);
+        assert_eq!(bytes[0], 11);
+        tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity(),
+        )
+        .await
+        .expect("success must notify");
+        assert!(tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity()
+        )
+        .await
+        .is_err());
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn owned_submission_errors_and_cancellation_do_not_notify() {
+    for cancel in [false, true] {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let attempt_calls = calls.clone();
+        let mut adapter = MockAdapter::new();
+        adapter.expect_submit().times(1).returning(move |tx| {
+            attempt_calls.fetch_add(1, Ordering::SeqCst);
+            tx.payload_details[0].success_criteria.as_mut().unwrap()[0] = 9;
+            if cancel {
+                Err(LanderError::TxSubmissionError("retry fixture".to_owned()))
+            } else {
+                Err(LanderError::EstimationFailed)
+            }
+        });
+        let (state, _) = reprocess_test_state(adapter);
+        let tx = retry_clone_fixture();
+        if cancel {
+            assert!(tokio::time::timeout(
+                Duration::from_millis(10),
+                InclusionStage::submit_tx(tx, &state)
+            )
+            .await
+            .is_err());
+        } else {
+            let error = InclusionStage::submit_tx(tx, &state).await.unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                LanderError::NonRetryableError(LanderError::EstimationFailed.to_string())
+                    .to_string()
+            );
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity()
+        )
+        .await
+        .is_err());
+    }
 }

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::{future::Future, time::Duration};
 
 use futures_util::{stream, Stream, StreamExt};
@@ -54,7 +55,6 @@ pub(super) async fn read_transaction_status_batch(
     for tx in &mut checked_txs {
         tx.last_status_check = Some(checked_at);
     }
-    let mut query_txs = Vec::new();
     let status_slots = checked_txs
         .iter()
         .map(|tx| {
@@ -63,11 +63,24 @@ pub(super) async fn read_transaction_status_batch(
             {
                 Some(Ok(TransactionStatus::Finalized))
             } else {
-                query_txs.push(tx.clone());
                 None
             }
         })
         .collect::<Vec<_>>();
+    // Most batches query every transaction. Borrow their checked copies; only
+    // mixed/finalized batches need a separate filtered, owned query buffer.
+    let query_txs: Cow<'_, [Transaction]> = if status_slots.iter().any(Option::is_some) {
+        Cow::Owned(
+            checked_txs
+                .iter()
+                .zip(&status_slots)
+                .filter(|(_, status)| status.is_none())
+                .map(|(tx, _)| tx.clone())
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(&checked_txs)
+    };
     state
         .metrics
         .observe_status_read_batch(stage, query_txs.len(), &state.domain);
@@ -289,3 +302,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod status_batch_tests;

--- a/rust/main/lander/src/dispatcher/stages/utils/status_batch_tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils/status_batch_tests.rs
@@ -1,0 +1,224 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::Semaphore;
+
+use crate::adapter::{AdaptsChain, GasLimit, TxBuildingResult};
+use crate::dispatcher::{DispatcherMetrics, DispatcherState};
+use crate::tests::test_utils::{dummy_tx, tmp_dbs};
+use crate::transaction::{Transaction, TransactionStatus, TransactionUuid};
+use crate::{FullPayload, LanderError};
+use hyperlane_core::H512;
+
+use super::{read_transaction_status_batch, FinalizedStatusRead};
+
+#[derive(Default)]
+struct BatchAdapter {
+    calls: Mutex<Vec<Vec<(TransactionUuid, usize)>>>,
+    gate: Option<Arc<Semaphore>>,
+    wrong_count: bool,
+}
+
+#[async_trait]
+impl AdaptsChain for BatchAdapter {
+    async fn estimate_gas_limit(&self, _: &FullPayload) -> Result<Option<GasLimit>, LanderError> {
+        unimplemented!()
+    }
+    async fn build_transactions(&self, _: &[FullPayload]) -> Vec<TxBuildingResult> {
+        unimplemented!()
+    }
+    async fn estimate_tx(&self, _: &mut Transaction) -> Result<(), LanderError> {
+        unimplemented!()
+    }
+    async fn submit(&self, _: &mut Transaction) -> Result<(), LanderError> {
+        unimplemented!()
+    }
+    async fn get_tx_hash_status(&self, _: H512) -> Result<TransactionStatus, LanderError> {
+        unimplemented!()
+    }
+    fn estimated_block_time(&self) -> &Duration {
+        unimplemented!()
+    }
+    fn update_vm_specific_metrics(&self, _: &Transaction, _: &DispatcherMetrics) {
+        unimplemented!()
+    }
+    async fn tx_statuses(
+        &self,
+        txs: &[Transaction],
+    ) -> Vec<Result<TransactionStatus, LanderError>> {
+        self.calls.lock().unwrap().push(
+            txs.iter()
+                .map(|tx| (tx.uuid.clone(), buffer_pointer(tx)))
+                .collect(),
+        );
+        if let Some(gate) = &self.gate {
+            gate.acquire().await.unwrap().forget();
+        }
+        if self.wrong_count {
+            return vec![];
+        }
+        txs.iter()
+            .enumerate()
+            .map(|(index, _)| {
+                if index == 0 {
+                    Err(LanderError::NetworkError("read failed".to_owned()))
+                } else {
+                    Ok(TransactionStatus::Mempool)
+                }
+            })
+            .collect()
+    }
+}
+
+fn buffer_pointer(tx: &Transaction) -> usize {
+    tx.payload_details[0]
+        .success_criteria
+        .as_ref()
+        .unwrap()
+        .as_ptr() as usize
+}
+
+fn fixture(status: TransactionStatus) -> Transaction {
+    let mut payload = FullPayload::default();
+    payload.details.success_criteria = Some(vec![7; 4096]);
+    payload.details.metadata = "status allocation fixture".to_owned();
+    dummy_tx(vec![payload], status)
+}
+
+fn state(adapter: Arc<BatchAdapter>) -> DispatcherState {
+    let (payload_db, tx_db, _) = tmp_dbs();
+    DispatcherState::new(
+        payload_db,
+        tx_db,
+        adapter,
+        DispatcherMetrics::dummy_instance(),
+        "test".to_owned(),
+    )
+}
+
+#[tokio::test]
+async fn status_batch_preserves_selection_snapshots_errors_and_borrowing() {
+    for (policy, statuses) in [
+        (FinalizedStatusRead::Query, vec![]),
+        (
+            FinalizedStatusRead::Query,
+            vec![
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Finalized,
+                TransactionStatus::Included,
+            ],
+        ),
+        (
+            FinalizedStatusRead::TrustPersisted,
+            vec![
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Included,
+            ],
+        ),
+        (
+            FinalizedStatusRead::TrustPersisted,
+            vec![
+                TransactionStatus::Finalized,
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Included,
+                TransactionStatus::Finalized,
+            ],
+        ),
+        (
+            FinalizedStatusRead::TrustPersisted,
+            vec![TransactionStatus::Finalized, TransactionStatus::Finalized],
+        ),
+    ] {
+        let originals: Vec<_> = statuses.into_iter().map(fixture).collect();
+        let input = originals.clone();
+        let input_pointers: Vec<_> = input.iter().map(buffer_pointer).collect();
+        let queries: Vec<_> = originals
+            .iter()
+            .filter(|tx| {
+                !matches!(policy, FinalizedStatusRead::TrustPersisted)
+                    || tx.status != TransactionStatus::Finalized
+            })
+            .map(|tx| tx.uuid.clone())
+            .collect();
+        let adapter = Arc::new(BatchAdapter::default());
+        let result =
+            read_transaction_status_batch(&state(adapter.clone()), input, policy, "test").await;
+        let calls = adapter.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1); // Even an empty/all-trusted batch calls the adapter.
+        assert_eq!(
+            calls[0]
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect::<Vec<_>>(),
+            queries
+        );
+        assert_eq!(result.len(), originals.len());
+        for (index, (snapshot, checked, status)) in result.iter().enumerate() {
+            assert_eq!(snapshot, &originals[index]);
+            assert_eq!(buffer_pointer(snapshot), input_pointers[index]);
+            assert_ne!(buffer_pointer(snapshot), buffer_pointer(checked));
+            assert!(checked.last_status_check.is_some());
+            let mut expected_checked = snapshot.clone();
+            expected_checked.last_status_check = checked.last_status_check;
+            assert_eq!(checked, &expected_checked);
+            if let Some(query_index) = queries.iter().position(|id| id == &snapshot.uuid) {
+                if queries.len() == originals.len() {
+                    assert_eq!(calls[0][query_index].1, buffer_pointer(checked));
+                } else {
+                    assert_ne!(calls[0][query_index].1, buffer_pointer(checked));
+                }
+                if query_index == 0 {
+                    assert!(matches!(status, Err(LanderError::NetworkError(_))));
+                } else {
+                    assert!(matches!(status, Ok(TransactionStatus::Mempool)));
+                }
+            } else {
+                assert!(matches!(status, Ok(TransactionStatus::Finalized)));
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "adapter returned a mismatched transaction status count")]
+async fn status_batch_rejects_mismatched_adapter_result_count() {
+    let adapter = Arc::new(BatchAdapter {
+        wrong_count: true,
+        ..Default::default()
+    });
+    read_transaction_status_batch(
+        &state(adapter),
+        vec![fixture(TransactionStatus::Included)],
+        FinalizedStatusRead::Query,
+        "test",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn cancelling_status_batch_keeps_the_original_snapshot_unchanged() {
+    let adapter = Arc::new(BatchAdapter {
+        gate: Some(Arc::new(Semaphore::new(0))),
+        ..Default::default()
+    });
+    let state = state(adapter.clone());
+    let original = fixture(TransactionStatus::Included);
+    let snapshot = original.clone();
+    let task = tokio::spawn(async move {
+        read_transaction_status_batch(&state, vec![snapshot], FinalizedStatusRead::Query, "test")
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while adapter.calls.lock().unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("status query should enter the adapter");
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(adapter.calls.lock().unwrap().len(), 1);
+    assert_eq!(original.status, TransactionStatus::Included);
+    assert!(original.last_status_check.is_none());
+}

--- a/rust/main/lander/src/transaction/types.rs
+++ b/rust/main/lander/src/transaction/types.rs
@@ -1,7 +1,7 @@
 // TODO: re-enable clippy warnings
 #![allow(dead_code)]
 
-use std::{collections::HashMap, ops::Deref};
+use std::ops::Deref;
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
@@ -109,40 +109,32 @@ impl TransactionStatus {
     pub fn classify_tx_status_from_hash_statuses(
         statuses: Vec<Result<TransactionStatus, LanderError>>,
     ) -> TransactionStatus {
-        let mut status_counts = HashMap::<TransactionStatus, usize>::new();
+        let mut included = false;
+        let mut mempool = false;
+        let mut pending = false;
+        let mut dropped = false;
 
-        // count the occurrences of each successfully queried hash status
-        for status in statuses.iter().flatten() {
-            let entry = status_counts.entry(status.clone()).or_insert(0);
-            *entry = entry.saturating_add(1);
+        // Only category presence matters; counts and cloned drop reasons are unused.
+        for status in statuses.into_iter().flatten() {
+            match status {
+                TransactionStatus::Finalized => return TransactionStatus::Finalized,
+                TransactionStatus::Included => included = true,
+                TransactionStatus::Mempool => mempool = true,
+                TransactionStatus::PendingInclusion => pending = true,
+                TransactionStatus::Dropped(_) => dropped = true,
+            }
         }
 
-        let finalized_count = status_counts
-            .get(&TransactionStatus::Finalized)
-            .unwrap_or(&0);
-        let included_count = status_counts
-            .get(&TransactionStatus::Included)
-            .unwrap_or(&0);
-        let pending_count = status_counts
-            .get(&TransactionStatus::PendingInclusion)
-            .unwrap_or(&0);
-        let mempool_count = status_counts.get(&TransactionStatus::Mempool).unwrap_or(&0);
-        if *finalized_count > 0 {
-            return TransactionStatus::Finalized;
-        } else if *included_count > 0 {
-            return TransactionStatus::Included;
-        } else if *mempool_count > 0 {
-            return TransactionStatus::Mempool;
-        } else if *pending_count > 0 {
-            return TransactionStatus::PendingInclusion;
-        } else if !status_counts.is_empty() {
-            // if the hashmap is not empty, it must mean that the hashes were dropped,
-            // because the hashmap is populated only if the status query was successful
-            return TransactionStatus::Dropped(DropReason::DroppedByChain);
+        if included {
+            TransactionStatus::Included
+        } else if mempool {
+            TransactionStatus::Mempool
+        } else if pending || !dropped {
+            // Empty or entirely failed reads retain the existing pending fallback.
+            TransactionStatus::PendingInclusion
+        } else {
+            TransactionStatus::Dropped(DropReason::DroppedByChain)
         }
-
-        // otherwise, return `PendingInclusion`, assuming the rpc is down temporarily and returns errors
-        TransactionStatus::PendingInclusion
     }
 }
 
@@ -179,6 +171,94 @@ pub enum VmSpecificTxData {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn legacy_classify(statuses: Vec<Result<TransactionStatus, LanderError>>) -> TransactionStatus {
+        let mut status_counts = HashMap::<TransactionStatus, usize>::new();
+
+        // count the occurrences of each successfully queried hash status
+        for status in statuses.iter().flatten() {
+            let entry = status_counts.entry(status.clone()).or_insert(0);
+            *entry = entry.saturating_add(1);
+        }
+
+        let finalized_count = status_counts
+            .get(&TransactionStatus::Finalized)
+            .unwrap_or(&0);
+        let included_count = status_counts
+            .get(&TransactionStatus::Included)
+            .unwrap_or(&0);
+        let pending_count = status_counts
+            .get(&TransactionStatus::PendingInclusion)
+            .unwrap_or(&0);
+        let mempool_count = status_counts.get(&TransactionStatus::Mempool).unwrap_or(&0);
+        if *finalized_count > 0 {
+            return TransactionStatus::Finalized;
+        } else if *included_count > 0 {
+            return TransactionStatus::Included;
+        } else if *mempool_count > 0 {
+            return TransactionStatus::Mempool;
+        } else if *pending_count > 0 {
+            return TransactionStatus::PendingInclusion;
+        } else if !status_counts.is_empty() {
+            // if the hashmap is not empty, it must mean that the hashes were dropped,
+            // because the hashmap is populated only if the status query was successful
+            return TransactionStatus::Dropped(DropReason::DroppedByChain);
+        }
+
+        // otherwise, return `PendingInclusion`, assuming the rpc is down temporarily and returns errors
+        TransactionStatus::PendingInclusion
+    }
+
+    fn classification_input(category: usize) -> Result<TransactionStatus, LanderError> {
+        match category {
+            0 => Err(LanderError::NetworkError("unavailable".to_owned())),
+            1 => Ok(TransactionStatus::PendingInclusion),
+            2 => Ok(TransactionStatus::Mempool),
+            3 => Ok(TransactionStatus::Included),
+            4 => Ok(TransactionStatus::Finalized),
+            5 => Ok(TransactionStatus::Dropped(DropReason::DroppedByChain)),
+            6 => Ok(TransactionStatus::Dropped(DropReason::FailedSimulation)),
+            7 => Ok(TransactionStatus::Dropped(DropReason::Other(
+                "first reason".to_owned(),
+            ))),
+            _ => Ok(TransactionStatus::Dropped(DropReason::Other(
+                "second reason".to_owned(),
+            ))),
+        }
+    }
+
+    #[test]
+    fn classification_matches_legacy_for_all_small_category_sequences() {
+        for length in 0..=4 {
+            for mut sequence in 0..9usize.pow(length) {
+                let categories: Vec<_> = (0..length)
+                    .map(|_| {
+                        let category = sequence % 9;
+                        sequence /= 9;
+                        category
+                    })
+                    .collect();
+                let legacy = legacy_classify(
+                    categories
+                        .iter()
+                        .copied()
+                        .map(classification_input)
+                        .collect(),
+                );
+                let actual = TransactionStatus::classify_tx_status_from_hash_statuses(
+                    categories
+                        .iter()
+                        .copied()
+                        .map(classification_input)
+                        .collect(),
+                );
+                assert_eq!(actual, legacy, "categories: {categories:?}");
+            }
+        }
+    }
+
     #[test]
     fn test_transaction_status_classification_finalized() {
         use super::*;


### PR DESCRIPTION
## Problem

Lander copies serialized records and owned transactions between local lifecycle helpers even when those helpers only inspect them. Status classification allocates a count map despite needing only category presence, and status batching copies vectors unnecessarily.

## Solution

Return existing JSON serialization buffers, classify status presence directly, move owned batches, and borrow status inputs where filtering is unnecessary. Borrow/move transaction state through estimation, submission, dropped-transaction recovery and building-stage handoff. Preserve the snapshot copy required for stale-result comparison and the channel-owned copy required for sending.

Submission retries retain attempt mutations; estimate/simulation retries still start with a fresh copy. Persistence-before-send, error wrapping, ordering, cancellation boundaries, JSON bytes and arbitrary-writer semantics stay unchanged.

## Numerical evidence

Original allocation probes of the named portions, not whole stages:

| Change / original PR | Numerical result |
| --- | --- |
| Direct JSON records [#9496](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9496) | Actual 4 KiB FullPayload: 9→8 calls; 47,610→32,640 requested bytes; identical 14,970-byte JSON |
| Status classification [#9498](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9498) | Actual one-Pending-result classifier: 1→0 allocation calls; 140→0 requested bytes |
| Owned status batches [#9508](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9508) | Actual 16-transaction 4 KiB CosmWasm ownership portion: 150→51 calls; 208,920→71,384 bytes |
| Retry-attempt copies [#9509](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9509) | Actual 4 KiB EVM portion: 10→5 calls; 9,170→4,585 bytes |
| Owned submit wrapper [#9517](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9517) | Actual 4 KiB EVM portion: 11 allocations/9,450 requested bytes removed; measured future 728→1,032 bytes (+304 inline) |
| Dropped finality [#9518](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9518) | Actual one-payload 4 KiB EVM portion: 8 allocations/8,757 bytes removed |
| Building handoff [#9527](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9527) | Actual one-payload 4 KiB EVM portion: 13 allocations/13,342 bytes removed; sixteen payloads 103/201,082 |

These are separate workloads and lifecycle slices, not additive percentages or a whole-pipeline benchmark. Fixture construction is excluded. Real EVM calldata uses shared Bytes; retained snapshot/channel clones, DB work and runtime/logging allocations remain. Requested bytes are not RSS. The submit future grows 304 bytes despite fewer heap allocations. Direct JSON’s Transaction encoder has the same source-derived copy saving, but that initial encoder probe measured FullPayload only. No RPC/production CPU claim.

## Validation

Fresh at the consolidated commit: full Lander suite 366 passed / one existing ignored, strict production Lander Clippy passed, and normal commit hooks passed. Original regressions retained: 40 JSON byte/roundtrip/short-writer cases; 7,381 classifier cases; status ordering/snapshot/cancellation; fresh estimation retries versus mutation-preserving submission retries; exact dropped payload recovery; real DB building handoff success/error ownership and exact requeue order. Closed channels remain nonretryable under the existing utility.

Stack: follows [#9469](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9469). Consolidates seven linked PRs without code changes. Storage files also compose with the separately reviewed validator storage stack; latest aggregate 49 composition/tests are retained evidence, not a new all-features run at every group. No deployment implied.
