### PR TITLE
perf(validator): compact checkpoints queued before signing

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -13,7 +13,7 @@ use hyperlane_core::rpc_clients::call_and_retry_indefinitely;
 use hyperlane_core::{
     accumulator::incremental::IncrementalMerkle, Checkpoint, CheckpointAtBlock,
     CheckpointWithMessageId, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneSignerExt, IncrementalMerkleAtBlock,
+    HyperlaneSignerExt, IncrementalMerkleAtBlock, H256,
 };
 use hyperlane_core::{
     ChainResult, HyperlaneSigner, MerkleTreeHook, ReorgEvent, ReorgPeriod, SignedType,
@@ -24,6 +24,27 @@ use crate::reorg_reporter::ReorgReporter;
 use crate::server::ValidatorReadiness;
 
 const CHECKPOINT_SUBMISSION_CHUNK_INTERVAL: Duration = Duration::from_millis(100);
+
+// All queued checkpoints share the hook address and domain of the final verified
+// checkpoint. Retain only the fields that vary until that correctness gate passes.
+struct QueuedCheckpoint {
+    root: H256,
+    index: u32,
+    message_id: H256,
+}
+
+impl QueuedCheckpoint {
+    fn into_checkpoint(self, verified_checkpoint: Checkpoint) -> CheckpointWithMessageId {
+        CheckpointWithMessageId {
+            checkpoint: Checkpoint {
+                root: self.root,
+                index: self.index,
+                ..verified_checkpoint
+            },
+            message_id: self.message_id,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct ValidatorSubmitter {
@@ -321,10 +342,9 @@ impl ValidatorSubmitter {
             let message_id = insertion.message_id();
             tree.ingest(message_id);
 
-            let checkpoint = self.checkpoint(tree);
-
-            checkpoint_queue.push(CheckpointWithMessageId {
-                checkpoint,
+            checkpoint_queue.push(QueuedCheckpoint {
+                root: tree.root(),
+                index: tree.index(),
                 message_id,
             });
         }
@@ -397,7 +417,12 @@ impl ValidatorSubmitter {
                 queue_len = checkpoint_queue.len(),
                 "Reached tree consistency"
             );
-            self.sign_and_submit_checkpoints(checkpoint_queue).await;
+            self.sign_and_submit_checkpoints(
+                checkpoint_queue
+                    .into_iter()
+                    .map(move |queued| queued.into_checkpoint(checkpoint)),
+            )
+            .await;
 
             info!(
                 index = checkpoint.index,
@@ -528,16 +553,22 @@ impl ValidatorSubmitter {
     }
 
     /// Signs and submits any previously unsubmitted checkpoints.
-    async fn sign_and_submit_checkpoints(&self, mut checkpoints: Vec<CheckpointWithMessageId>) {
-        // The checkpoints are ordered by index, so the last one is the highest index.
-        let mut latest_index_to_publish = match checkpoints.last() {
+    async fn sign_and_submit_checkpoints<I>(&self, checkpoints: I)
+    where
+        I: IntoIterator<Item = CheckpointWithMessageId>,
+        I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+    {
+        // Reconstruct compact queue entries only as their signing chunk is consumed.
+        // The input is ordered by index, so reversing starts with the highest index.
+        let mut checkpoints = checkpoints.into_iter().rev().peekable();
+        let mut latest_index_to_publish = match checkpoints.peek() {
             Some(c) => Some(c.index),
             None => return,
         };
 
         let arc_self = Arc::new(self.clone());
 
-        while !checkpoints.is_empty() {
+        while checkpoints.len() > 0 {
             let start = Instant::now();
 
             // Take a chunk of checkpoints, starting with the highest index.
@@ -548,7 +579,7 @@ impl ValidatorSubmitter {
             // Keep bounded chunks so a storage/signing burst is paced before the next chunk.
             let mut chunk = Vec::with_capacity(self.max_sign_concurrency);
             for _ in 0..self.max_sign_concurrency {
-                if let Some(cp) = checkpoints.pop() {
+                if let Some(cp) = checkpoints.next() {
                     chunk.push(cp);
                 } else {
                     break;
@@ -619,7 +650,7 @@ impl ValidatorSubmitter {
 
             // Pace storage/signing bursts between chunks without delaying the latest-index
             // update, throttling all-existing backfills, or adding a final-chunk tail.
-            if wrote_checkpoint && !checkpoints.is_empty() {
+            if wrote_checkpoint && checkpoints.len() > 0 {
                 sleep(CHECKPOINT_SUBMISSION_CHUNK_INTERVAL).await;
             }
         }

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -133,6 +133,158 @@ fn submission_checkpoint(index: u32) -> CheckpointWithMessageId {
     }
 }
 
+#[test]
+fn compact_checkpoint_queue_entry_layout() {
+    let full = std::mem::size_of::<CheckpointWithMessageId>();
+    let compact = std::mem::size_of::<QueuedCheckpoint>();
+    println!("checkpoint queue logical entry bytes: {full} -> {compact}");
+    assert!(compact < full);
+}
+
+#[tokio::test(start_paused = true)]
+async fn compact_queue_replays_exact_checkpoints_only_after_final_insertion() {
+    let namespace = Checkpoint {
+        root: H256::zero(),
+        merkle_tree_hook_address: H256::from_low_u64_be(123),
+        mailbox_domain: 17,
+        index: 0,
+    };
+    let mut tree = IncrementalMerkle::default();
+    let expected: Vec<_> = (0..5)
+        .map(|index| {
+            let message_id = H256::from_low_u64_be(u64::from(index) + 1);
+            tree.ingest(message_id);
+            CheckpointWithMessageId {
+                checkpoint: Checkpoint {
+                    root: tree.root(),
+                    index,
+                    ..namespace
+                },
+                message_id,
+            }
+        })
+        .collect();
+    let final_read = Arc::new(AtomicBool::new(false));
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .times(5)
+        .returning({
+            let expected = expected.clone();
+            let final_read = Arc::clone(&final_read);
+            move |index| {
+                let index = *index;
+                if index == 4 {
+                    final_read.store(true, Ordering::SeqCst);
+                }
+                Ok(Some(MerkleTreeInsertion::new(
+                    index,
+                    expected[index as usize].message_id,
+                )))
+            }
+        });
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let signer_address = signer.eth_address();
+    let writes = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer.expect_fetch_checkpoint().times(5).returning({
+        let final_read = Arc::clone(&final_read);
+        move |_| {
+            assert!(final_read.load(Ordering::SeqCst));
+            Ok(None)
+        }
+    });
+    syncer.expect_write_checkpoint().times(5).returning({
+        let expected = expected.clone();
+        let writes = Arc::clone(&writes);
+        move |signed| {
+            assert_eq!(signed.value, expected[signed.value.index as usize]);
+            assert_eq!(signed.recover().unwrap(), signer_address);
+            writes.lock().unwrap().push(signed.value.index);
+            Ok(())
+        }
+    });
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(4))
+        .once()
+        .returning(|_| Ok(()));
+    let mut hook = MockMerkleTreeHook::new();
+    hook.expect_address()
+        .return_const(namespace.merkle_tree_hook_address);
+    hook.expect_domain()
+        .return_const(dummy_domain(17, "queue_domain"));
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(hook),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(syncer),
+        Arc::new(db),
+        dummy_metrics(),
+        2,
+        Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
+    );
+    submitter
+        .submit_checkpoints_until_correctness_checkpoint(
+            &mut IncrementalMerkle::default(),
+            &CheckpointAtBlock {
+                checkpoint: expected[4].checkpoint,
+                block_height: Some(1),
+            },
+        )
+        .await;
+    // Each chunk completes before the next starts; sibling completion order is unconstrained.
+    let writes = writes.lock().unwrap();
+    let mut first = writes[..2].to_vec();
+    first.sort_unstable();
+    let mut second = writes[2..4].to_vec();
+    second.sort_unstable();
+    assert_eq!(first, vec![3, 4]);
+    assert_eq!(second, vec![1, 2]);
+    assert_eq!(writes[4], 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn compact_queue_materializes_only_the_active_chunk() {
+    let materialized = Arc::new(AtomicUsize::new(0));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer.expect_fetch_checkpoint().times(2).returning({
+        let attempts = Arc::clone(&attempts);
+        move |_| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err(eyre::eyre!("storage temporarily unavailable"))
+        }
+    });
+    let submitter = submission_test_submitter(syncer, dummy_readiness());
+    let task = tokio::spawn({
+        let materialized = Arc::clone(&materialized);
+        async move {
+            submitter
+                .sign_and_submit_checkpoints((0..100).map(move |index| {
+                    materialized.fetch_add(1, Ordering::SeqCst);
+                    QueuedCheckpoint {
+                        root: H256::zero(),
+                        index,
+                        message_id: H256::zero(),
+                    }
+                    .into_checkpoint(submission_checkpoint(99).checkpoint)
+                }))
+                .await;
+        }
+    });
+    while attempts.load(Ordering::SeqCst) < 2 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(materialized.load(Ordering::SeqCst), 2);
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(materialized.load(Ordering::SeqCst), 2);
+}
+
 #[tokio::test(start_paused = true)]
 async fn latest_index_waits_for_newest_checkpoint_but_not_older_siblings() {
     for failing_index in [7, 8] {


### PR DESCRIPTION
Consolidated into #9471 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Validator bootstrap and tail replay retain every intermediate checkpoint until the final tree matches the authoritative correctness checkpoint. Each queued entry repeats the same 32-byte hook address and 4-byte domain, increasing memory during large replays.

## Solution

Keep only each intermediate root, index and message ID in a private queue. After the unchanged correctness gate succeeds, reconstruct the full checkpoint with the verified hook/domain as each bounded signing chunk is consumed. Preserve newest-first chunking, retries, latest-index ownership, pacing and signature contents.

## Numerical impact

Measured Rust type sizes on the local 64-bit build: **104 → 68 bytes per logical queue entry**, a **34.6% reduction**. For one million retained entries, the code-derived payload is **104 MB → 68 MB**, saving **36 MB** (decimal units). These figures exclude Vec spare capacity, allocator bookkeeping, active signing chunks and the rest of process memory; they are not measured RSS or latency improvements.

Production logs ground the large-replay scenario: a bounded seven-day mainnet3 validator query on 2026-09-05 returned **72 logged queues of at least 100 entries** (limit 100, not reached), with counts **341–2,503,089**; five exceeded one million. All matching events were on 2026-09-03. The largest was an **Arbitrum BackfillCheckpointSubmitter** event at 17:39:05 UTC. For that observed count, the measured layouts imply **260.32 MB → 170.21 MB** of logical queue payload, saving **90.11 MB**. This is a modeled memory saving applied to an observed workload, not a deployed result or measured RSS.

A separate capped sample of the latest 1,000 positive queues contained 920 one-entry queues and none above six entries. The benefit is therefore concentrated in large backfills; ordinary tail queues save only 36–216 logical bytes in that sample. Neither query is a fleet-wide workload distribution.

The lazy reconstruction test materializes only **2 of 100** queued entries while a two-slot signing chunk is blocked, and cancellation leaves the remaining 98 untouched. The backing compact Vec remains retained during submission, as the full Vec did previously.

## Verification and scope

- **82 validator tests passed**, including three new tests: actual entry layout, five-leaf exact checkpoint/signature replay across chunk boundaries, and bounded reconstruction/cancellation.
- Existing mismatch/reorg, duplicate-highest publication and retry/pacing regressions passed. The mismatch fixture allows no checkpoint fetch/write before the gate.
- Commands from `rust/main`: `cargo +1.93.0 test -p validator --locked`; reproduce sizes with `cargo +1.93.0 test -p validator compact_checkpoint_queue_entry_layout --locked -- --nocapture`.
- Production validator strict Clippy passed: `cargo +1.93.0 clippy -p validator --bin validator --no-deps --locked -- -D warnings`. Existing dependency warnings remain outside the scoped package. Normal commit hooks passed, including both Rust workspace formatting checks.
- Root and independent relayer review found no blockers.
- Snapshot #9448 reduces the number of replayed entries; this reduces bytes per remaining entry. Apply the per-entry saving only to the post-snapshot tail and do not add it to snapshot replay elimination. No overlap with checkpoint pooling, indexing or polling changes in the excluded gists.

Stack: follows #9495 (pinned typed RocksDB reads) on the validator stack. No public API, quorum, verification or signing-authority changes.
