### PR TITLE
perf(docker): deduplicate renamed NCC WASM assets

### DIFF
--- a/docs/performance/2026-09-05-wasm-dedup/README.md
+++ b/docs/performance/2026-09-05-wasm-dedup/README.md
@@ -1,0 +1,63 @@
+# Preserve NCC WASM deduplication after chunk renaming
+
+## Problem
+
+NCC can swap `aleo_wasm.wasm` and `aleo_wasm1.wasm` when the module graph changes. After the lazy LiFi import change in #9483, the Rebalancer bundle emitted those names in the opposite order from an unchanged Keyfunder bundle. The payloads remained identical, but the Docker build's same-filename comparison retained both extra copies.
+
+## Solution
+
+After the existing same-name deduplication, compare remaining regular `*.wasm` files against the canonical Rebalancer WASM files. Replace byte-identical files with relative symlinks while retaining each service's original filename. Skip existing symlinks and missing globs. Abort packaging if removing a duplicate or creating its replacement link fails.
+
+Cross-name matching applies only to WASM. JavaScript workers and native addons retain the existing rules because their paths can affect module resolution.
+
+## Performance evidence
+
+Local Node 24.13.0 / NCC 0.38.4 bundles:
+
+- Rebalancer: `d8e5fcdf0001b415c61b81c2dbb3688e8c304cc1` (#9483).
+- Keyfunder: `c566d54e83cd122a5f4c34f3a44dd24a59bcfffa` (#9466), unchanged by this PR.
+
+Running the actual Docker deduplication loop against these two bundles reduced retained regular-file bytes from **146,567,218 to 105,157,126**, saving **41,410,092 bytes (28.3%)**. Two additional relative symlinks replaced WASM copies of 20,704,991 and 20,705,101 bytes. Resolved payload hashes stayed identical; see `comparison.json`.
+
+This is a two-bundle packaging fixture, with the other five service directories empty. It is not a measured full-image size, compressed layer size, runtime latency, or production improvement. Filename assignment depends on NCC's module graph; if all names already align, the fallback saves zero additional bytes. Existing same-name deduplication remains active.
+
+## Validation
+
+`python3 -m unittest discover -s scripts/tests -p test_ncc_wasm_dedup.py -v`
+
+Five tests execute the production shell loop extracted from `typescript/Dockerfile`, using the same `sh -c` error mode. They cover missing globs, different payloads, same-name deduplication, idempotence, renamed twins, exclusion of cross-name JavaScript/native files, and a failed `ln` that must abort packaging.
+
+The actual Keyfunder bundle also completed an offline fake-chain job in the parent, deduplicated, and relocated symlink-preserving layouts. The configured chain was skipped for funding; construction still exercised the provider, test wallet, and IGP. All three jobs exited 0 with zero network attempts. A preload blocked Node sockets and fetch; no signing or transactions occurred. Reading both WASM symlinks reproduced the original SHA-256 hashes.
+
+No full Docker build or deployment was performed. Local artifacts contain macOS native addons; Linux native packaging and the complete seven-service image remain CI/deployment validation boundaries. Docker already preserves the existing relative symlinks when copying the services directory.
+
+## Reproduce the byte comparison
+
+Build both input service bundles with their ordinary `pnpm ... build` / `pnpm ... bundle` commands at the revisions above. Save the parent Dockerfile with `git show d8e5fcdf:typescript/Dockerfile > /tmp/parent.Dockerfile`. From the repository root, use the same helper as the tests:
+
+```python
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, 'scripts/tests')
+from test_ncc_wasm_dedup import SERVICES, deduplicate
+
+inputs = {
+    'rebalancer': Path('/path/to/rebalancer/bundle'),
+    'keyfunder': Path('/path/to/keyfunder/bundle'),
+}
+for dockerfile in [Path('/tmp/parent.Dockerfile'), Path('typescript/Dockerfile')]:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        for service in SERVICES:
+            if service in inputs:
+                shutil.copytree(inputs[service], root / service, symlinks=True)
+            else:
+                (root / service).mkdir()
+        deduplicate(root, dockerfile)
+        retained = sum(p.stat().st_size for p in root.rglob('*')
+                       if p.is_file() and not p.is_symlink())
+        print(dockerfile, retained)
+```

--- a/docs/performance/2026-09-05-wasm-dedup/README.md
+++ b/docs/performance/2026-09-05-wasm-dedup/README.md
@@ -10,7 +10,7 @@ After the existing same-name deduplication, compare remaining regular `*.wasm` f
 
 Cross-name matching applies only to WASM. JavaScript workers and native addons retain the existing rules because their paths can affect module resolution.
 
-## Performance evidence
+## Two-bundle performance evidence
 
 Local Node 24.13.0 / NCC 0.38.4 bundles:
 
@@ -21,6 +21,47 @@ Running the actual Docker deduplication loop against these two bundles reduced r
 
 This is a two-bundle packaging fixture, with the other five service directories empty. It is not a measured full-image size, compressed layer size, runtime latency, or production improvement. Filename assignment depends on NCC's module graph; if all names already align, the fallback saves zero additional bytes. Existing same-name deduplication remains active.
 
+## Seven-service integration evidence
+
+An independent combined-stack build produced all seven service bundles: 30 build tasks passed, with 23 cache hits and all seven bundle tasks rebuilt. Applying the exact old/new Docker loops reduced retained regular-file bytes from **293,115,406 to 251,705,314**, saving **41,410,092 bytes (14.13%)** across the complete local service layout.
+
+All **108 resolved files** retained identical full SHA-256 hashes and lengths, including JavaScript and native addons. All **44 existing symlink targets** stayed unchanged. The new loop was idempotent. The only new links were `relayer/aleo_wasm.wasm` and `relayer/aleo_wasm1.wasm`, each pointing to the opposite-named Rebalancer asset. All six other services retained the same regular-byte totals.
+
+This differs from the two-bundle fixture above: the combined source graph gave Keyfunder matching canonical filenames, while Relayer had swapped suffixes. Savings depend on emitted filenames, not on a fixed affected service. See `integration-comparison.json` for service totals and exact source heads.
+
+The measurement remains a local macOS/NCC layout comparison, excluding symlink metadata. It is not a Linux or compressed-image size comparison, native-addon ABI validation, WASM execution test, or deployment result. No service was started during the seven-service comparison.
+
+### Reproduce the combined source inputs
+
+In an isolated clone, fetch the five PR heads and merge their exact recorded commits into the common base, in this order:
+
+```sh
+git fetch origin pull/9466/head pull/9467/head pull/9473/head pull/9483/head pull/9486/head
+git switch -c wasm-dedup-fixture 58e16ce875e3e312ab7344810bb159a5540f253b
+git merge --no-ff --no-edit c566d54e83cd122a5f4c34f3a44dd24a59bcfffa
+git merge --no-ff --no-edit a4c4943e9781f1722f65f9e3818ac1dc0968d332
+git merge --no-ff --no-edit 4a7b1677d72c9853e2e362b3da576a0635ded555
+git merge --no-ff --no-edit d8e5fcdf0001b415c61b81c2dbb3688e8c304cc1
+git merge --no-ff --no-edit bcd635d46f2afe21191df90b8e6cf65b830a1439
+```
+
+Relayer and fee-quoting remain at the common base. The measured integration commit was `ac515c7cf027cf100916c7aa1876d6b4ffe29112`; equivalent merges should reproduce source tree `37aab57cc68cf320279c62fc1be876869c1b48ea` even if merge timestamps produce a different commit ID. This integration commit is only a local fixture identifier; the five inputs above are published PR commits.
+
+After installing frozen dependencies, run Docker's seven-service build invocation with bounded build concurrency:
+
+```sh
+pnpm turbo run bundle --concurrency=2 \
+  --filter=@hyperlane-xyz/rebalancer \
+  --filter=@hyperlane-xyz/warp-monitor \
+  --filter=@hyperlane-xyz/ccip-server \
+  --filter=@hyperlane-xyz/keyfunder \
+  --filter=@hyperlane-xyz/relayer \
+  --filter=@hyperlane-xyz/fee-quoting \
+  --filter=@hyperlane-xyz/scraper-proxy
+```
+
+Use all seven bundle directories as `inputs` in the comparison snippet below. Compare the Dockerfile from `d8e5fcdf` against packaging source `5cb6327949c9472c56d345c1afb3cc04cf821ecc`. Hash every resolved output file, compare existing symlink targets, and rerun the new loop to verify idempotence. Subsequent documentation-only commits do not alter that shell input.
+
 ## Validation
 
 `python3 -m unittest discover -s scripts/tests -p test_ncc_wasm_dedup.py -v`
@@ -29,7 +70,7 @@ Five tests execute the production shell loop extracted from `typescript/Dockerfi
 
 The actual Keyfunder bundle also completed an offline fake-chain job in the parent, deduplicated, and relocated symlink-preserving layouts. The configured chain was skipped for funding; construction still exercised the provider, test wallet, and IGP. All three jobs exited 0 with zero network attempts. A preload blocked Node sockets and fetch; no signing or transactions occurred. Reading both WASM symlinks reproduced the original SHA-256 hashes.
 
-No full Docker build or deployment was performed. Local artifacts contain macOS native addons; Linux native packaging and the complete seven-service image remain CI/deployment validation boundaries. Docker already preserves the existing relative symlinks when copying the services directory.
+No local full Docker build or deployment was performed. The source commit `5cb6327949c9472c56d345c1afb3cc04cf821ecc` subsequently passed the [Node Services image build-and-push CI job](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33942893822). That CI result does not measure before/after compressed image size or prove deployment. Local artifacts contain macOS native addons; Linux native runtime behavior remains a deployment validation boundary. Docker already preserves the existing relative symlinks when copying the services directory.
 
 ## Reproduce the byte comparison
 

--- a/docs/performance/2026-09-05-wasm-dedup/comparison.json
+++ b/docs/performance/2026-09-05-wasm-dedup/comparison.json
@@ -1,0 +1,36 @@
+{
+  "parent": {
+    "regularFileBytes": 146567218,
+    "regularFiles": 28,
+    "symlinks": 5,
+    "keyfunderWasm": {
+      "aleo_wasm1.wasm": {
+        "bytes": 20704991,
+        "symlink": null,
+        "sha256Prefix": "6138bdab037f4e98"
+      },
+      "aleo_wasm.wasm": {
+        "bytes": 20705101,
+        "symlink": null,
+        "sha256Prefix": "9aaead677ec3cc79"
+      }
+    }
+  },
+  "head": {
+    "regularFileBytes": 105157126,
+    "regularFiles": 26,
+    "symlinks": 7,
+    "keyfunderWasm": {
+      "aleo_wasm1.wasm": {
+        "bytes": 20704991,
+        "symlink": "../rebalancer/aleo_wasm.wasm",
+        "sha256Prefix": "6138bdab037f4e98"
+      },
+      "aleo_wasm.wasm": {
+        "bytes": 20705101,
+        "symlink": "../rebalancer/aleo_wasm1.wasm",
+        "sha256Prefix": "9aaead677ec3cc79"
+      }
+    }
+  }
+}

--- a/docs/performance/2026-09-05-wasm-dedup/integration-comparison.json
+++ b/docs/performance/2026-09-05-wasm-dedup/integration-comparison.json
@@ -1,0 +1,86 @@
+{
+  "integrationHead": "ac515c7cf027cf100916c7aa1876d6b4ffe29112",
+  "fixture": "Local macOS NCC bundles, not Linux image or compressed layers",
+  "resolvedFileCount": 108,
+  "allResolvedContentsIdentical": true,
+  "idempotent": true,
+  "newWasmSymlinks": {
+    "relayer/aleo_wasm1.wasm": "../rebalancer/aleo_wasm.wasm",
+    "relayer/aleo_wasm.wasm": "../rebalancer/aleo_wasm1.wasm"
+  },
+  "oldRegularBytes": 293115406,
+  "newRegularBytes": 251705314,
+  "avoidedRegularBytes": 41410092,
+  "serviceStackInputs": [
+    {
+      "service": "keyfunder",
+      "pr": 9466,
+      "sha": "c566d54e83cd122a5f4c34f3a44dd24a59bcfffa"
+    },
+    {
+      "service": "scraper-proxy",
+      "pr": 9467,
+      "sha": "a4c4943e9781f1722f65f9e3818ac1dc0968d332"
+    },
+    {
+      "service": "warp-monitor",
+      "pr": 9473,
+      "sha": "4a7b1677d72c9853e2e362b3da576a0635ded555"
+    },
+    {
+      "service": "rebalancer",
+      "pr": 9483,
+      "sha": "d8e5fcdf0001b415c61b81c2dbb3688e8c304cc1"
+    },
+    {
+      "service": "ccip-server",
+      "pr": 9486,
+      "sha": "bcd635d46f2afe21191df90b8e6cf65b830a1439"
+    }
+  ],
+  "unchangedServiceSources": {
+    "relayer": "58e16ce875e3e312ab7344810bb159a5540f253b",
+    "fee-quoting": "58e16ce875e3e312ab7344810bb159a5540f253b"
+  },
+  "packagingPR": {
+    "number": 9497,
+    "sha": "5cb6327949c9472c56d345c1afb3cc04cf821ecc"
+  },
+  "publishedDockerMatchesSnapshot": true,
+  "allExistingLinkTargetsUnchanged": true,
+  "buildTasks": {
+    "successful": 30,
+    "cached": 23,
+    "rebuiltServiceBundles": 7
+  },
+  "services": {
+    "rebalancer": {
+      "oldRegularBytes": 83863257,
+      "newRegularBytes": 83863257
+    },
+    "warp-monitor": {
+      "oldRegularBytes": 35483017,
+      "newRegularBytes": 35483017
+    },
+    "ccip-server": {
+      "oldRegularBytes": 29172454,
+      "newRegularBytes": 29172454
+    },
+    "keyfunder": {
+      "oldRegularBytes": 19853104,
+      "newRegularBytes": 19853104
+    },
+    "relayer": {
+      "oldRegularBytes": 65622255,
+      "newRegularBytes": 24212163
+    },
+    "fee-quoting": {
+      "oldRegularBytes": 51097993,
+      "newRegularBytes": 51097993
+    },
+    "scraper-proxy": {
+      "oldRegularBytes": 8023326,
+      "newRegularBytes": 8023326
+    }
+  }
+}

--- a/scripts/tests/test_ncc_wasm_dedup.py
+++ b/scripts/tests/test_ncc_wasm_dedup.py
@@ -1,0 +1,99 @@
+"""Exercise the actual Docker asset-deduplication shell against local fixtures."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+DOCKERFILE = Path(__file__).resolve().parents[2] / "typescript/Dockerfile"
+SERVICES = (
+    "rebalancer", "warp-monitor", "ccip-server", "keyfunder", "relayer",
+    "fee-quoting", "scraper-proxy",
+)
+
+
+def deduplicate(services_dir, dockerfile=DOCKERFILE):
+    source = dockerfile.read_text()
+    # Run the production loop itself, excluding bundle copying and image setup.
+    script = source.split("    CANONICAL=rebalancer &&", 1)[1]
+    script = script.split("# Production stage", 1)[0].strip()
+    script = 'SERVICES_DIR="$1"\nCANONICAL=rebalancer &&' + script
+    subprocess.run(
+        ["sh", "-c", script.replace("\\\n", "\n"), "dedup", str(services_dir)],
+        check=True,
+    )
+
+
+class WasmDedupTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        for service in SERVICES:
+            (self.root / service).mkdir()
+
+    def write(self, service, name, contents):
+        path = self.root / service / name
+        path.write_bytes(contents)
+        return path
+
+    def test_missing_wasm_globs(self):
+        self.write("keyfunder", "index.js", b"entry")
+        deduplicate(self.root)
+        self.assertEqual((self.root / "keyfunder/index.js").read_bytes(), b"entry")
+        self.write("rebalancer", "only.wasm", b"canonical only")
+        deduplicate(self.root)
+        self.assertFalse((self.root / "keyfunder/only.wasm").exists())
+
+    def test_different_bytes_remain_regular_files(self):
+        self.write("rebalancer", "module.wasm", b"canonical")
+        target = self.write("keyfunder", "module1.wasm", b"different")
+        deduplicate(self.root)
+        self.assertFalse(target.is_symlink())
+        self.assertEqual(target.read_bytes(), b"different")
+
+    def test_same_filename_and_already_deduplicated(self):
+        self.write("rebalancer", "module.wasm", b"same")
+        target = self.write("keyfunder", "module.wasm", b"same")
+        for _ in range(2):
+            deduplicate(self.root)
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(os.readlink(target), "../rebalancer/module.wasm")
+            self.assertEqual(target.read_bytes(), b"same")
+
+    def test_failed_renamed_symlink_aborts_packaging(self):
+        self.write("rebalancer", "module.wasm", b"same")
+        self.write("keyfunder", "module1.wasm", b"same")
+        tools = self.root / "tools"
+        tools.mkdir()
+        failing_ln = tools / "ln"
+        failing_ln.write_text("#!/bin/sh\nexit 17\n")
+        failing_ln.chmod(0o755)
+        with patch.dict(os.environ, {"PATH": str(tools) + os.pathsep + os.environ["PATH"]}):
+            with self.assertRaises(subprocess.CalledProcessError) as failure:
+                deduplicate(self.root)
+        self.assertEqual(failure.exception.returncode, 1)
+
+    def test_renamed_twins_preserve_names_and_bytes_without_cross_name_js_links(self):
+        self.write("rebalancer", "aleo.wasm", b"first")
+        self.write("rebalancer", "aleo1.wasm", b"second")
+        first = self.write("keyfunder", "aleo.wasm", b"second")
+        second = self.write("keyfunder", "aleo1.wasm", b"first")
+        self.write("rebalancer", "worker.js", b"worker")
+        worker = self.write("keyfunder", "worker1.js", b"worker")
+        self.write("rebalancer", "addon.node", b"addon")
+        addon = self.write("keyfunder", "addon1.node", b"addon")
+        for _ in range(2):
+            deduplicate(self.root)
+            self.assertEqual(os.readlink(first), "../rebalancer/aleo1.wasm")
+            self.assertEqual(os.readlink(second), "../rebalancer/aleo.wasm")
+            self.assertEqual(first.read_bytes(), b"second")
+            self.assertEqual(second.read_bytes(), b"first")
+            self.assertFalse(worker.is_symlink())
+            self.assertFalse(addon.is_symlink())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -136,7 +136,9 @@ RUN --mount=type=cache,id=node-services-turbo-${TARGETARCH},target=/hyperlane-mo
 # NCC produces byte-identical copies of WASM files (~18MB each), workers,
 # and native addons in every bundle. Replace duplicates with symlinks to
 # the rebalancer (canonical) copy. Done in the builder so that only the
-# deduped result is COPY'd into the runner stage.
+# deduped result is COPY'd into the runner stage. WASM also matches across
+# filenames because NCC can swap numeric suffixes when its module graph changes.
+# Keep cross-name matching limited to WASM; JS/native paths can affect resolution.
 RUN SERVICES_DIR=/hyperlane-monorepo/services && \
     mkdir -p $SERVICES_DIR && \
     for svc in rebalancer warp-monitor ccip-server keyfunder relayer fee-quoting scraper-proxy; do \
@@ -155,6 +157,18 @@ RUN SERVICES_DIR=/hyperlane-monorepo/services && \
           rm "$target" && \
           ln -s "../${CANONICAL}/${fname}" "$target"; \
         fi; \
+      done; \
+      for target in "${svc}"/*.wasm; do \
+        [ ! -f "$target" ] && continue; \
+        [ -L "$target" ] && continue; \
+        for file in "${CANONICAL}"/*.wasm; do \
+          [ ! -f "$file" ] && continue; \
+          if cmp -s "$file" "$target"; then \
+            rm "$target" && \
+            ln -s "../${file}" "$target" || exit 1; \
+            break; \
+          fi; \
+        done; \
       done; \
       if [ -d "${CANONICAL}/prebuilds" ]; then \
         for file in ${CANONICAL}/prebuilds/linux-x64/*; do \


### PR DESCRIPTION
Consolidated stack: shared image packaging follows the rebalancer runtime group #9507. The packaging patch is unchanged; replaying it after the runtime group produces the exact former final stack tree. Five packaging tests and 394 rebalancer tests passed after regrouping; the latter used a 10-second harness timeout after the unchanged LiFi import exceeded the default 2 seconds. Original artifact measurements below retain their stated source/platform scope.

Stacked on the consolidated rebalancer runtime PR #9507.

## Problem

NCC module-graph changes can swap `aleo_wasm.wasm` and `aleo_wasm1.wasm` between service bundles. Docker currently deduplicates only same-named identical assets, retaining duplicate WASM payloads when matching content has different names. This appeared when validating the lazy LiFi import stack.

## Solution

Compare remaining regular WASM files against the canonical Rebalancer WASM files by content. Preserve each service's filename with a relative symlink, skip existing symlinks, and abort packaging if replacement fails. Cross-name matching excludes JavaScript workers and native addons because their paths can affect resolution.

## Performance evidence

Actual local NCC bundles processed by the exact parent/head Docker loops:

| Fixture | Parent retained bytes | This PR | Saving |
| --- | ---: | ---: | ---: |
| All seven services, combined performance stacks | 293,115,406 | 251,705,314 | 41,410,092 (14.13%) |
| Earlier Rebalancer + Keyfunder fixture | 146,567,218 | 105,157,126 | 41,410,092 (28.3%) |

The independent seven-service build passed all **30 build tasks**, rebuilding all seven bundles. All **108 resolved files** retained identical SHA-256 hashes and lengths, all **44 existing link targets** stayed unchanged, and a second deduplication pass was identical. Only two Relayer WASM links were added in this combined layout; the other six services were unchanged.

The earlier two-bundle fixture added two Keyfunder links instead. NCC filename assignment depends on the combined source graph. These are separate local macOS packaging measurements, not additive savings or a fixed affected-service claim. They exclude symlink metadata and do not measure compressed Linux image size, runtime latency, or deployment improvement. Already-aligned filenames save zero additional bytes.

### Linux CI artifact inspection

The successful linux/amd64 CI artifact for source tree `5cb6327949c9472c56d345c1afb3cc04cf821ecc` was inspected at immutable digest `ghcr.io/hyperlane-xyz/hyperlane-node-services@sha256:a19951a1b007ef30bce49305acd5518d519a41e5e68b9f6dcd7f1df4f49f803a`.

It contains **six cross-name WASM symlinks** across CCIP, fee-quoting and relayer, replacing **124,230,276 bytes of duplicate payload** that the old same-filename comparison would retain. Each link resolves to identical content under the opposite canonical filename; the same-named canonical file has a different SHA-256. Independent inspection verified all **113 resolved files**, lengths and link targets. The container was never started.

This is the PR branch's Linux image artifact, with different source inputs from the combined macOS fixture above. These figures are not additive and do not constitute a side-by-side compressed-image size comparison or runtime measurement. The image's synthetic CI merge revision and the stated source commit have the same Git tree.

[Evidence, exact input heads, merge instructions and reproduction](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/b0fb3581de400dc08acc8a626c6544b6533c7cd1/docs/performance/2026-09-05-wasm-dedup/README.md).

## Validation

- Five tests execute the actual Docker shell loop with production `sh -c` semantics: missing globs, different bytes, same names, idempotence, renamed twins, JS/native exclusion, and injected `ln` failure.
- Actual bundled Keyfunder fake-chain job completed in parent, deduplicated, and relocated symlink-preserving layouts: all exited 0 with zero network attempts. Funding was skipped; socket/fetch access was blocked.
- Independent source review and seven-service file/layout validation; normal gitleaks/format hooks and `git diff --check` passed.
- Source commit `5cb6327949c9472c56d345c1afb3cc04cf821ecc` passed the [Node Services image build-and-push CI job](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33942893822). The later commit updates documentation only. No deployment or Linux runtime execution was performed.
- No application/package API changes or changeset.
