### PR TITLE
perf(relayer): classify transaction statuses without allocation

### DIFF
--- a/rust/main/agents/relayer/src/merkle_tree/builder.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/builder.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use eyre::{Context, Result};
-use tracing::{error, instrument};
+use tracing::instrument;
 
 use hyperlane_base::db::DbError;
 use hyperlane_core::{

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use derive_more::Deref;
-use futures_util::future::join_all;
-use futures_util::stream::{FuturesUnordered, StreamExt};
+use futures_util::stream::{FuturesOrdered, FuturesUnordered, StreamExt};
 
 use derive_new::new;
 use tracing::{debug, info, instrument};
@@ -192,19 +191,23 @@ impl AggregationIsmMetadataBuilder {
         &self,
         ism_addresses: Vec<H256>,
     ) -> Option<(usize, Box<dyn InterchainSecurityModule>, H256)> {
-        let sub_isms = join_all(ism_addresses.iter().map(|sub_ism_address| async {
-            let ism_and_module_type =
-                message_builder::ism_and_module_type(self.base.clone(), *sub_ism_address).await;
-            (ism_and_module_type, *sub_ism_address)
-        }))
-        .await;
-        sub_isms.into_iter().enumerate().find_map(|(index, ism)| {
-            if let (Ok((ism, ModuleType::MessageIdMultisig)), address) = ism {
-                Some((index, ism, address))
-            } else {
-                None
+        // Poll lookups concurrently, but preserve configured module priority. Once
+        // the first eligible module is known, trailing lookups need not delay it.
+        let mut sub_isms: FuturesOrdered<_> = ism_addresses
+            .iter()
+            .enumerate()
+            .map(|(index, sub_ism_address)| async move {
+                let ism_and_module_type =
+                    message_builder::ism_and_module_type(self.base.clone(), *sub_ism_address).await;
+                (index, ism_and_module_type, *sub_ism_address)
+            })
+            .collect();
+        while let Some((index, ism, address)) = sub_isms.next().await {
+            if let Ok((ism, ModuleType::MessageIdMultisig)) = ism {
+                return Some((index, ism, address));
             }
-        })
+        }
+        None
     }
 
     async fn build_message_id_aggregation_metadata(
@@ -386,10 +389,19 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use ethers::utils::hex::FromHex;
-    use hyperlane_core::{KnownHyperlaneDomain, U256};
+    use hyperlane_core::{
+        ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneProvider, KnownHyperlaneDomain,
+        U256,
+    };
 
     use hyperlane_core::HyperlaneDomain;
 
@@ -461,6 +473,246 @@ mod test {
         .await
         .expect("failed to build MessageMetadataBuilder");
         AggregationIsmMetadataBuilder::new(inner)
+    }
+
+    #[derive(Debug, Default)]
+    struct LookupProgress {
+        started: AtomicUsize,
+        active: AtomicUsize,
+        completed: AtomicUsize,
+    }
+
+    struct ActiveLookup<'a>(&'a LookupProgress);
+
+    impl Drop for ActiveLookup<'_> {
+        fn drop(&mut self) {
+            self.0.active.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
+    struct DelayedModule {
+        inner: MockInterchainSecurityModule,
+        delay: Duration,
+        progress: Arc<LookupProgress>,
+    }
+
+    impl HyperlaneContract for DelayedModule {
+        fn address(&self) -> H256 {
+            self.inner.address()
+        }
+    }
+
+    impl HyperlaneChain for DelayedModule {
+        fn domain(&self) -> &HyperlaneDomain {
+            self.inner.domain()
+        }
+
+        fn provider(&self) -> Box<dyn HyperlaneProvider> {
+            self.inner.provider()
+        }
+    }
+
+    #[async_trait]
+    impl InterchainSecurityModule for DelayedModule {
+        async fn module_type(&self) -> ChainResult<ModuleType> {
+            self.progress.started.fetch_add(1, Ordering::SeqCst);
+            self.progress.active.fetch_add(1, Ordering::SeqCst);
+            let _active = ActiveLookup(&self.progress);
+            tokio::time::sleep(self.delay).await;
+            self.progress.completed.fetch_add(1, Ordering::SeqCst);
+            self.inner.module_type().await
+        }
+
+        async fn dry_run_verify(
+            &self,
+            message: &HyperlaneMessage,
+            metadata: &Metadata,
+        ) -> ChainResult<Option<U256>> {
+            self.inner.dry_run_verify(message, metadata).await
+        }
+    }
+
+    fn insert_delayed_module(
+        base: &MockBaseMetadataBuilder,
+        address: H256,
+        module_type: ModuleType,
+        delay: Duration,
+    ) -> Arc<LookupProgress> {
+        let progress = Arc::new(LookupProgress::default());
+        base.responses.push_build_ism_response(
+            address,
+            Ok(Box::new(DelayedModule {
+                inner: MockInterchainSecurityModule::new(address, TEST_DOMAIN.clone(), module_type),
+                delay,
+                progress: progress.clone(),
+            })),
+        );
+        progress
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discovery_returns_before_trailing_lookup_and_cancels_it() {
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        let first = H256::from_low_u64_be(10);
+        let trailing = H256::from_low_u64_be(11);
+        insert_delayed_module(
+            &base,
+            first,
+            ModuleType::MessageIdMultisig,
+            Duration::from_millis(100),
+        );
+        let progress =
+            insert_delayed_module(&base, trailing, ModuleType::Null, Duration::from_secs(5));
+        let builder = make_builder(base).await;
+        let start = tokio::time::Instant::now();
+
+        let (index, ism, address) = builder
+            .try_find_message_id_multisig_ism(vec![first, trailing])
+            .await
+            .unwrap();
+
+        assert_eq!((index, address, ism.address()), (0, first, first));
+        assert_eq!(start.elapsed(), Duration::from_millis(100));
+        assert_eq!(progress.started.load(Ordering::SeqCst), 1);
+        assert_eq!(progress.completed.load(Ordering::SeqCst), 0);
+        assert_eq!(progress.active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discovery_preserves_priority_over_completion_order() {
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        let first = H256::from_low_u64_be(10);
+        let second = H256::from_low_u64_be(11);
+        insert_delayed_module(
+            &base,
+            first,
+            ModuleType::MessageIdMultisig,
+            Duration::from_secs(5),
+        );
+        let progress = insert_delayed_module(
+            &base,
+            second,
+            ModuleType::MessageIdMultisig,
+            Duration::from_millis(100),
+        );
+        let builder = make_builder(base).await;
+        let start = tokio::time::Instant::now();
+
+        let (index, _, address) = builder
+            .try_find_message_id_multisig_ism(vec![first, second])
+            .await
+            .unwrap();
+
+        assert_eq!((index, address), (0, first));
+        assert_eq!(start.elapsed(), Duration::from_secs(5));
+        assert_eq!(progress.completed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discovery_skips_failed_and_nonmatching_prefix() {
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        let addresses: Vec<_> = (10..13).map(H256::from_low_u64_be).collect();
+        insert_failing_submodule(&base, addresses[0]);
+        insert_delayed_module(
+            &base,
+            addresses[1],
+            ModuleType::Null,
+            Duration::from_millis(200),
+        );
+        insert_delayed_module(
+            &base,
+            addresses[2],
+            ModuleType::MessageIdMultisig,
+            Duration::from_millis(100),
+        );
+        let expected = addresses[2];
+        let builder = make_builder(base).await;
+        let start = tokio::time::Instant::now();
+
+        let (index, _, address) = builder
+            .try_find_message_id_multisig_ism(addresses)
+            .await
+            .unwrap();
+
+        assert_eq!((index, address), (2, expected));
+        assert_eq!(start.elapsed(), Duration::from_millis(200));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discovery_without_eligible_module_waits_for_all_and_returns_none() {
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        let first = H256::from_low_u64_be(10);
+        let second = H256::from_low_u64_be(11);
+        insert_delayed_module(&base, first, ModuleType::Null, Duration::from_millis(100));
+        let progress =
+            insert_delayed_module(&base, second, ModuleType::Routing, Duration::from_secs(5));
+        let builder = make_builder(base).await;
+        let start = tokio::time::Instant::now();
+
+        assert!(builder
+            .try_find_message_id_multisig_ism(vec![first, second])
+            .await
+            .is_none());
+        assert_eq!(start.elapsed(), Duration::from_secs(5));
+        assert_eq!(progress.completed.load(Ordering::SeqCst), 1);
+        assert!(builder
+            .try_find_message_id_multisig_ism(vec![])
+            .await
+            .is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn canceled_discovery_is_rebuilt_when_fast_path_fails() {
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        let aggregation = H256::from_low_u64_be(1);
+        let first = H256::from_low_u64_be(10);
+        let trailing = H256::from_low_u64_be(11);
+        insert_aggregation_ism(&base, aggregation, vec![first, trailing], 1);
+        insert_delayed_module(
+            &base,
+            first,
+            ModuleType::MessageIdMultisig,
+            Duration::from_millis(100),
+        );
+        let progress =
+            insert_delayed_module(&base, trailing, ModuleType::Null, Duration::from_secs(5));
+        // The chosen fast path fails while constructing its multisig adapter.
+        base.responses
+            .build_multisig_ism
+            .lock()
+            .unwrap()
+            .push_back(Err(eyre::eyre!("multisig adapter unavailable")));
+        // The general path retries the canceled trailing lookup and verifies it.
+        insert_failing_submodule(&base, first);
+        insert_null_submodule(&base, trailing, Ok(Some(U256::from(100))));
+        let remaining_lookups = base.responses.build_ism.clone();
+        let builder = make_builder(base).await;
+        let start = tokio::time::Instant::now();
+
+        let metadata = builder
+            .build(
+                aggregation,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await
+            .unwrap();
+
+        let mut expected = vec![0; 8];
+        expected.extend_from_slice(&16u32.to_be_bytes());
+        expected.extend_from_slice(&16u32.to_be_bytes());
+        assert_eq!(metadata.as_ref(), expected.as_slice());
+        assert_eq!(start.elapsed(), Duration::from_millis(100));
+        assert_eq!(progress.started.load(Ordering::SeqCst), 1);
+        assert_eq!(progress.completed.load(Ordering::SeqCst), 0);
+        assert_eq!(progress.active.load(Ordering::SeqCst), 0);
+        assert!(remaining_lookups
+            .lock()
+            .unwrap()
+            .get(&trailing)
+            .unwrap()
+            .is_empty());
     }
 
     // ── build tests ──────────────────────────────────────────────────────────

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -61,7 +61,11 @@ impl AggregationIsmMetadataBuilder {
         //  [????:????] ISM metadata, packed encoding
         // Initialize the range tuple part of the buffer, so the actual metadatas can
         // simply be appended to it
-        let mut buffer = vec![0; range_tuples_size];
+        let capacity = metadatas.iter().fold(range_tuples_size, |size, entry| {
+            size.saturating_add(entry.metadata.as_ref().len())
+        });
+        let mut buffer = Vec::with_capacity(capacity);
+        buffer.resize(range_tuples_size, 0);
         for SubModuleMetadata { index, metadata } in metadatas.iter_mut() {
             let range_start = buffer.len();
             buffer.extend_from_slice(metadata.as_ref());
@@ -71,11 +75,10 @@ impl AggregationIsmMetadataBuilder {
             // Also see: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/445da4fb0d8140a08c4b314e3051b7a934b0f968/solidity/contracts/libs/isms/AggregationIsmMetadata.sol#L49
             let encoded_range_start = METADATA_RANGE_SIZE.saturating_mul(2).saturating_mul(*index);
             // Overwrite the 0-initialized buffer
-            buffer.splice(
-                encoded_range_start
-                    ..encoded_range_start.saturating_add(METADATA_RANGE_SIZE.saturating_mul(2)),
-                [encode_byte_index(range_start), encode_byte_index(range_end)].concat(),
-            );
+            let range = &mut buffer[encoded_range_start
+                ..encoded_range_start.saturating_add(METADATA_RANGE_SIZE.saturating_mul(2))];
+            range[..METADATA_RANGE_SIZE].copy_from_slice(&encode_byte_index(range_start));
+            range[METADATA_RANGE_SIZE..].copy_from_slice(&encode_byte_index(range_end));
         }
         buffer
     }
@@ -873,6 +876,75 @@ mod test {
         assert_eq!(
             result.unwrap_err(),
             MetadataBuildError::AggregationThresholdNotMet(2)
+        );
+    }
+
+    fn legacy_format_metadata(metadatas: &mut [SubModuleMetadata], ism_count: usize) -> Vec<u8> {
+        // See test solidity implementation of this fn at:
+        // https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/445da4fb0d8140a08c4b314e3051b7a934b0f968/solidity/test/isms/AggregationIsm.t.sol#L35
+        fn encode_byte_index(i: usize) -> [u8; 4] {
+            (i as u32).to_be_bytes()
+        }
+        let range_tuples_size = METADATA_RANGE_SIZE
+            .saturating_mul(2)
+            .saturating_mul(ism_count);
+        //  Format of metadata:
+        //  [????:????] Metadata start/end uint32 ranges, packed as uint64
+        //  [????:????] ISM metadata, packed encoding
+        // Initialize the range tuple part of the buffer, so the actual metadatas can
+        // simply be appended to it
+        let mut buffer = vec![0; range_tuples_size];
+        for SubModuleMetadata { index, metadata } in metadatas.iter_mut() {
+            let range_start = buffer.len();
+            buffer.extend_from_slice(metadata.as_ref());
+            let range_end = buffer.len();
+
+            // The new tuple starts at the end of the previous ones.
+            // Also see: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/445da4fb0d8140a08c4b314e3051b7a934b0f968/solidity/contracts/libs/isms/AggregationIsmMetadata.sol#L49
+            let encoded_range_start = METADATA_RANGE_SIZE.saturating_mul(2).saturating_mul(*index);
+            // Overwrite the 0-initialized buffer
+            buffer.splice(
+                encoded_range_start
+                    ..encoded_range_start.saturating_add(METADATA_RANGE_SIZE.saturating_mul(2)),
+                [encode_byte_index(range_start), encode_byte_index(range_end)].concat(),
+            );
+        }
+        buffer
+    }
+
+    #[test]
+    fn aggregation_formatter_matches_legacy_for_sparse_and_reordered_modules() {
+        for ism_count in [0, 1, 3, 5] {
+            for selected in 0..(1usize << ism_count) {
+                for length in [0, 1, 32, 1291, 4096] {
+                    let mut entries: Vec<_> = (0..ism_count)
+                        .filter(|index| selected & (1 << index) != 0)
+                        .map(|index| {
+                            SubModuleMetadata::new(index, Metadata::new(vec![index as u8; length]))
+                        })
+                        .collect();
+                    for reverse in [false, true] {
+                        if reverse {
+                            entries.reverse();
+                        }
+                        let expected = legacy_format_metadata(&mut entries, ism_count);
+                        assert_eq!(
+                            AggregationIsmMetadataBuilder::format_metadata(&mut entries, ism_count),
+                            expected
+                        );
+                    }
+                }
+            }
+        }
+        // Preserve the existing last-entry-wins header behavior for duplicate indices.
+        let mut entries = vec![
+            SubModuleMetadata::new(1, Metadata::new(vec![1; 17])),
+            SubModuleMetadata::new(1, Metadata::new(vec![2; 33])),
+        ];
+        let expected = legacy_format_metadata(&mut entries, 3);
+        assert_eq!(
+            AggregationIsmMetadataBuilder::format_metadata(&mut entries, 3),
+            expected
         );
     }
 

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -3,13 +3,12 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use derive_more::{AsRef, Deref};
 use derive_new::new;
-use ethers::abi::Token;
 
 use eyre::Result;
 use hyperlane_base::cache::FunctionCallCache;
 use hyperlane_base::settings::CheckpointSyncerBuildError;
 use hyperlane_base::MultisigCheckpointSyncer;
-use hyperlane_core::accumulator::merkle::Proof;
+use hyperlane_core::accumulator::{merkle::Proof, TREE_DEPTH};
 use hyperlane_core::{
     HyperlaneMessage, Metadata, ModuleType, MultisigIsm, MultisigSignedCheckpoint, H256,
 };
@@ -28,6 +27,56 @@ pub struct MultisigMetadata {
     merkle_leaf_index: u32,
     // optional because it's only used for MerkleRootMultisig
     proof: Option<Proof>,
+}
+
+impl MultisigMetadata {
+    fn format(&self, layout: &[MetadataToken]) -> Vec<u8> {
+        const SIGNATURE_LENGTH: usize = 65;
+        let size = layout.iter().fold(0usize, |size, token| {
+            size.saturating_add(match token {
+                MetadataToken::CheckpointMerkleRoot
+                | MetadataToken::CheckpointMerkleTreeHook
+                | MetadataToken::MessageId => H256::len_bytes(),
+                MetadataToken::MessageMerkleLeafIndex | MetadataToken::CheckpointIndex => {
+                    std::mem::size_of::<u32>()
+                }
+                MetadataToken::MerkleProof => TREE_DEPTH.saturating_mul(H256::len_bytes()),
+                MetadataToken::Signatures => self.signatures.len().saturating_mul(SIGNATURE_LENGTH),
+            })
+        });
+        let mut output = Vec::with_capacity(size);
+        for token in layout {
+            match token {
+                MetadataToken::CheckpointMerkleRoot => {
+                    output.extend_from_slice(self.checkpoint.root.as_bytes());
+                }
+                MetadataToken::MessageMerkleLeafIndex => {
+                    output.extend_from_slice(&self.merkle_leaf_index.to_be_bytes());
+                }
+                MetadataToken::CheckpointIndex => {
+                    output.extend_from_slice(&self.checkpoint.index.to_be_bytes());
+                }
+                MetadataToken::CheckpointMerkleTreeHook => {
+                    output.extend_from_slice(self.checkpoint.merkle_tree_hook_address.as_bytes());
+                }
+                MetadataToken::MessageId => {
+                    output.extend_from_slice(self.checkpoint.message_id.as_bytes());
+                }
+                MetadataToken::MerkleProof => {
+                    // ABI bytes32 values are already one word each: no offset, length or padding.
+                    for sibling in &self.proof.as_ref().expect("Metadata is missing proof").path {
+                        output.extend_from_slice(sibling.as_bytes());
+                    }
+                }
+                MetadataToken::Signatures => {
+                    for signature in &self.signatures {
+                        output.extend_from_slice(&<[u8; SIGNATURE_LENGTH]>::from(signature));
+                    }
+                }
+            }
+        }
+        output
+    }
 }
 
 #[derive(Debug, Display, PartialEq, Eq, Clone)]
@@ -55,48 +104,10 @@ pub trait MultisigIsmMetadataBuilder: AsRef<MessageMetadataBuilder> + Send + Syn
         checkpoint_syncer: &MultisigCheckpointSyncer,
     ) -> Result<Option<MultisigMetadata>, MetadataBuildError>;
 
-    fn token_layout(&self) -> Vec<MetadataToken>;
+    fn token_layout(&self) -> &'static [MetadataToken];
 
     fn format_metadata(&self, metadata: MultisigMetadata) -> Result<Vec<u8>> {
-        let build_token = |token: &MetadataToken| -> Result<Vec<u8>> {
-            match token {
-                MetadataToken::CheckpointMerkleRoot => {
-                    Ok(metadata.checkpoint.root.to_fixed_bytes().into())
-                }
-                MetadataToken::MessageMerkleLeafIndex => {
-                    Ok(metadata.merkle_leaf_index.to_be_bytes().into())
-                }
-                MetadataToken::CheckpointIndex => {
-                    Ok(metadata.checkpoint.index.to_be_bytes().into())
-                }
-                MetadataToken::CheckpointMerkleTreeHook => Ok(metadata
-                    .checkpoint
-                    .merkle_tree_hook_address
-                    .to_fixed_bytes()
-                    .into()),
-                MetadataToken::MessageId => {
-                    Ok(metadata.checkpoint.message_id.to_fixed_bytes().into())
-                }
-                MetadataToken::MerkleProof => {
-                    let proof_tokens: Vec<Token> = metadata
-                        .proof
-                        .expect("Metadata is missing proof")
-                        .path
-                        .iter()
-                        .map(|x| Token::FixedBytes(x.to_fixed_bytes().into()))
-                        .collect();
-                    Ok(ethers::abi::encode(&proof_tokens))
-                }
-                MetadataToken::Signatures => Ok(metadata
-                    .signatures
-                    .iter()
-                    .map(|x| x.to_vec())
-                    .collect::<Vec<_>>()
-                    .concat()),
-            }
-        };
-        let metas: Result<Vec<Vec<u8>>> = self.token_layout().iter().map(build_token).collect();
-        Ok(metas?.into_iter().flatten().collect())
+        Ok(metadata.format(self.token_layout()))
     }
 
     /// Returns the validators and threshold for the given multisig ISM.
@@ -308,4 +319,109 @@ pub(crate) async fn build_from_known_validators<T: MultisigIsmMetadataBuilder>(
         .base_builder()
         .update_ism_metric(ism_build_metrics_params);
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers::abi::{encode, Token};
+    use hyperlane_core::{Checkpoint, CheckpointWithMessageId, Signature, U256};
+
+    use super::*;
+
+    // Retain the prior ABI-based encoder as an independent byte-layout oracle.
+    fn legacy_format(metadata: &MultisigMetadata, layout: &[MetadataToken]) -> Vec<u8> {
+        let fields: Vec<Vec<u8>> = layout
+            .iter()
+            .map(|token| match token {
+                MetadataToken::CheckpointMerkleRoot => metadata.checkpoint.root.as_bytes().to_vec(),
+                MetadataToken::CheckpointIndex => metadata.checkpoint.index.to_be_bytes().to_vec(),
+                MetadataToken::CheckpointMerkleTreeHook => metadata
+                    .checkpoint
+                    .merkle_tree_hook_address
+                    .as_bytes()
+                    .to_vec(),
+                MetadataToken::MessageId => metadata.checkpoint.message_id.as_bytes().to_vec(),
+                MetadataToken::MerkleProof => encode(
+                    &metadata
+                        .proof
+                        .expect("Merkle proof fixture")
+                        .path
+                        .iter()
+                        .map(|hash| Token::FixedBytes(hash.as_bytes().to_vec()))
+                        .collect::<Vec<_>>(),
+                ),
+                MetadataToken::MessageMerkleLeafIndex => {
+                    metadata.merkle_leaf_index.to_be_bytes().to_vec()
+                }
+                MetadataToken::Signatures => metadata
+                    .signatures
+                    .iter()
+                    .map(|signature| signature.to_vec())
+                    .collect::<Vec<_>>()
+                    .concat(),
+            })
+            .collect();
+        fields.into_iter().flatten().collect()
+    }
+
+    #[test]
+    fn packed_multisig_metadata_matches_legacy_abi_encoder() {
+        let message_id_layout = [
+            MetadataToken::CheckpointMerkleTreeHook,
+            MetadataToken::CheckpointMerkleRoot,
+            MetadataToken::CheckpointIndex,
+            MetadataToken::Signatures,
+        ];
+        let merkle_root_layout = [
+            MetadataToken::CheckpointMerkleTreeHook,
+            MetadataToken::MessageMerkleLeafIndex,
+            MetadataToken::MessageId,
+            MetadataToken::MerkleProof,
+            MetadataToken::CheckpointIndex,
+            MetadataToken::Signatures,
+        ];
+        for count in [0_u32, 1, 3, 50] {
+            for index in [0, 1, u32::MAX] {
+                for v in [0, 1, 27, 28, 255, 256, u64::MAX] {
+                    let mut metadata = MultisigMetadata::new(
+                        MultisigSignedCheckpoint {
+                            checkpoint: CheckpointWithMessageId {
+                                checkpoint: Checkpoint {
+                                    merkle_tree_hook_address: H256::repeat_byte(0x12),
+                                    mailbox_domain: 7,
+                                    root: H256::repeat_byte(0x34),
+                                    index,
+                                },
+                                message_id: H256::repeat_byte(0x56),
+                            },
+                            signatures: (0..count)
+                                .map(|i| Signature {
+                                    r: U256::from(i),
+                                    s: U256::max_value().saturating_sub(U256::from(i)),
+                                    v,
+                                })
+                                .collect(),
+                        },
+                        index.saturating_sub(1),
+                        None,
+                    );
+                    assert_eq!(
+                        metadata.format(&message_id_layout),
+                        legacy_format(&metadata, &message_id_layout)
+                    );
+                    metadata.proof = Some(Proof {
+                        leaf: H256::repeat_byte(0x78),
+                        index: 9,
+                        path: std::array::from_fn(|i| {
+                            H256::repeat_byte(u8::try_from(i).expect("proof depth fits u8"))
+                        }),
+                    });
+                    assert_eq!(
+                        metadata.format(&merkle_root_layout),
+                        legacy_format(&metadata, &merkle_root_layout)
+                    );
+                }
+            }
+        }
+    }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
@@ -22,8 +22,8 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
         ModuleType::MerkleRootMultisig
     }
 
-    fn token_layout(&self) -> Vec<MetadataToken> {
-        vec![
+    fn token_layout(&self) -> &'static [MetadataToken] {
+        &[
             MetadataToken::CheckpointMerkleTreeHook,
             MetadataToken::MessageMerkleLeafIndex,
             MetadataToken::MessageId,

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
@@ -21,8 +21,8 @@ impl MultisigIsmMetadataBuilder for MessageIdMultisigMetadataBuilder {
         ModuleType::MessageIdMultisig
     }
 
-    fn token_layout(&self) -> Vec<MetadataToken> {
-        vec![
+    fn token_layout(&self) -> &'static [MetadataToken] {
+        &[
             MetadataToken::CheckpointMerkleTreeHook,
             MetadataToken::CheckpointMerkleRoot,
             MetadataToken::CheckpointIndex,

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -348,21 +348,17 @@ impl PendingOperation for PendingMessage {
             None => None,
         };
 
-        let metadata = match self.metadata.as_ref() {
-            Some(metadata) => {
-                tracing::debug!(USE_CACHE_METADATA_LOG);
-                metadata.clone()
-            }
-            _ => match self.build_metadata().await {
-                Ok(metadata) => {
-                    self.metadata = Some(metadata.clone());
-                    metadata
-                }
-                Err(err) => {
-                    return err;
-                }
+        match self.metadata.as_ref() {
+            Some(_) => tracing::debug!(USE_CACHE_METADATA_LOG),
+            None => match self.build_metadata().await {
+                Ok(metadata) => self.metadata = Some(metadata),
+                Err(err) => return err,
             },
-        };
+        }
+        let metadata = self
+            .metadata
+            .as_ref()
+            .expect("Metadata was cached or successfully built");
 
         // Estimate transaction costs for the process call. If there are issues, it's
         // likely that gas estimation has failed because the message is
@@ -379,7 +375,7 @@ impl PendingOperation for PendingMessage {
                 match self
                     .ctx
                     .destination_mailbox
-                    .process_estimate_costs(&self.message, &metadata)
+                    .process_estimate_costs(&self.message, metadata)
                     .await
                 {
                     Ok(cost) => {
@@ -444,7 +440,12 @@ impl PendingOperation for PendingMessage {
         }
 
         self.submission_data = Some(Box::new(MessageSubmissionData {
-            metadata,
+            // Retries above only need the cached metadata. Copy it once admission
+            // succeeds and the submission data needs its own owned buffer.
+            metadata: self
+                .metadata
+                .clone()
+                .expect("Successful preparation retains its metadata"),
             gas_limit,
         }));
         PendingOperationResult::Success
@@ -780,8 +781,6 @@ impl PendingMessage {
         let domain_name = mailbox.domain().name();
         let fn_key = "is_contract";
         let fn_params = self.message.recipient;
-        let provider = self.ctx.destination_mailbox.provider();
-
         // Check cache for recipient contract status
         if let Some(is_contract) = self
             .get_from_cache::<bool>(domain_name, fn_key, &fn_params)
@@ -790,6 +789,8 @@ impl PendingMessage {
             return Ok(is_contract);
         }
 
+        // Construct the provider only when the cached status cannot answer.
+        let provider = mailbox.provider();
         // Check if the recipient is a contract
         let is_contract = provider.is_contract(&fn_params).await.map_err(|err| {
             self.on_reprepare(
@@ -1264,6 +1265,295 @@ mod test {
     use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
     use super::{PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES, VALIDATOR_SIGNATURE_FAST_RETRY_MAX};
+
+    #[derive(Debug)]
+    struct ContractProvider {
+        result: Option<bool>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl HyperlaneChain for ContractProvider {
+        fn domain(&self) -> &HyperlaneDomain {
+            unimplemented!()
+        }
+        fn provider(&self) -> Box<dyn HyperlaneProvider> {
+            unimplemented!()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HyperlaneProvider for ContractProvider {
+        async fn get_block_by_height(&self, _: u64) -> ChainResult<BlockInfo> {
+            unimplemented!()
+        }
+        async fn get_txn_by_hash(&self, _: &H512) -> ChainResult<TxnInfo> {
+            unimplemented!()
+        }
+        async fn get_balance(&self, _: String) -> ChainResult<U256> {
+            unimplemented!()
+        }
+        async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
+            unimplemented!()
+        }
+        async fn is_contract(&self, _: &H256) -> ChainResult<bool> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.result.ok_or_else(|| {
+                ChainCommunicationError::from_other_str("contract lookup unavailable")
+            })
+        }
+    }
+
+    fn pending_with_mailbox(
+        mailbox: hyperlane_test::mocks::MockMailboxContract,
+        max_gas: Option<U256>,
+    ) -> (tempfile::TempDir, PendingMessage) {
+        use crate::{
+            msg::gas_payment::GasPaymentEnforcer,
+            settings::{GasPaymentEnforcementConf, GasPaymentEnforcementPolicy},
+        };
+        use hyperlane_base::cache::{
+            LocalCache, MeteredCache, MeteredCacheConfig, MeteredCacheMetrics,
+        };
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let dir = tempfile::tempdir().unwrap();
+        let db = HyperlaneRocksDB::new(&domain, DB::from_path(dir.path()).unwrap());
+        let cache = OptionalCache::new(Some(MeteredCache::new(
+            LocalCache::new("pending-allocation-tests"),
+            MeteredCacheMetrics {
+                hit_count: None,
+                miss_count: None,
+            },
+            MeteredCacheConfig {
+                cache_name: "pending-allocation-tests".to_owned(),
+            },
+        )));
+        let base = dummy_metadata_builder(&domain, &domain, &db, cache.clone());
+        let mut context = dummy_message_context(Arc::new(base), &db, cache);
+        context.destination_mailbox = Arc::new(mailbox);
+        context.transaction_gas_limit = max_gas;
+        context.origin_gas_payment_enforcer =
+            Arc::new(tokio::sync::RwLock::new(GasPaymentEnforcer::new(
+                [GasPaymentEnforcementConf {
+                    policy: GasPaymentEnforcementPolicy::None,
+                    matching_list: Default::default(),
+                }],
+                db,
+            )));
+        let message = HyperlaneMessage {
+            origin: domain.id(),
+            destination: domain.id(),
+            ..Default::default()
+        };
+        (
+            dir,
+            PendingMessage::new(
+                message,
+                Arc::new(context),
+                PendingOperationStatus::FirstPrepareAttempt,
+                None,
+                DEFAULT_MAX_MESSAGE_RETRIES,
+            ),
+        )
+    }
+
+    fn contract_test_mailbox() -> hyperlane_test::mocks::MockMailboxContract {
+        let mut mailbox = hyperlane_test::mocks::MockMailboxContract::new();
+        mailbox
+            .expect__domain()
+            .return_const(HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum));
+        mailbox
+    }
+
+    #[tokio::test]
+    async fn cached_contract_status_skips_provider_construction() {
+        for expected in [false, true] {
+            let mut mailbox = contract_test_mailbox();
+            mailbox.expect__provider().times(0);
+            let (_dir, mut pending) = pending_with_mailbox(mailbox, None);
+            pending
+                .store_to_cache(
+                    "arbitrum",
+                    "is_contract",
+                    &pending.message.recipient,
+                    &expected,
+                )
+                .await;
+            for _ in 0..10 {
+                assert_eq!(pending.is_recipient_contract().await.unwrap(), expected);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn contract_status_miss_fetches_once_and_caches_both_results() {
+        for expected in [false, true] {
+            let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let provider_calls = calls.clone();
+            let mut mailbox = contract_test_mailbox();
+            mailbox.expect__provider().times(1).returning(move || {
+                Box::new(ContractProvider {
+                    result: Some(expected),
+                    calls: provider_calls.clone(),
+                })
+            });
+            let (_dir, mut pending) = pending_with_mailbox(mailbox, None);
+            for _ in 0..10 {
+                assert_eq!(pending.is_recipient_contract().await.unwrap(), expected);
+            }
+            assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn contract_status_error_reprepares_and_does_not_cache() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let provider_calls = calls.clone();
+        let mut mailbox = contract_test_mailbox();
+        mailbox.expect__provider().times(2).returning(move || {
+            Box::new(ContractProvider {
+                result: None,
+                calls: provider_calls.clone(),
+            })
+        });
+        let (_dir, mut pending) = pending_with_mailbox(mailbox, None);
+        for _ in 0..2 {
+            assert!(matches!(
+                pending.is_recipient_contract().await,
+                Err(PendingOperationResult::Reprepare(
+                    ReprepareReason::ErrorCheckingIfRecipientIsContract
+                ))
+            ));
+        }
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(pending.num_retries, 2);
+    }
+
+    #[tokio::test]
+    async fn prepare_retains_metadata_on_success_and_clears_it_above_gas_limit() {
+        for max_gas in [None, Some(U256::one())] {
+            let mut mailbox = contract_test_mailbox();
+            mailbox.expect__provider().times(0);
+            mailbox
+                .expect__delivered()
+                .times(1)
+                .returning(|_| Ok(false));
+            mailbox
+                .expect_process_estimate_costs()
+                .times(1)
+                .withf(|_, metadata| metadata == vec![7; 1291].as_slice())
+                .returning(|_, _| {
+                    Ok(TxCostEstimate {
+                        gas_limit: U256::from(100),
+                        gas_price: FixedPointNumber::zero(),
+                        l2_gas_limit: None,
+                    })
+                });
+            let (_dir, mut pending) = pending_with_mailbox(mailbox, max_gas);
+            pending
+                .store_to_cache("arbitrum", "is_contract", &pending.message.recipient, &true)
+                .await;
+            pending.metadata = Some(Metadata::new(vec![7; 1291]));
+            let original_buffer = pending.metadata.as_ref().unwrap().as_ptr();
+            let result = pending.prepare().await;
+            if max_gas.is_some() {
+                assert!(matches!(
+                    result,
+                    PendingOperationResult::Reprepare(ReprepareReason::ExceedsMaxGasLimit)
+                ));
+                assert!(pending.metadata.is_none());
+                assert!(pending.submission_data.is_none());
+            } else {
+                assert!(matches!(result, PendingOperationResult::Success));
+                assert_eq!(pending.metadata.as_ref().unwrap().as_ptr(), original_buffer);
+                let submission = pending.submission_data.as_ref().unwrap();
+                assert_eq!(
+                    submission.metadata.as_ref(),
+                    pending.metadata.as_ref().unwrap().as_ref()
+                );
+                assert_ne!(submission.metadata.as_ptr(), original_buffer);
+                assert_eq!(submission.gas_limit, U256::from(100));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn newly_built_metadata_preserves_success_reveal_and_failure_behavior() {
+        use crate::test_utils::{
+            mock_base_builder::build_mock_base_builder, mock_ism::MockInterchainSecurityModule,
+        };
+        for outcome in ["success", "ICA: Invalid Reveal", "simulation failed"] {
+            let mut mailbox = contract_test_mailbox();
+            mailbox.expect__provider().times(0);
+            mailbox
+                .expect__delivered()
+                .times(1)
+                .returning(|_| Ok(false));
+            mailbox
+                .expect__recipient_ism()
+                .times(1)
+                .returning(|_| Ok(H256::zero()));
+            mailbox
+                .expect_process_estimate_costs()
+                .times(1)
+                .withf(|_, metadata| metadata.is_empty())
+                .returning(move |_, _| {
+                    if outcome == "success" {
+                        Ok(TxCostEstimate {
+                            gas_limit: U256::from(100),
+                            gas_price: FixedPointNumber::zero(),
+                            l2_gas_limit: None,
+                        })
+                    } else {
+                        Err(ChainCommunicationError::from_other_str(outcome))
+                    }
+                });
+            let (_dir, mut pending) = pending_with_mailbox(mailbox, None);
+            let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+            let base = build_mock_base_builder(domain.clone(), domain.clone());
+            base.responses.push_build_ism_response(
+                H256::zero(),
+                Ok(Box::new(MockInterchainSecurityModule::new(
+                    H256::zero(),
+                    domain,
+                    ModuleType::Null,
+                ))),
+            );
+            Arc::get_mut(&mut pending.ctx).unwrap().metadata_builder = Arc::new(base);
+            pending
+                .store_to_cache("arbitrum", "is_contract", &pending.message.recipient, &true)
+                .await;
+            assert!(pending.metadata.is_none());
+            let result = pending.prepare().await;
+            match outcome {
+                "success" => {
+                    assert!(matches!(result, PendingOperationResult::Success));
+                    assert!(pending.metadata.as_ref().unwrap().is_empty());
+                    assert!(pending
+                        .submission_data
+                        .as_ref()
+                        .unwrap()
+                        .metadata
+                        .is_empty());
+                }
+                "ICA: Invalid Reveal" => {
+                    assert!(matches!(result, PendingOperationResult::Reprepare(_)));
+                    assert!(pending.metadata.as_ref().unwrap().is_empty());
+                    assert!(pending.submission_data.is_none());
+                    assert_eq!(pending.ica_reveal_attempts, 1);
+                    assert_eq!(pending.num_retries, 0);
+                }
+                _ => {
+                    assert!(matches!(
+                        result,
+                        PendingOperationResult::Reprepare(ReprepareReason::ErrorEstimatingGas)
+                    ));
+                    assert!(pending.metadata.is_none());
+                    assert!(pending.submission_data.is_none());
+                    assert_eq!(pending.num_retries, 1);
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_calculate_msg_backoff_does_not_overflow() {

--- a/rust/main/agents/relayer/src/prover.rs
+++ b/rust/main/agents/relayer/src/prover.rs
@@ -7,7 +7,7 @@ use hyperlane_core::accumulator::{
     TREE_DEPTH,
 };
 use hyperlane_core::H256;
-use tracing::{error, instrument};
+use tracing::instrument;
 
 /// A depth-32 sparse Merkle tree capable of producing proofs for arbitrary
 /// elements.

--- a/rust/main/hyperlane-core/src/matching_list.rs
+++ b/rust/main/hyperlane-core/src/matching_list.rs
@@ -3,6 +3,7 @@
 //! ANY CHANGES HERE NEED TO BE REFLECTED IN THE TYPESCRIPT SDK.
 
 use std::{
+    cell::OnceCell,
     fmt,
     fmt::{Debug, Display, Formatter},
     marker::PhantomData,
@@ -280,6 +281,21 @@ pub struct ListElement {
     body_regex: Option<RegexWrapper>,
 }
 
+impl ListElement {
+    fn matches_route(
+        &self,
+        src_domain: u32,
+        src_addr: &H256,
+        dst_domain: u32,
+        dst_addr: &H256,
+    ) -> bool {
+        self.origin_domain.matches(&src_domain)
+            && self.sender_address.matches(src_addr)
+            && self.destination_domain.matches(&dst_domain)
+            && self.recipient_address.matches(dst_addr)
+    }
+}
+
 impl Display for ListElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
@@ -352,7 +368,31 @@ impl MatchingList {
     /// Check if a message matches any of the rules.
     /// - `default`: What to return if the matching list is empty.
     pub fn msg_matches(&self, msg: &HyperlaneMessage, default: bool) -> bool {
-        self.matches(msg.into(), default)
+        let Some(rules) = &self.0 else {
+            return default;
+        };
+        // Most lists filter only addresses/domains. Hash and encode the body only
+        // when a candidate rule needs them, once per matching attempt.
+        let message_id = OnceCell::new();
+        let body = OnceCell::new();
+        rules.iter().any(|rule| {
+            rule.matches_route(msg.origin, &msg.sender, msg.destination, &msg.recipient)
+                && match &rule.message_id {
+                    Filter::Wildcard => true,
+                    Filter::Enumerated(ids) => {
+                        !ids.is_empty() && ids.contains(message_id.get_or_init(|| msg.id()))
+                    }
+                }
+                && rule
+                    .body_regex
+                    .as_ref()
+                    .map(|regex| {
+                        regex
+                            .0
+                            .is_match(body.get_or_init(|| hex::encode(&msg.body)))
+                    })
+                    .unwrap_or(true)
+        })
     }
 
     /// Check if a match info matches any of the rules.
@@ -369,10 +409,12 @@ impl MatchingList {
 fn matches_any_rule<'a>(mut rules: impl Iterator<Item = &'a ListElement>, info: MatchInfo) -> bool {
     rules.any(|rule| {
         rule.message_id.matches(&info.src_msg_id)
-            && rule.origin_domain.matches(&info.src_domain)
-            && rule.sender_address.matches(info.src_addr)
-            && rule.destination_domain.matches(&info.dst_domain)
-            && rule.recipient_address.matches(info.dst_addr)
+            && rule.matches_route(
+                info.src_domain,
+                info.src_addr,
+                info.dst_domain,
+                info.dst_addr,
+            )
             && rule
                 .body_regex
                 .as_ref()
@@ -408,6 +450,66 @@ mod test {
     use crate::{H160, H256};
 
     use super::{Filter::*, MatchInfo, MatchingList};
+
+    #[test]
+    fn message_matching_preserves_eager_results() {
+        let messages: Vec<_> = [vec![], vec![0, 0xab, 0xff], vec![0x42; 4096]]
+            .into_iter()
+            .flat_map(|body| {
+                [0, 1]
+                    .into_iter()
+                    .map(move |origin| crate::HyperlaneMessage {
+                        origin,
+                        destination: 2,
+                        sender: H256::repeat_byte(3),
+                        recipient: H256::repeat_byte(4),
+                        body: body.clone(),
+                        ..Default::default()
+                    })
+            })
+            .collect();
+        let mut lists = vec![MatchingList(None), MatchingList(Some(vec![]))];
+        for config in [
+            r"[{}]",
+            r#"[{"origindomain":1,"destinationdomain":2}]"#,
+            r#"[{"bodyregex":"^00abff$"}]"#,
+            r#"[{"bodyregex":"^$"}]"#,
+            r#"[{"bodyregex":"^0x00abff$"}]"#,
+            r#"[{"bodyregex":"^no$"},{"bodyregex":"^00abff$"}]"#,
+            r#"[{"origindomain":99,"bodyregex":".*"}, {"destinationdomain":2}]"#,
+            r#"[{}, {"bodyregex":".*"}]"#,
+            r#"[{"messageid":[]}]"#,
+        ] {
+            lists.push(serde_json::from_str(config).unwrap());
+        }
+        for field in ["senderaddress", "recipientaddress"] {
+            for address in [H256::repeat_byte(3), H256::repeat_byte(4)] {
+                lists.push(
+                    serde_json::from_value(serde_json::json!([
+                        {field: format!("{address:?}")}
+                    ]))
+                    .unwrap(),
+                );
+            }
+        }
+        lists.push(MatchingList::with_message_id(messages[0].id()));
+        lists.push(MatchingList::with_message_id(messages[3].id()));
+        lists.push(serde_json::from_str(&format!(
+            r#"[{{"messageid":"{:?}","bodyregex":"^no$"}},{{"messageid":"{:?}","bodyregex":"^00abff$"}}]"#,
+            messages[3].id(), messages[3].id(),
+        )).unwrap());
+        for list in lists {
+            for message in &messages {
+                for default in [false, true] {
+                    assert_eq!(
+                        list.msg_matches(message, default),
+                        list.matches(message.into(), default),
+                        "list {list:?}, message {message:?}, default {default}",
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn basic_config() {

--- a/rust/main/hyperlane-core/src/types/message.rs
+++ b/rust/main/hyperlane-core/src/types/message.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
-use sha3::{digest::Update, Digest, Keccak256};
+use sha3::{Digest, Keccak256};
 
 use crate::{
     utils::{fmt_address_for_domain, fmt_domain},
@@ -163,14 +163,67 @@ impl Decode for HyperlaneMessage {
 impl HyperlaneMessage {
     /// Convert the message to a message id
     pub fn id(&self) -> H256 {
-        H256::from_slice(Keccak256::new().chain(self.to_vec()).finalize().as_slice())
+        let mut hasher = Keccak256::new();
+        // The digest writer consumes the canonical encoding without allocating
+        // an intermediate message buffer. Its writes are infallible.
+        self.write_to(&mut hasher)
+            .expect("Writing to Keccak256 cannot fail");
+        H256::from_slice(hasher.finalize().as_slice())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{HyperlaneMessage, RawHyperlaneMessage, HYPERLANE_MESSAGE_PREFIX_LEN};
-    use crate::{Decode, H256};
+    use crate::{Decode, Encode, H256};
+    use sha3::{Digest, Keccak256};
+
+    #[test]
+    fn id_matches_known_message_vector() {
+        // Existing vectors/message.json fixture, with its independently specified ID.
+        let mut sender = [0; 32];
+        sender[12..].fill(0x11);
+        let mut recipient = [0; 32];
+        recipient[12..].fill(0x22);
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce: 0,
+            origin: 1000,
+            sender: sender.into(),
+            destination: 2000,
+            recipient: recipient.into(),
+            body: vec![0x12, 0x34],
+        };
+        let expected = H256::from([
+            0xf8, 0xa6, 0x6f, 0x8a, 0xad, 0xee, 0x75, 0x1d, 0x84, 0x26, 0x16, 0xfe, 0xe0, 0xed,
+            0x14, 0xa3, 0xad, 0x6d, 0xa1, 0xe1, 0x35, 0x64, 0x92, 0x03, 0x64, 0xee, 0x0a, 0xd3,
+            0x5a, 0x02, 0x70, 0x3f,
+        ]);
+        assert_eq!(message.id(), expected);
+    }
+
+    #[test]
+    fn streamed_id_matches_canonical_encoding_at_hash_block_boundaries() {
+        for length in [0, 1, 58, 59, 60, 135, 136, 137, 271, 272, 4096, 65536] {
+            for version in [0, 3, u8::MAX] {
+                for nonce in [0, 1, u32::MAX] {
+                    let message = HyperlaneMessage {
+                        version,
+                        nonce,
+                        origin: nonce.rotate_left(7),
+                        sender: H256::repeat_byte(version),
+                        destination: nonce ^ 0xa5a5_a5a5,
+                        recipient: H256::repeat_byte(!version),
+                        body: (0..length).map(|i| (i % 256) as u8).collect(),
+                    };
+                    let encoded = message.to_vec();
+                    assert_eq!(encoded.len(), HYPERLANE_MESSAGE_PREFIX_LEN + length);
+                    let expected = H256::from_slice(Keccak256::digest(&encoded).as_slice());
+                    assert_eq!(message.id(), expected);
+                }
+            }
+        }
+    }
 
     fn sample_message() -> HyperlaneMessage {
         HyperlaneMessage {

--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -394,6 +394,13 @@ impl PayloadDb for HyperlaneRocksDB {
 }
 
 impl Encode for FullPayload {
+    fn to_vec(&self) -> Vec<u8> {
+        // Database writes need the JSON buffer itself, not a copy through write_to.
+        serde_json::to_vec(self)
+            .map_err(|_| std::io::Error::other("Failed to serialize"))
+            .expect("!alloc")
+    }
+
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
         W: Write,
@@ -447,6 +454,39 @@ mod tests {
 
     fn tmp_db() -> Arc<HyperlaneRocksDB> {
         db_in(&tempfile::tempdir().unwrap())
+    }
+
+    #[test]
+    fn payload_owned_encoding_matches_writer_and_roundtrips() {
+        use crate::payload::{DropReason, RetryReason};
+        use hyperlane_core::{Decode, Encode};
+        for length in [0, 1, 4096, 65536] {
+            for status in [
+                PayloadStatus::ReadyToSubmit,
+                PayloadStatus::Retry(RetryReason::Reorged),
+                PayloadStatus::Dropped(DropReason::FailedSimulation),
+                PayloadStatus::InTransaction(TransactionStatus::Included),
+                PayloadStatus::InTransaction(TransactionStatus::Finalized),
+            ] {
+                let payload = FullPayload {
+                    data: (0..length).map(|i| (i % 256) as u8).collect(),
+                    status,
+                    ..FullPayload::default()
+                };
+                let mut legacy = Vec::new();
+                assert_eq!(payload.write_to(&mut legacy).unwrap(), legacy.len());
+                let encoded = payload.to_vec();
+                assert_eq!(encoded, legacy);
+                assert_eq!(
+                    FullPayload::read_from(&mut encoded.as_slice()).unwrap(),
+                    payload
+                );
+                // Preserve the existing arbitrary-writer contract, including short writes.
+                let mut partial = [0; 1];
+                assert_eq!(payload.write_to(&mut partial.as_mut_slice()).unwrap(), 1);
+                assert_eq!(partial[0], encoded[0]);
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
+++ b/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
@@ -142,6 +142,13 @@ impl TransactionDb for HyperlaneRocksDB {
 }
 
 impl Encode for Transaction {
+    fn to_vec(&self) -> Vec<u8> {
+        // Database writes need the JSON buffer itself, not a copy through write_to.
+        serde_json::to_vec(self)
+            .map_err(|_| std::io::Error::other("Failed to serialize"))
+            .expect("!alloc")
+    }
+
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
         W: Write,
@@ -187,6 +194,38 @@ mod tests {
         let domain = KnownHyperlaneDomain::Arbitrum.into();
 
         (Arc::new(HyperlaneRocksDB::new(&domain, db))) as _
+    }
+
+    #[test]
+    fn transaction_owned_encoding_matches_writer_and_roundtrips() {
+        use crate::transaction::{DropReason, Transaction};
+        use hyperlane_core::{Decode, Encode, H512};
+        for length in [0, 1, 4096, 65536] {
+            for status in [
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Mempool,
+                TransactionStatus::Included,
+                TransactionStatus::Finalized,
+                TransactionStatus::Dropped(DropReason::Other("retry \"quoted\" reason".to_owned())),
+            ] {
+                let mut payload = FullPayload::default();
+                payload.details.metadata = "x".repeat(length);
+                payload.details.success_criteria = Some(vec![0, 255, 1]);
+                let mut tx = dummy_tx(vec![payload], status);
+                tx.tx_hashes = vec![H512::repeat_byte(0x12), H512::repeat_byte(0x34)];
+                tx.submission_attempts = u32::MAX;
+                tx.last_submission_attempt = Some(tx.creation_timestamp);
+                tx.last_status_check = Some(tx.creation_timestamp);
+                let mut legacy = Vec::new();
+                assert_eq!(tx.write_to(&mut legacy).unwrap(), legacy.len());
+                let encoded = tx.to_vec();
+                assert_eq!(encoded, legacy);
+                assert_eq!(Transaction::read_from(&mut encoded.as_slice()).unwrap(), tx);
+                let mut partial = [0; 1];
+                assert_eq!(tx.write_to(&mut partial.as_mut_slice()).unwrap(), 1);
+                assert_eq!(partial[0], encoded[0]);
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -361,7 +361,10 @@ impl FinalityStage {
             {
                 // update payload status in db
                 state
-                    .update_status_for_payloads(&[payload.clone()], PayloadStatus::ReadyToSubmit)
+                    .update_status_for_payloads(
+                        std::slice::from_ref(payload),
+                        PayloadStatus::ReadyToSubmit,
+                    )
                     .await;
                 // cannot remove a record from the db, so
                 // just link the payload to the null tx id

--- a/rust/main/lander/src/transaction/types.rs
+++ b/rust/main/lander/src/transaction/types.rs
@@ -1,7 +1,7 @@
 // TODO: re-enable clippy warnings
 #![allow(dead_code)]
 
-use std::{collections::HashMap, ops::Deref};
+use std::ops::Deref;
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
@@ -109,40 +109,32 @@ impl TransactionStatus {
     pub fn classify_tx_status_from_hash_statuses(
         statuses: Vec<Result<TransactionStatus, LanderError>>,
     ) -> TransactionStatus {
-        let mut status_counts = HashMap::<TransactionStatus, usize>::new();
+        let mut included = false;
+        let mut mempool = false;
+        let mut pending = false;
+        let mut dropped = false;
 
-        // count the occurrences of each successfully queried hash status
-        for status in statuses.iter().flatten() {
-            let entry = status_counts.entry(status.clone()).or_insert(0);
-            *entry = entry.saturating_add(1);
+        // Only category presence matters; counts and cloned drop reasons are unused.
+        for status in statuses.into_iter().flatten() {
+            match status {
+                TransactionStatus::Finalized => return TransactionStatus::Finalized,
+                TransactionStatus::Included => included = true,
+                TransactionStatus::Mempool => mempool = true,
+                TransactionStatus::PendingInclusion => pending = true,
+                TransactionStatus::Dropped(_) => dropped = true,
+            }
         }
 
-        let finalized_count = status_counts
-            .get(&TransactionStatus::Finalized)
-            .unwrap_or(&0);
-        let included_count = status_counts
-            .get(&TransactionStatus::Included)
-            .unwrap_or(&0);
-        let pending_count = status_counts
-            .get(&TransactionStatus::PendingInclusion)
-            .unwrap_or(&0);
-        let mempool_count = status_counts.get(&TransactionStatus::Mempool).unwrap_or(&0);
-        if *finalized_count > 0 {
-            return TransactionStatus::Finalized;
-        } else if *included_count > 0 {
-            return TransactionStatus::Included;
-        } else if *mempool_count > 0 {
-            return TransactionStatus::Mempool;
-        } else if *pending_count > 0 {
-            return TransactionStatus::PendingInclusion;
-        } else if !status_counts.is_empty() {
-            // if the hashmap is not empty, it must mean that the hashes were dropped,
-            // because the hashmap is populated only if the status query was successful
-            return TransactionStatus::Dropped(DropReason::DroppedByChain);
+        if included {
+            TransactionStatus::Included
+        } else if mempool {
+            TransactionStatus::Mempool
+        } else if pending || !dropped {
+            // Empty or entirely failed reads retain the existing pending fallback.
+            TransactionStatus::PendingInclusion
+        } else {
+            TransactionStatus::Dropped(DropReason::DroppedByChain)
         }
-
-        // otherwise, return `PendingInclusion`, assuming the rpc is down temporarily and returns errors
-        TransactionStatus::PendingInclusion
     }
 }
 
@@ -179,6 +171,94 @@ pub enum VmSpecificTxData {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn legacy_classify(statuses: Vec<Result<TransactionStatus, LanderError>>) -> TransactionStatus {
+        let mut status_counts = HashMap::<TransactionStatus, usize>::new();
+
+        // count the occurrences of each successfully queried hash status
+        for status in statuses.iter().flatten() {
+            let entry = status_counts.entry(status.clone()).or_insert(0);
+            *entry = entry.saturating_add(1);
+        }
+
+        let finalized_count = status_counts
+            .get(&TransactionStatus::Finalized)
+            .unwrap_or(&0);
+        let included_count = status_counts
+            .get(&TransactionStatus::Included)
+            .unwrap_or(&0);
+        let pending_count = status_counts
+            .get(&TransactionStatus::PendingInclusion)
+            .unwrap_or(&0);
+        let mempool_count = status_counts.get(&TransactionStatus::Mempool).unwrap_or(&0);
+        if *finalized_count > 0 {
+            return TransactionStatus::Finalized;
+        } else if *included_count > 0 {
+            return TransactionStatus::Included;
+        } else if *mempool_count > 0 {
+            return TransactionStatus::Mempool;
+        } else if *pending_count > 0 {
+            return TransactionStatus::PendingInclusion;
+        } else if !status_counts.is_empty() {
+            // if the hashmap is not empty, it must mean that the hashes were dropped,
+            // because the hashmap is populated only if the status query was successful
+            return TransactionStatus::Dropped(DropReason::DroppedByChain);
+        }
+
+        // otherwise, return `PendingInclusion`, assuming the rpc is down temporarily and returns errors
+        TransactionStatus::PendingInclusion
+    }
+
+    fn classification_input(category: usize) -> Result<TransactionStatus, LanderError> {
+        match category {
+            0 => Err(LanderError::NetworkError("unavailable".to_owned())),
+            1 => Ok(TransactionStatus::PendingInclusion),
+            2 => Ok(TransactionStatus::Mempool),
+            3 => Ok(TransactionStatus::Included),
+            4 => Ok(TransactionStatus::Finalized),
+            5 => Ok(TransactionStatus::Dropped(DropReason::DroppedByChain)),
+            6 => Ok(TransactionStatus::Dropped(DropReason::FailedSimulation)),
+            7 => Ok(TransactionStatus::Dropped(DropReason::Other(
+                "first reason".to_owned(),
+            ))),
+            _ => Ok(TransactionStatus::Dropped(DropReason::Other(
+                "second reason".to_owned(),
+            ))),
+        }
+    }
+
+    #[test]
+    fn classification_matches_legacy_for_all_small_category_sequences() {
+        for length in 0..=4 {
+            for mut sequence in 0..9usize.pow(length) {
+                let categories: Vec<_> = (0..length)
+                    .map(|_| {
+                        let category = sequence % 9;
+                        sequence /= 9;
+                        category
+                    })
+                    .collect();
+                let legacy = legacy_classify(
+                    categories
+                        .iter()
+                        .copied()
+                        .map(classification_input)
+                        .collect(),
+                );
+                let actual = TransactionStatus::classify_tx_status_from_hash_statuses(
+                    categories
+                        .iter()
+                        .copied()
+                        .map(classification_input)
+                        .collect(),
+                );
+                assert_eq!(actual, legacy, "categories: {categories:?}");
+            }
+        }
+    }
+
     #[test]
     fn test_transaction_status_classification_finalized() {
         use super::*;


### PR DESCRIPTION
Consolidated into #9496 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Lander classifies already-fetched transaction-hash statuses on each status check. The previous implementation built a hash map, counted occurrences, and cloned drop-reason strings even though only category presence was used.

## Solution

Replace that map with an owned scan that preserves Finalized > Included > Mempool > Pending > Dropped priority. Empty and entirely failed reads still return Pending; dropped-only inputs still normalize to DroppedByChain. RPC requests and their ordering are unchanged.

## Numerical impact

Measured synthetic allocation counts per classification, using the extracted old/new production functions and actual Lander types:

| Input | Allocation calls before → after | Requested bytes before → after |
| --- | --- | --- |
| One pending status | 1 → 0 | 140 → 0 |
| Four mixed statuses | 2 → 0 | 412 → 0 |
| Four dropped statuses, including two 1 KiB reasons | 4 → 0 | 2,460 → 0 |
| Empty or all errors | 0 → 0 | 0 → 0 |

The measured functions allocate nothing after this change. Input construction is excluded; these are allocator-traffic measurements, not fleet CPU, RSS, latency, or RPC savings.

## Verification

All 7 focused classification tests passed, including 7,381 exhaustive comparisons against the legacy implementation across nine categories and sequence lengths zero through four. Strict production Lander Clippy passed. Self-review and independent review found no issues.
Stack: follows #9496 on the relayer stack.
