### PR TITLE
perf(metrics): reuse observed managed-lockbox collateral

### DIFF
--- a/.changeset/fresh-managed-collateral.md
+++ b/.changeset/fresh-managed-collateral.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/metrics': patch
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Reused the collateral address from the current managed-lockbox balance observation when reading token metadata, avoiding a duplicate contract lookup while retaining fresh metadata and standalone lookup behavior.

--- a/typescript/metrics/docs/managed-lockbox-reads.md
+++ b/typescript/metrics/docs/managed-lockbox-reads.md
@@ -1,0 +1,38 @@
+# Managed-lockbox collateral observation
+
+## Problem
+
+Both warp-monitor and rebalancer first read a managed lockbox's collateral balance, then fetch its collateral metadata. The balance helper already returns tokenAddress, but metadata resolution repeated the ERC20() address read.
+
+A bounded production Prometheus query on 2026-09-05 found two hyperlane_warp_route_token_balance series with token_standard="EvmManagedLockbox": one centralized monitor and one oUSDT rebalancer. One-hour log samples contained six monitor and 26 rebalancer successful collateral-balance messages. This establishes a modest active consumer; it is not a deployed performance measurement or a fleet-wide throughput estimate.
+
+## Solution
+
+getManagedLockBoxCollateralInfo accepts an optional collateral address from the current balance observation. Both current callers pass balance.tokenAddress. Standalone callers still read ERC20() afresh. There is no persistent cache.
+
+If the lockbox's ERC20 address changes between the balance and metadata steps, metadata now refers to the token whose balance was actually measured. The next balance sample reads the current address. This is not a block-atomic observation: balance and metadata still use their normal latest-state reads.
+
+All three metadata reads remain: decimals, symbol and name. Their existing failures still reject the sample; removing unused values must not accidentally hide metadata failures.
+
+## Numerical evidence
+
+The real ethers/SDK adapter fixture stubs provider contract calls:
+
+- Before: ERC20 + balanceOf + ERC20 + decimals + symbol + name = 6 calls.
+- After: ERC20 + balanceOf + decimals + symbol + name = 5 calls (16.7% fewer).
+- Standalone metadata: 4 calls, unchanged.
+- Next successful balance/metadata observation: another 5 fresh calls.
+
+Balances, USD values, names and addresses match for unchanged collateral. The fixture covers an intervening collateral-address change, standalone freshness and each metadata failure followed by a fresh retry. Counts exclude price-getter requests and provider transport overhead. No production latency reduction is claimed.
+
+## Validation
+
+29 metrics, 42 warp-monitor and 380 rebalancer tests passed. The dependency/service build passed 20 tasks and all three package lints passed (existing rebalancer expect-expression warnings). Runtime tests use the previously documented ignored core-js compatibility shim required by the locked Provable dependency; no dependency/lockfile changes are included. Self-review and independent review found no blockers.
+
+Reproduce the provider call counts with:
+
+```sh
+pnpm -C typescript/metrics test
+```
+
+See src/managed-lockbox.test.ts. No deployment was performed.

