### PR TITLE
perf(scraper): project sequence event lookup fields

### DIFF
--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use eyre::{ensure, Result};
 use migration::OnConflict;
 use sea_orm::{
-    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, TransactionTrait,
+    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, QuerySelect,
+    TransactionTrait,
 };
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, MerkleTreeInsertion, H256};
@@ -82,19 +83,26 @@ impl ScraperDb {
         leaf_index: u32,
     ) -> Result<Option<(MerkleTreeInsertion, u64)>> {
         let row = merkle_tree_insertion::Entity::find()
+            .select_only()
+            .columns([
+                merkle_tree_insertion::Column::LeafIndex,
+                merkle_tree_insertion::Column::MessageId,
+                merkle_tree_insertion::Column::BlockNumber,
+            ])
             .filter(merkle_tree_insertion::Column::Domain.eq(domain))
             .filter(
                 merkle_tree_insertion::Column::MerkleTreeHook
                     .eq(address_to_bytes(merkle_tree_hook)),
             )
             .filter(merkle_tree_insertion::Column::LeafIndex.eq(leaf_index))
+            .into_tuple::<(i32, Vec<u8>, i64)>()
             .one(&self.0)
             .await?;
 
-        Ok(row.map(|row| {
+        Ok(row.map(|(leaf_index, message_id, block_number)| {
             (
-                MerkleTreeInsertion::new(row.leaf_index as u32, H256::from_slice(&row.message_id)),
-                row.block_number as u64,
+                MerkleTreeInsertion::new(leaf_index as u32, H256::from_slice(&message_id)),
+                block_number as u64,
             )
         }))
     }

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -4,10 +4,7 @@ use std::collections::HashSet;
 
 use eyre::{ensure, Result};
 use itertools::Itertools;
-use sea_orm::{
-    prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, QueryTrait,
-    TransactionTrait,
-};
+use sea_orm::{prelude::*, ActiveValue::*, Insert, QuerySelect, QueryTrait, TransactionTrait};
 use tracing::{debug, instrument, trace};
 
 use hyperlane_core::{
@@ -64,17 +61,20 @@ impl ScraperDb {
         destination_mailbox: &H256,
         sequence: u32,
     ) -> Result<Option<Delivery>> {
-        if let Some(delivery) = delivered_message::Entity::find()
+        if let Some(msg_id) = delivered_message::Entity::find()
+            .select_only()
+            .column(delivered_message::Column::MsgId)
             .filter(delivered_message::Column::Domain.eq(destination_domain))
             .filter(
                 delivered_message::Column::DestinationMailbox
                     .eq(address_to_bytes(destination_mailbox)),
             )
             .filter(delivered_message::Column::Sequence.eq(sequence))
+            .into_tuple::<Vec<u8>>()
             .one(&self.0)
             .await?
         {
-            let delivery = H256::from_slice(&delivery.msg_id);
+            let delivery = H256::from_slice(&msg_id);
             Ok(Some(delivery))
         } else {
             Ok(None)
@@ -218,26 +218,32 @@ impl ScraperDb {
         origin_mailbox: &H256,
         nonce: u32,
     ) -> Result<Option<HyperlaneMessage>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Nonce,
-        }
-        if let Some(message) = message::Entity::find()
+        if let Some((origin, destination, nonce, sender, recipient, body)) = message::Entity::find()
+            .select_only()
+            .columns([
+                message::Column::Origin,
+                message::Column::Destination,
+                message::Column::Nonce,
+                message::Column::Sender,
+                message::Column::Recipient,
+                message::Column::MsgBody,
+            ])
             .filter(message::Column::Origin.eq(origin_domain))
             .filter(message::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)))
             .filter(message::Column::Nonce.eq(nonce))
+            .into_tuple::<(i32, i32, i32, Vec<u8>, Vec<u8>, Option<Vec<u8>>)>()
             .one(&self.0)
             .await?
         {
             Ok(Some(HyperlaneMessage {
                 // We do not write version to the DB.
                 version: 3,
-                origin: message.origin as u32,
-                destination: message.destination as u32,
-                nonce: message.nonce as u32,
-                sender: bytes_to_address(message.sender)?,
-                recipient: bytes_to_address(message.recipient)?,
-                body: message.msg_body.unwrap_or(Vec::new()),
+                origin: origin as u32,
+                destination: destination as u32,
+                nonce: nonce as u32,
+                sender: bytes_to_address(sender)?,
+                recipient: bytes_to_address(recipient)?,
+                body: body.unwrap_or(Vec::new()),
             }))
         } else {
             Ok(None)

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -71,3 +71,6 @@ mod write_batches;
 
 #[cfg(test)]
 mod lookup_batches;
+
+#[cfg(test)]
+mod sequence_reads;

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -42,21 +42,29 @@ impl ScraperDb {
         interchain_gas_paymaster: &H256,
         sequence: u32,
     ) -> Result<Option<InterchainGasPayment>> {
-        if let Some(payment) = gas_payment::Entity::find()
+        if let Some((msg_id, destination, payment, gas_amount)) = gas_payment::Entity::find()
+            .select_only()
+            .columns([
+                gas_payment::Column::MsgId,
+                gas_payment::Column::Destination,
+                gas_payment::Column::Payment,
+                gas_payment::Column::GasAmount,
+            ])
             .filter(gas_payment::Column::Origin.eq(origin))
             .filter(
                 gas_payment::Column::InterchainGasPaymaster
                     .eq(address_to_bytes(interchain_gas_paymaster)),
             )
             .filter(gas_payment::Column::Sequence.eq(sequence))
+            .into_tuple::<(Vec<u8>, i32, BigDecimal, BigDecimal)>()
             .one(&self.0)
             .await?
         {
             let payment = InterchainGasPayment {
-                message_id: H256::from_slice(&payment.msg_id),
-                destination: payment.destination as u32,
-                payment: decimal_to_u256(payment.payment),
-                gas_amount: decimal_to_u256(payment.gas_amount),
+                message_id: H256::from_slice(&msg_id),
+                destination: destination as u32,
+                payment: decimal_to_u256(payment),
+                gas_amount: decimal_to_u256(gas_amount),
             };
             Ok(Some(payment))
         } else {

--- a/rust/main/agents/scraper/src/db/sequence_reads.rs
+++ b/rust/main/agents/scraper/src/db/sequence_reads.rs
@@ -1,0 +1,106 @@
+//! Sequence lookups select only event reconstruction fields.
+use std::collections::BTreeMap;
+
+use hyperlane_core::H256;
+use sea_orm::{DatabaseBackend, DbErr, MockDatabase, Value};
+
+use super::ScraperDb;
+
+#[tokio::test]
+async fn sequence_readers_project_payload_columns_and_preserve_absence() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<BTreeMap<String, Value>>::new(); 4])
+            .into_connection(),
+    );
+    let address = H256::from_low_u64_be(42);
+    assert!(db
+        .retrieve_delivery_by_sequence(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_dispatched_message_by_nonce(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_payment_by_sequence(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_merkle_tree_insertion(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 4);
+    for (query, (table, columns)) in log.iter().zip([
+        ("delivered_message", &["msg_id"][..]),
+        (
+            "message",
+            &[
+                "origin",
+                "destination",
+                "nonce",
+                "sender",
+                "recipient",
+                "msg_body",
+            ][..],
+        ),
+        (
+            "gas_payment",
+            &["msg_id", "destination", "payment", "gas_amount"][..],
+        ),
+        (
+            "merkle_tree_insertion",
+            &["leaf_index", "message_id", "block_number"][..],
+        ),
+    ]) {
+        assert_eq!(query.statements().len(), 1);
+        let statement = &query.statements()[0];
+        let projection = columns
+            .iter()
+            .map(|column| format!("\"{table}\".\"{column}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        assert!(
+            statement
+                .sql
+                .starts_with(&format!("SELECT {projection} FROM \"{table}\" WHERE ")),
+            "{}",
+            statement.sql
+        );
+        // Three original filter values and the existing LIMIT 1.
+        assert_eq!(statement.values.as_ref().unwrap().0.len(), 4);
+    }
+}
+
+#[tokio::test]
+async fn sequence_readers_propagate_database_errors() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_errors((0..4).map(|_| DbErr::Custom("sequence read failed".into())))
+            .into_connection(),
+    );
+    let address = H256::zero();
+    let errors = [
+        db.retrieve_delivery_by_sequence(1, &address, 7)
+            .await
+            .unwrap_err(),
+        db.retrieve_dispatched_message_by_nonce(1, &address, 7)
+            .await
+            .unwrap_err(),
+        db.retrieve_payment_by_sequence(1, &address, 7)
+            .await
+            .unwrap_err(),
+        db.retrieve_merkle_tree_insertion(1, &address, 7)
+            .await
+            .unwrap_err(),
+    ];
+    for error in errors {
+        assert!(error.to_string().contains("sequence read failed"));
+    }
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -422,6 +422,26 @@ async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()
             .await?,
         0
     );
+    // Projected reads preserve both NULL/empty and nonempty bodies without transaction metadata.
+    for nonce in [0, 3_250] {
+        let mut expected = rows().nth(nonce as usize).unwrap().msg;
+        expected.version = 3; // Message versions are reconstructed, not stored.
+        assert_eq!(
+            db.retrieve_dispatched_message_by_nonce(DOMAIN, &address, nonce)
+                .await?,
+            Some(expected)
+        );
+    }
+    for (domain, mailbox, nonce) in [
+        (DOMAIN, address, 3_251),
+        (DOMAIN + 1, address, 0),
+        (DOMAIN, H256::from_low_u64_be(2), 0),
+    ] {
+        assert!(db
+            .retrieve_dispatched_message_by_nonce(domain, &mailbox, nonce)
+            .await?
+            .is_none());
+    }
     let stored = super::generated::message::Entity::find().all(&db.0).await?;
     assert_eq!(stored.len(), 3_251);
     for row in stored {


### PR DESCRIPTION
Consolidated into #9468 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stacked on #9500; review the child diff.

## Problem

Scraper sequence readers select and decode complete database models although event reconstruction uses only part of each row. This transfers unused IDs, timestamps, scope fields and transaction references on every successful lookup.

## Solution

Select the existing event reconstruction fields directly into SeaORM tuples for dispatches, deliveries, gas payments and Merkle insertions. Keep the same filters, LIMIT 1, casts, address/decimal conversions, nullable body handling and return types. Merkle reads still return the insertion and block height. Missing transaction metadata continues to permit event retrieval.

## Numerical impact

Source-derived selected/decoded column counts per successful lookup:

| Reader | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Delivery | 7 | 1 | 85.7% |
| Dispatch | 11 | 6 | 45.5% |
| Gas payment | 12 | 4 | 66.7% |
| Merkle insertion | 6 | 3 | 50% |

Each lookup still issues one SELECT. These are column counts, not measured wire-byte, latency or total-memory reductions; variable-sized payloads remain unchanged.

## Verification

- Full scraper binary suite: 55 passed, 0 failed, 1 existing ignored test; includes real PostgreSQL payload/replay/rollback tests, NULL transaction metadata and restart reads.
- New SQL projection oracle verifies exact selected columns, absent rows and unchanged parameter counts; database errors propagate.
- Extended PostgreSQL dispatch fixture verifies empty and nonempty bodies, absent nonce and wrong domain/mailbox.
- Existing PostgreSQL Merkle test verifies insertion plus height across insert chunk boundaries and replay.
- Strict scraper production Clippy (`--no-deps -- -D warnings`), formatting and normal commit hooks passed (exit 0).
- Self-review and independent source review found no blockers. No production database writes.