--- a/typescript/metrics/src/balance.ts
+++ b/typescript/metrics/src/balance.ts
@@ -355,20 +355,22 @@ export async function getExtraLockboxBalance(
  * @param multiProvider - The multi-protocol provider
  * @param warpToken - The warp token
  * @param lockBoxAddress - The lockbox contract address
+ * @param knownCollateralTokenAddress - Address from this observation's balance read
  * @returns The token name and address of the collateral
  */
 export async function getManagedLockBoxCollateralInfo(
   multiProvider: MultiProviderAdapter,
   warpToken: Token,
   lockBoxAddress: Address,
+  knownCollateralTokenAddress?: Address,
 ): Promise<{ tokenName: string; tokenAddress: Address }> {
-  const lockBoxInstance = getManagedLockBox(
-    multiProvider,
-    warpToken.chainName,
-    lockBoxAddress,
-  );
-
-  const collateralTokenAddress = await lockBoxInstance['ERC20']();
+  const collateralTokenAddress =
+    knownCollateralTokenAddress ??
+    (await getManagedLockBox(
+      multiProvider,
+      warpToken.chainName,
+      lockBoxAddress,
+    )['ERC20']());
   const collateralTokenAdapter = new EvmTokenAdapter(
     warpToken.chainName,
     multiProvider,

--- a/typescript/metrics/src/managed-lockbox.test.ts
+++ b/typescript/metrics/src/managed-lockbox.test.ts
@@ -1,0 +1,237 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import sinon from 'sinon';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import {
+  getExtraLockboxBalance,
+  getManagedLockBoxCollateralInfo,
+} from './balance.js';
+
+const lockbox = `0x${'12'.repeat(20)}`;
+const collateral = `0x${'34'.repeat(20)}`;
+const nextCollateral = `0x${'56'.repeat(20)}`;
+const abi = new ethers.utils.Interface([
+  'function ERC20() view returns (address)',
+  'function balanceOf(address) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+  'function symbol() view returns (string)',
+  'function name() view returns (string)',
+]);
+const logger = pino({ enabled: false });
+
+function fixture() {
+  const provider = new ethers.providers.StaticJsonRpcProvider(undefined, {
+    chainId: 1,
+    name: 'test',
+  });
+  const multiProvider = new MultiProtocolProvider({
+    test: {
+      name: 'test',
+      chainId: 1,
+      domainId: 1,
+      protocol: ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+    },
+  });
+  sinon.stub(multiProvider, 'getEthersV5Provider').returns(provider);
+  const token = new Token({
+    chainName: 'test',
+    standard: TokenStandard.EvmHypVSXERC20,
+    addressOrDenom: lockbox,
+    decimals: 2,
+    symbol: 'TOKEN',
+    name: 'Token',
+  });
+  let address = collateral;
+  const calls: Array<{ name: string; to: string | undefined }> = [];
+  let failedMethod: string | undefined;
+  const failure = new Error('metadata unavailable');
+  sinon.stub(provider, 'call').callsFake(async (transaction) => {
+    const data = await transaction.data;
+    if (data === undefined) throw new Error('Expected contract calldata');
+    const decoded = abi.parseTransaction({ data: ethers.utils.hexlify(data) });
+    const to = await transaction.to;
+    calls.push({ name: decoded.name, to });
+    if (decoded.name === failedMethod) throw failure;
+    let value: string | number;
+    switch (decoded.name) {
+      case 'ERC20':
+        value = address;
+        break;
+      case 'balanceOf':
+        value = 300;
+        break;
+      case 'decimals':
+        value = 2;
+        break;
+      case 'symbol':
+        value = 'TOKEN';
+        break;
+      case 'name':
+        value =
+          to?.toLowerCase() === nextCollateral
+            ? 'Next collateral'
+            : 'Collateral';
+        break;
+      default:
+        throw new Error(`Unexpected method ${decoded.name}`);
+    }
+    return abi.encodeFunctionResult(decoded.name, [value]);
+  });
+  const priceGetter = { tryGetTokenPrice: async () => 2 };
+  return {
+    multiProvider,
+    token,
+    priceGetter,
+    calls,
+    failure,
+    setAddress: (next: string) => {
+      address = next;
+    },
+    failMethod: (method?: string) => {
+      failedMethod = method;
+    },
+  };
+}
+
+describe('managed-lockbox collateral observation', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('reduces a balance and metadata observation from six reads to five with identical output', async () => {
+    const f = fixture();
+    const beforeBalance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    const beforeMetadata = await getManagedLockBoxCollateralInfo(
+      f.multiProvider,
+      f.token,
+      lockbox,
+    );
+    expect(f.calls).to.have.length(6);
+    f.calls.length = 0;
+    const balance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    if (!balance) throw new Error('Expected balance');
+    const metadata = await getManagedLockBoxCollateralInfo(
+      f.multiProvider,
+      f.token,
+      lockbox,
+      balance.tokenAddress,
+    );
+    expect(balance).to.deep.equal(beforeBalance);
+    expect(metadata).to.deep.equal(beforeMetadata);
+    expect(balance).to.deep.equal({
+      balance: 3,
+      valueUSD: 6,
+      tokenAddress: collateral,
+    });
+    expect(f.calls.map(({ name }) => name)).to.deep.equal([
+      'ERC20',
+      'balanceOf',
+      'decimals',
+      'symbol',
+      'name',
+    ]);
+  });
+
+  it('keeps metadata with the observed balance address and refreshes the next sample', async () => {
+    const f = fixture();
+    const balance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    if (!balance) throw new Error('Expected balance');
+    f.setAddress(nextCollateral);
+    expect(
+      await getManagedLockBoxCollateralInfo(
+        f.multiProvider,
+        f.token,
+        lockbox,
+        balance.tokenAddress,
+      ),
+    ).to.deep.equal({ tokenName: 'Collateral', tokenAddress: collateral });
+    const nextBalance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    if (!nextBalance) throw new Error('Expected next balance');
+    expect(
+      await getManagedLockBoxCollateralInfo(
+        f.multiProvider,
+        f.token,
+        lockbox,
+        nextBalance.tokenAddress,
+      ),
+    ).to.deep.equal({
+      tokenName: 'Next collateral',
+      tokenAddress: nextCollateral,
+    });
+    expect(f.calls).to.have.length(10);
+    f.calls.length = 0;
+    expect(
+      await getManagedLockBoxCollateralInfo(f.multiProvider, f.token, lockbox),
+    ).to.deep.equal({
+      tokenName: 'Next collateral',
+      tokenAddress: nextCollateral,
+    });
+    expect(f.calls.map(({ name }) => name)).to.deep.equal([
+      'ERC20',
+      'decimals',
+      'symbol',
+      'name',
+    ]);
+  });
+
+  for (const method of ['decimals', 'symbol', 'name']) {
+    it(`retains ${method} failure and fresh retry behavior`, async () => {
+      const f = fixture();
+      f.failMethod(method);
+      try {
+        await getManagedLockBoxCollateralInfo(
+          f.multiProvider,
+          f.token,
+          lockbox,
+          collateral,
+        );
+        expect.fail('Expected metadata failure');
+      } catch (error) {
+        expect(error).to.equal(f.failure);
+      }
+      f.failMethod();
+      expect(
+        await getManagedLockBoxCollateralInfo(
+          f.multiProvider,
+          f.token,
+          lockbox,
+          collateral,
+        ),
+      ).to.deep.equal({ tokenName: 'Collateral', tokenAddress: collateral });
+      expect(f.calls).to.have.length(6);
+    });
+  }
+});

--- a/typescript/rebalancer/src/metrics/Metrics.ts
+++ b/typescript/rebalancer/src/metrics/Metrics.ts
@@ -274,6 +274,7 @@ export class Metrics implements IMetrics {
                     this.warpCore.multiProvider,
                     token,
                     lockbox.lockbox,
+                    balance.tokenAddress,
                   );
 
                 updateManagedLockboxBalanceMetrics(

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -608,6 +608,7 @@ async function updateTokenMetrics(
                   warpCore.multiProvider,
                   token,
                   lockbox.lockbox,
+                  balance.tokenAddress,
                 );
 
               updateManagedLockboxBalanceMetrics(


### PR DESCRIPTION
## Problem

Warp-monitor and rebalancer read the managed-lockbox collateral address twice in one balance/metadata observation. Two live balance series and bounded one-hour success logs (6 monitor / 26 rebalancer) establish current consumers, not deployed savings.

## Solution

Pass the collateral address returned by the current balance read into the metadata helper. Standalone metadata callers still resolve it afresh; every next sample reads afresh. All decimals/symbol/name reads and errors remain.

If collateral changes between steps, metadata now describes the token whose balance was observed. Reads remain latest-state calls; no block-atomicity or cross-cycle cache is introduced. Stacked on #9473; shared rebalancer caller is included.

## Performance evidence

Actual ethers/SDK provider fixture: **6 → 5 contract reads (-16.7%)** per successful balance+metadata observation. Balance/USD/name/address outputs match for unchanged collateral. Standalone metadata remains **4 reads**. Counts exclude price-getter and provider transport overhead; no production latency reduction is claimed.

## Validation

- 29 metrics, 42 warp-monitor and 380 rebalancer tests passed.
- Five new real-adapter cases verify call counts, intervening address changes, next-sample/standalone freshness, and every metadata failure/retry.
- 20 dependency/service build tasks passed; all three lints passed (existing rebalancer expect-expression warnings).
- Self-review and independent review found no blockers; patch changeset covers published metrics and rebalancer packages.

Runtime tests use the previously documented ignored core-js compatibility shim for the locked Provable dependency; no dependency/lockfile edits. Reproduction and numerical scope: `typescript/metrics/docs/managed-lockbox-reads.md`. No deployment performed.


---

Superseded by consolidated draft #9504: [perf(metrics): reduce warp monitoring reads and log volume](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9504). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
