### PR TITLE
perf(metrics): reduce warp monitoring reads and log volume

### DIFF
--- a/.changeset/compact-balance-observations.md
+++ b/.changeset/compact-balance-observations.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+Consolidated token balance and USD value into one INFO observation while retaining the separate value event at DEBUG, reducing repeated metric labels in monitor and rebalancer logs.

--- a/.changeset/fresh-managed-collateral.md
+++ b/.changeset/fresh-managed-collateral.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/metrics': patch
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Reused the collateral address from the current managed-lockbox balance observation when reading token metadata, avoiding a duplicate contract lookup while retaining fresh metadata and standalone lookup behavior.

--- a/.changeset/fresh-xerc20-observation.md
+++ b/.changeset/fresh-xerc20-observation.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+Resolved the xERC20 address once per limit observation instead of repeating the same read for each limit and label. Preserved fresh address and limit reads on every monitoring cycle.

--- a/.changeset/quiet-derived-risk-logs.md
+++ b/.changeset/quiet-derived-risk-logs.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+Moved per-chain value-at-risk success logs to debug level to reduce repeated log serialization and ingestion in warp monitors and rebalancers. Retained per-token balance/value observations at info level and preserved all metric series.

--- a/typescript/metrics/docs/balance-log-volume.md
+++ b/typescript/metrics/docs/balance-log-volume.md
@@ -1,0 +1,46 @@
+# Token balance observation logs
+
+The shared token balance updater now includes available USD value in the existing
+`Wallet balance updated for token` INFO event. The separate value event remains
+at DEBUG. Zero USD remains present; nullish values are omitted. All gauge updates,
+the balance event's placement, and failure propagation remain unchanged. Queries
+for the separate INFO value message should use the balance message's `valueUSD`
+field instead. No repository alert rule was found using the old message; external
+log queries were not audited.
+
+A bounded read-only last-hour sample from 15 mainnet pods (14 rebalancers and the
+central monitor), capped at 15,000 lines per pod with no cap reached, contained
+4,688 balance events and 2,778 value events. Consolidation would remove 2,778 of
+7,466 events (37.2%) while retaining every balance observation. A separately
+sampled private-agents Moonpay pod is excluded from this estimate.
+
+The value events occupied 1,835,423 raw JSON line bytes. This is not the net saving:
+each priced balance event gains a USD field. With a synthetic USD value of
+12.345678901234567, Pino adds 30 bytes per balance record; applying that assumption
+to the observed event count gives a modeled net reduction of 1,752,083 bytes in
+the sampled hour. Actual USD number lengths vary. This is neither a deployed
+measurement nor a compressed storage, CPU, or billing claim.
+
+Reproduce the byte fixture from `typescript/metrics`:
+
+```sh
+node --input-type=module <<'JS'
+import { pino } from 'pino';
+const records = [];
+const logger = pino({ level: 'info', timestamp: false, base: null }, {
+  write: (record) => records.push(record),
+});
+const labels = {
+  chain_name: 'ethereum', token_name: 'Token', warp_route_id: 'TEST/metric-logging',
+};
+logger.info({ labels, balance: 3 }, 'Wallet balance updated for token');
+logger.info({ labels, valueUSD: 12.345678901234567 }, 'Wallet value updated for token');
+logger.info({ labels, balance: 3, valueUSD: 12.345678901234567 }, 'Wallet balance updated for token');
+console.log(records.map((record) => Buffer.byteLength(record)));
+// [160, 176, 190]: old pair 336 bytes, consolidated record 190 bytes.
+JS
+```
+
+`pnpm test` covers actual Pino INFO/DEBUG output, zero and missing prices, and
+identical Prometheus output across log levels. The 20-chain priced fixture emits
+one INFO event (previously two) and retains all 22 DEBUG-level events.

--- a/typescript/metrics/docs/managed-lockbox-reads.md
+++ b/typescript/metrics/docs/managed-lockbox-reads.md
@@ -1,0 +1,38 @@
+# Managed-lockbox collateral observation
+
+## Problem
+
+Both warp-monitor and rebalancer first read a managed lockbox's collateral balance, then fetch its collateral metadata. The balance helper already returns tokenAddress, but metadata resolution repeated the ERC20() address read.
+
+A bounded production Prometheus query on 2026-09-05 found two hyperlane_warp_route_token_balance series with token_standard="EvmManagedLockbox": one centralized monitor and one oUSDT rebalancer. One-hour log samples contained six monitor and 26 rebalancer successful collateral-balance messages. This establishes a modest active consumer; it is not a deployed performance measurement or a fleet-wide throughput estimate.
+
+## Solution
+
+getManagedLockBoxCollateralInfo accepts an optional collateral address from the current balance observation. Both current callers pass balance.tokenAddress. Standalone callers still read ERC20() afresh. There is no persistent cache.
+
+If the lockbox's ERC20 address changes between the balance and metadata steps, metadata now refers to the token whose balance was actually measured. The next balance sample reads the current address. This is not a block-atomic observation: balance and metadata still use their normal latest-state reads.
+
+All three metadata reads remain: decimals, symbol and name. Their existing failures still reject the sample; removing unused values must not accidentally hide metadata failures.
+
+## Numerical evidence
+
+The real ethers/SDK adapter fixture stubs provider contract calls:
+
+- Before: ERC20 + balanceOf + ERC20 + decimals + symbol + name = 6 calls.
+- After: ERC20 + balanceOf + decimals + symbol + name = 5 calls (16.7% fewer).
+- Standalone metadata: 4 calls, unchanged.
+- Next successful balance/metadata observation: another 5 fresh calls.
+
+Balances, USD values, names and addresses match for unchanged collateral. The fixture covers an intervening collateral-address change, standalone freshness and each metadata failure followed by a fresh retry. Counts exclude price-getter requests and provider transport overhead. No production latency reduction is claimed.
+
+## Validation
+
+29 metrics, 42 warp-monitor and 380 rebalancer tests passed. The dependency/service build passed 20 tasks and all three package lints passed (existing rebalancer expect-expression warnings). Runtime tests use the previously documented ignored core-js compatibility shim required by the locked Provable dependency; no dependency/lockfile changes are included. Self-review and independent review found no blockers.
+
+Reproduce the provider call counts with:
+
+```sh
+pnpm -C typescript/metrics test
+```
+
+See src/managed-lockbox.test.ts. No deployment was performed.

--- a/typescript/metrics/src/balance.test.ts
+++ b/typescript/metrics/src/balance.test.ts
@@ -1,0 +1,179 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import sinon from 'sinon';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { getXERC20Info } from './balance.js';
+
+const abi = new ethers.utils.Interface([
+  'function wrappedToken() view returns (address)',
+  'function xERC20() view returns (address)',
+  'function mintingCurrentLimitOf(address) view returns (uint256)',
+  'function mintingMaxLimitOf(address) view returns (uint256)',
+  'function burningCurrentLimitOf(address) view returns (uint256)',
+  'function burningMaxLimitOf(address) view returns (uint256)',
+]);
+const router = `0x${'12'.repeat(20)}`;
+const underlying = `0x${'34'.repeat(20)}`;
+const updatedUnderlying = `0x${'56'.repeat(20)}`;
+
+function fixture(standard: TokenStandard) {
+  const provider = new ethers.providers.StaticJsonRpcProvider(undefined, {
+    chainId: 1,
+    name: 'test',
+  });
+  const multiProvider = new MultiProtocolProvider<{ mailbox?: string }>({
+    test: {
+      name: 'test',
+      chainId: 1,
+      domainId: 1,
+      protocol: standard.startsWith('Tron')
+        ? ProtocolType.Tron
+        : ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+    },
+  });
+  sinon.stub(multiProvider, 'getEthersV5Provider').returns(provider);
+  const token = new Token({
+    chainName: 'test',
+    standard,
+    addressOrDenom: router,
+    decimals: 2,
+    symbol: 'TOKEN',
+    name: 'Token',
+  });
+  const amounts: Record<string, number> = {
+    mintingCurrentLimitOf: 100,
+    mintingMaxLimitOf: 200,
+    burningCurrentLimitOf: 300,
+    burningMaxLimitOf: 400,
+  };
+  let address = underlying;
+  const calls: Array<{
+    method: string;
+    to: string | undefined;
+    bridge?: string;
+  }> = [];
+  const call = sinon.stub(provider, 'call').callsFake(async (transaction) => {
+    const decoded = abi.parseTransaction({
+      data: ethers.utils.hexlify((await transaction.data)!),
+    });
+    const to = await transaction.to;
+    calls.push({ method: decoded.name, to, bridge: decoded.args[0] });
+    const value =
+      decoded.name === 'wrappedToken' || decoded.name === 'xERC20'
+        ? address
+        : amounts[decoded.name];
+    return abi.encodeFunctionResult(decoded.name, [value]);
+  });
+  return {
+    token,
+    warpCore: new WarpCore(multiProvider, [token]),
+    call,
+    calls,
+    amounts,
+    setAddress: (value: string) => {
+      address = value;
+    },
+  };
+}
+
+describe('xERC20 metric acquisition', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  for (const standard of [
+    TokenStandard.EvmHypXERC20,
+    TokenStandard.EvmHypVSXERC20,
+    TokenStandard.EvmHypXERC20Lockbox,
+    TokenStandard.EvmHypVSXERC20Lockbox,
+    TokenStandard.TronHypXERC20,
+    TokenStandard.TronHypVSXERC20,
+    TokenStandard.TronHypXERC20Lockbox,
+    TokenStandard.TronHypVSXERC20Lockbox,
+  ]) {
+    it(`resolves one underlying address and reads all four current limits for ${standard}`, async () => {
+      const { warpCore, token, calls } = fixture(standard);
+      const result = await getXERC20Info(warpCore, token);
+      expect(result).to.deep.equal({
+        xERC20Address: underlying,
+        limits: { mint: 1, mintMax: 2, burn: 3, burnMax: 4 },
+      });
+      expect(calls).to.have.length(5);
+      expect(
+        calls.filter(
+          ({ method }) => method === 'wrappedToken' || method === 'xERC20',
+        ),
+      ).to.have.length(1);
+      const limitCalls = calls.filter(({ bridge }) => bridge !== undefined);
+      expect(limitCalls).to.have.length(4);
+      expect(
+        limitCalls.every(
+          ({ to, bridge }) =>
+            to?.toLowerCase() === underlying &&
+            bridge?.toLowerCase() === router,
+        ),
+      ).to.equal(true);
+    });
+  }
+
+  it('refreshes the address and every limit on each observation', async () => {
+    const { warpCore, token, calls, amounts, setAddress } = fixture(
+      TokenStandard.EvmHypXERC20,
+    );
+    await getXERC20Info(warpCore, token);
+    setAddress(updatedUnderlying);
+    amounts['mintingCurrentLimitOf'] = 500;
+    const result = await getXERC20Info(warpCore, token);
+    expect(result.xERC20Address).to.equal(updatedUnderlying);
+    expect(result.limits.mint).to.equal(5);
+    expect(calls).to.have.length(10);
+    expect(
+      calls.slice(6).every(({ to }) => to?.toLowerCase() === updatedUnderlying),
+    ).to.equal(true);
+  });
+
+  it('rejects a failed limit sample without substituting partial or cached values', async () => {
+    const { warpCore, token, call } = fixture(TokenStandard.EvmHypXERC20);
+    const failure = new Error('limit unavailable');
+    call.onCall(2).rejects(failure);
+    try {
+      await getXERC20Info(warpCore, token);
+      expect.fail('Expected limit failure');
+    } catch (error) {
+      expect(error).to.equal(failure);
+    }
+    expect((await getXERC20Info(warpCore, token)).limits).to.deep.equal({
+      mint: 1,
+      mintMax: 2,
+      burn: 3,
+      burnMax: 4,
+    });
+    expect(call.callCount).to.equal(10);
+  });
+
+  it('propagates read failures and retries fresh on the next observation', async () => {
+    const { warpCore, token, call } = fixture(
+      TokenStandard.EvmHypXERC20Lockbox,
+    );
+    const failure = new Error('RPC unavailable');
+    call.onCall(0).rejects(failure);
+    try {
+      await getXERC20Info(warpCore, token);
+      expect.fail('Expected read failure');
+    } catch (error) {
+      expect(error).to.equal(failure);
+    }
+    expect((await getXERC20Info(warpCore, token)).limits.mint).to.equal(1);
+    expect(call.callCount).to.equal(6);
+  });
+});

--- a/typescript/metrics/src/balance.ts
+++ b/typescript/metrics/src/balance.ts
@@ -355,20 +355,22 @@ export async function getExtraLockboxBalance(
  * @param multiProvider - The multi-protocol provider
  * @param warpToken - The warp token
  * @param lockBoxAddress - The lockbox contract address
+ * @param knownCollateralTokenAddress - Address from this observation's balance read
  * @returns The token name and address of the collateral
  */
 export async function getManagedLockBoxCollateralInfo(
   multiProvider: MultiProviderAdapter,
   warpToken: Token,
   lockBoxAddress: Address,
+  knownCollateralTokenAddress?: Address,
 ): Promise<{ tokenName: string; tokenAddress: Address }> {
-  const lockBoxInstance = getManagedLockBox(
-    multiProvider,
-    warpToken.chainName,
-    lockBoxAddress,
-  );
-
-  const collateralTokenAddress = await lockBoxInstance['ERC20']();
+  const collateralTokenAddress =
+    knownCollateralTokenAddress ??
+    (await getManagedLockBox(
+      multiProvider,
+      warpToken.chainName,
+      lockBoxAddress,
+    )['ERC20']());
   const collateralTokenAdapter = new EvmTokenAdapter(
     warpToken.chainName,
     multiProvider,

--- a/typescript/metrics/src/balance.ts
+++ b/typescript/metrics/src/balance.ts
@@ -163,28 +163,34 @@ export async function getXERC20Info(
   if (
     token.standard === TokenStandard.EvmHypXERC20 ||
     token.standard === TokenStandard.EvmHypVSXERC20 ||
-    token.standard == TokenStandard.TronHypVSXERC20 ||
-    token.standard == TokenStandard.TronHypXERC20
-  ) {
-    const adapter = token.getAdapter(
-      warpCore.multiProvider,
-    ) as EvmHypXERC20Adapter;
-    return {
-      limits: await getXERC20Limit(token, adapter),
-      xERC20Address: (await adapter.getXERC20()).address,
-    };
-  } else if (
+    token.standard === TokenStandard.TronHypVSXERC20 ||
+    token.standard === TokenStandard.TronHypXERC20 ||
     token.standard === TokenStandard.EvmHypXERC20Lockbox ||
     token.standard === TokenStandard.EvmHypVSXERC20Lockbox ||
     token.standard === TokenStandard.TronHypXERC20Lockbox ||
     token.standard === TokenStandard.TronHypVSXERC20Lockbox
   ) {
-    const adapter = token.getAdapter(
-      warpCore.multiProvider,
-    ) as EvmHypXERC20LockboxAdapter;
+    const adapter = token.getAdapter(warpCore.multiProvider) as
+      | EvmHypXERC20Adapter
+      | EvmHypXERC20LockboxAdapter;
+    // Resolve once for this observation; each adapter limit method would
+    // otherwise independently read the same wrapped-token address again.
+    const xerc20 = await adapter.getXERC20();
+    const bridgeAddress = adapter.contract.address;
+    const [mintCurrent, mintMax, burnCurrent, burnMax] = await Promise.all([
+      xerc20.mintingCurrentLimitOf(bridgeAddress),
+      xerc20.mintingMaxLimitOf(bridgeAddress),
+      xerc20.burningCurrentLimitOf(bridgeAddress),
+      xerc20.burningMaxLimitOf(bridgeAddress),
+    ]);
     return {
-      limits: await getXERC20Limit(token, adapter),
-      xERC20Address: (await adapter.getXERC20()).address,
+      limits: {
+        mint: formatBigInt(token, mintCurrent.toBigInt()),
+        mintMax: formatBigInt(token, mintMax.toBigInt()),
+        burn: formatBigInt(token, burnCurrent.toBigInt()),
+        burnMax: formatBigInt(token, burnMax.toBigInt()),
+      },
+      xERC20Address: xerc20.address,
     };
   }
 

--- a/typescript/metrics/src/managed-lockbox.test.ts
+++ b/typescript/metrics/src/managed-lockbox.test.ts
@@ -1,0 +1,237 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import sinon from 'sinon';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import {
+  getExtraLockboxBalance,
+  getManagedLockBoxCollateralInfo,
+} from './balance.js';
+
+const lockbox = `0x${'12'.repeat(20)}`;
+const collateral = `0x${'34'.repeat(20)}`;
+const nextCollateral = `0x${'56'.repeat(20)}`;
+const abi = new ethers.utils.Interface([
+  'function ERC20() view returns (address)',
+  'function balanceOf(address) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+  'function symbol() view returns (string)',
+  'function name() view returns (string)',
+]);
+const logger = pino({ enabled: false });
+
+function fixture() {
+  const provider = new ethers.providers.StaticJsonRpcProvider(undefined, {
+    chainId: 1,
+    name: 'test',
+  });
+  const multiProvider = new MultiProtocolProvider({
+    test: {
+      name: 'test',
+      chainId: 1,
+      domainId: 1,
+      protocol: ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+    },
+  });
+  sinon.stub(multiProvider, 'getEthersV5Provider').returns(provider);
+  const token = new Token({
+    chainName: 'test',
+    standard: TokenStandard.EvmHypVSXERC20,
+    addressOrDenom: lockbox,
+    decimals: 2,
+    symbol: 'TOKEN',
+    name: 'Token',
+  });
+  let address = collateral;
+  const calls: Array<{ name: string; to: string | undefined }> = [];
+  let failedMethod: string | undefined;
+  const failure = new Error('metadata unavailable');
+  sinon.stub(provider, 'call').callsFake(async (transaction) => {
+    const data = await transaction.data;
+    if (data === undefined) throw new Error('Expected contract calldata');
+    const decoded = abi.parseTransaction({ data: ethers.utils.hexlify(data) });
+    const to = await transaction.to;
+    calls.push({ name: decoded.name, to });
+    if (decoded.name === failedMethod) throw failure;
+    let value: string | number;
+    switch (decoded.name) {
+      case 'ERC20':
+        value = address;
+        break;
+      case 'balanceOf':
+        value = 300;
+        break;
+      case 'decimals':
+        value = 2;
+        break;
+      case 'symbol':
+        value = 'TOKEN';
+        break;
+      case 'name':
+        value =
+          to?.toLowerCase() === nextCollateral
+            ? 'Next collateral'
+            : 'Collateral';
+        break;
+      default:
+        throw new Error(`Unexpected method ${decoded.name}`);
+    }
+    return abi.encodeFunctionResult(decoded.name, [value]);
+  });
+  const priceGetter = { tryGetTokenPrice: async () => 2 };
+  return {
+    multiProvider,
+    token,
+    priceGetter,
+    calls,
+    failure,
+    setAddress: (next: string) => {
+      address = next;
+    },
+    failMethod: (method?: string) => {
+      failedMethod = method;
+    },
+  };
+}
+
+describe('managed-lockbox collateral observation', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('reduces a balance and metadata observation from six reads to five with identical output', async () => {
+    const f = fixture();
+    const beforeBalance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    const beforeMetadata = await getManagedLockBoxCollateralInfo(
+      f.multiProvider,
+      f.token,
+      lockbox,
+    );
+    expect(f.calls).to.have.length(6);
+    f.calls.length = 0;
+    const balance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    if (!balance) throw new Error('Expected balance');
+    const metadata = await getManagedLockBoxCollateralInfo(
+      f.multiProvider,
+      f.token,
+      lockbox,
+      balance.tokenAddress,
+    );
+    expect(balance).to.deep.equal(beforeBalance);
+    expect(metadata).to.deep.equal(beforeMetadata);
+    expect(balance).to.deep.equal({
+      balance: 3,
+      valueUSD: 6,
+      tokenAddress: collateral,
+    });
+    expect(f.calls.map(({ name }) => name)).to.deep.equal([
+      'ERC20',
+      'balanceOf',
+      'decimals',
+      'symbol',
+      'name',
+    ]);
+  });
+
+  it('keeps metadata with the observed balance address and refreshes the next sample', async () => {
+    const f = fixture();
+    const balance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    if (!balance) throw new Error('Expected balance');
+    f.setAddress(nextCollateral);
+    expect(
+      await getManagedLockBoxCollateralInfo(
+        f.multiProvider,
+        f.token,
+        lockbox,
+        balance.tokenAddress,
+      ),
+    ).to.deep.equal({ tokenName: 'Collateral', tokenAddress: collateral });
+    const nextBalance = await getExtraLockboxBalance(
+      f.multiProvider,
+      f.token,
+      f.priceGetter,
+      lockbox,
+      logger,
+    );
+    if (!nextBalance) throw new Error('Expected next balance');
+    expect(
+      await getManagedLockBoxCollateralInfo(
+        f.multiProvider,
+        f.token,
+        lockbox,
+        nextBalance.tokenAddress,
+      ),
+    ).to.deep.equal({
+      tokenName: 'Next collateral',
+      tokenAddress: nextCollateral,
+    });
+    expect(f.calls).to.have.length(10);
+    f.calls.length = 0;
+    expect(
+      await getManagedLockBoxCollateralInfo(f.multiProvider, f.token, lockbox),
+    ).to.deep.equal({
+      tokenName: 'Next collateral',
+      tokenAddress: nextCollateral,
+    });
+    expect(f.calls.map(({ name }) => name)).to.deep.equal([
+      'ERC20',
+      'decimals',
+      'symbol',
+      'name',
+    ]);
+  });
+
+  for (const method of ['decimals', 'symbol', 'name']) {
+    it(`retains ${method} failure and fresh retry behavior`, async () => {
+      const f = fixture();
+      f.failMethod(method);
+      try {
+        await getManagedLockBoxCollateralInfo(
+          f.multiProvider,
+          f.token,
+          lockbox,
+          collateral,
+        );
+        expect.fail('Expected metadata failure');
+      } catch (error) {
+        expect(error).to.equal(f.failure);
+      }
+      f.failMethod();
+      expect(
+        await getManagedLockBoxCollateralInfo(
+          f.multiProvider,
+          f.token,
+          lockbox,
+          collateral,
+        ),
+      ).to.deep.equal({ tokenName: 'Collateral', tokenAddress: collateral });
+      expect(f.calls).to.have.length(6);
+    });
+  }
+});

--- a/typescript/metrics/src/update.test.ts
+++ b/typescript/metrics/src/update.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import { Registry } from 'prom-client';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+
+import { createWarpMetricsGauges } from './gauges.js';
+import { updateTokenBalanceMetrics } from './update.js';
+
+function collect(level: string, valueUSD: number | undefined) {
+  const registry = new Registry();
+  const records: string[] = [];
+  const logger = pino(
+    { level },
+    {
+      write: (record: string) => {
+        records.push(record);
+      },
+    },
+  );
+  const tokens = Array.from(
+    { length: 20 },
+    (_, index) =>
+      new Token({
+        chainName: `chain${index}`,
+        standard: TokenStandard.EvmHypCollateral,
+        addressOrDenom: `0x${String(index + 1).padStart(40, '0')}`,
+        decimals: 18,
+        symbol: 'TOKEN',
+        name: 'Token',
+      }),
+  );
+  const warpCore = new WarpCore(new MultiProtocolProvider({}), tokens);
+  updateTokenBalanceMetrics(
+    createWarpMetricsGauges(registry),
+    warpCore,
+    tokens[0]!,
+    { balance: 3, valueUSD, tokenAddress: tokens[0]!.addressOrDenom },
+    'TEST/metric-logging',
+    logger,
+  );
+  return { registry, records };
+}
+
+describe('value-at-risk log volume', () => {
+  it('retains every metric while emitting only per-token observations at info', async () => {
+    const info = collect('info', 12);
+    const debug = collect('debug', 12);
+    expect(info.records).to.have.length(2);
+    expect(debug.records).to.have.length(22);
+    expect(info.records[0]).to.include('Wallet balance updated for token');
+    expect(info.records[1]).to.include('Wallet value updated for token');
+    expect(
+      debug.records.filter((record) => record.includes('Value at risk on ')),
+    ).to.have.length(20);
+    expect(await info.registry.metrics()).to.equal(
+      await debug.registry.metrics(),
+    );
+    const values = (
+      await info.registry
+        .getSingleMetric('hyperlane_warp_route_value_at_risk')!
+        .get()
+    ).values;
+    expect(values).to.have.length(20);
+    expect(values.every(({ value }) => value === 12)).to.equal(true);
+  });
+
+  it('preserves zero USD values and the balance-only path without a price', async () => {
+    const zero = collect('info', 0);
+    const missing = collect('info', undefined);
+    expect(zero.records).to.have.length(2);
+    const zeroValues = (
+      await zero.registry
+        .getSingleMetric('hyperlane_warp_route_value_at_risk')!
+        .get()
+    ).values;
+    expect(zeroValues.every(({ value }) => value === 0)).to.equal(true);
+    expect(missing.records).to.have.length(1);
+    const missingValues = (
+      await missing.registry
+        .getSingleMetric('hyperlane_warp_route_value_at_risk')!
+        .get()
+    ).values;
+    expect(missingValues).to.have.length(0);
+  });
+});

--- a/typescript/metrics/src/update.test.ts
+++ b/typescript/metrics/src/update.test.ts
@@ -47,14 +47,19 @@ function collect(level: string, valueUSD: number | undefined) {
   return { registry, records };
 }
 
-describe('value-at-risk log volume', () => {
+describe('token balance log volume', () => {
   it('retains every metric while emitting only per-token observations at info', async () => {
     const info = collect('info', 12);
     const debug = collect('debug', 12);
-    expect(info.records).to.have.length(2);
+    expect(info.records).to.have.length(1);
     expect(debug.records).to.have.length(22);
     expect(info.records[0]).to.include('Wallet balance updated for token');
-    expect(info.records[1]).to.include('Wallet value updated for token');
+    const observation = JSON.parse(info.records[0]!);
+    expect(observation).to.include({ balance: 3, valueUSD: 12 });
+    expect(observation.labels).to.deep.equal(
+      JSON.parse(debug.records[1]!).labels,
+    );
+    expect(debug.records[1]).to.include('Wallet value updated for token');
     expect(
       debug.records.filter((record) => record.includes('Value at risk on ')),
     ).to.have.length(20);
@@ -73,7 +78,11 @@ describe('value-at-risk log volume', () => {
   it('preserves zero USD values and the balance-only path without a price', async () => {
     const zero = collect('info', 0);
     const missing = collect('info', undefined);
-    expect(zero.records).to.have.length(2);
+    expect(zero.records).to.have.length(1);
+    expect(JSON.parse(zero.records[0]!)).to.include({
+      balance: 3,
+      valueUSD: 0,
+    });
     const zeroValues = (
       await zero.registry
         .getSingleMetric('hyperlane_warp_route_value_at_risk')!
@@ -81,6 +90,7 @@ describe('value-at-risk log volume', () => {
     ).values;
     expect(zeroValues.every(({ value }) => value === 0)).to.equal(true);
     expect(missing.records).to.have.length(1);
+    expect(JSON.parse(missing.records[0]!)).not.to.have.property('valueUSD');
     const missingValues = (
       await missing.registry
         .getSingleMetric('hyperlane_warp_route_value_at_risk')!

--- a/typescript/metrics/src/update.ts
+++ b/typescript/metrics/src/update.ts
@@ -93,7 +93,9 @@ export function updateTokenBalanceMetrics(
       gauges.warpRouteValueAtRisk
         .labels({ ...labels })
         .set(balanceInfo.valueUSD);
-      logger.info(
+      // The per-token value above already records this observation at info.
+      // Per-chain copies are derived metric detail and can dominate fleet logs.
+      logger.debug(
         {
           labels,
           valueUSD: balanceInfo.valueUSD,

--- a/typescript/metrics/src/update.ts
+++ b/typescript/metrics/src/update.ts
@@ -63,6 +63,9 @@ export function updateTokenBalanceMetrics(
     {
       labels: metrics,
       balance: balanceInfo.balance,
+      ...(!isNullish(balanceInfo.valueUSD)
+        ? { valueUSD: balanceInfo.valueUSD }
+        : {}),
     },
     'Wallet balance updated for token',
   );
@@ -72,7 +75,7 @@ export function updateTokenBalanceMetrics(
     gauges.warpRouteCollateralValue
       .labels({ ...metrics })
       .set(balanceInfo.valueUSD);
-    logger.info(
+    logger.debug(
       {
         labels: metrics,
         valueUSD: balanceInfo.valueUSD,

--- a/typescript/rebalancer/src/metrics/Metrics.ts
+++ b/typescript/rebalancer/src/metrics/Metrics.ts
@@ -274,6 +274,7 @@ export class Metrics implements IMetrics {
                     this.warpCore.multiProvider,
                     token,
                     lockbox.lockbox,
+                    balance.tokenAddress,
                   );
 
                 updateManagedLockboxBalanceMetrics(

--- a/typescript/warp-monitor/src/monitor-efficiency.test.ts
+++ b/typescript/warp-monitor/src/monitor-efficiency.test.ts
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { ExplorerPendingTransfersClient } from './explorer.js';
+import {
+  metricsRegister,
+  resetInventoryBalanceMetrics,
+  resetPendingDestinationMetrics,
+} from './metrics.js';
+import {
+  collectCoinGeckoIds,
+  runRouteCycle,
+  type RouteRuntime,
+  type SharedMonitorContext,
+} from './monitor.js';
+import { getLogger } from './utils.js';
+
+function fixture() {
+  const provider = new MultiProtocolProvider<{ mailbox?: string }>({
+    ethereum: {
+      name: 'ethereum',
+      chainId: 1,
+      domainId: 1,
+      protocol: ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+    },
+  });
+  const tokens = [
+    TokenStandard.EvmHypCollateral,
+    TokenStandard.EvmHypSynthetic,
+  ].map(
+    (standard, index) =>
+      new Token({
+        chainName: 'ethereum',
+        standard,
+        addressOrDenom: `0x${String(index + 1).padStart(40, '0')}`,
+        decimals: 0,
+        symbol: `TOKEN${index}`,
+        name: `Token ${index}`,
+        coinGeckoId: `price-${index}`,
+      }),
+  );
+  const supplyReads = tokens.map((token) => {
+    const adapter = token.getHypAdapter(provider);
+    sinon.stub(token, 'getHypAdapter').returns(adapter);
+    return sinon.stub(adapter, 'getBridgedSupply').resolves(3n);
+  });
+  const inventoryReads = tokens.map((token) => {
+    const adapter = token.getAdapter(provider);
+    sinon.stub(token, 'getAdapter').returns(adapter);
+    return sinon.stub(adapter, 'getBalance').resolves(7n);
+  });
+  const routerNodes = tokens.map((token) => ({
+    nodeId: `${token.symbol}|${token.chainName}|${token.addressOrDenom}`,
+    chainName: token.chainName,
+    domainId: 1,
+    routerAddress: token.addressOrDenom,
+    tokenAddress: token.addressOrDenom,
+    tokenName: token.name,
+    tokenSymbol: token.symbol,
+    tokenDecimals: token.decimals,
+    token,
+  }));
+  const pendingTransfersClient = new ExplorerPendingTransfersClient(
+    'http://localhost:8080',
+    routerNodes,
+    getLogger(),
+  );
+  const pendingReads = sinon
+    .stub(pendingTransfersClient, 'getPendingDestinationTransfers')
+    .resolves(
+      routerNodes.map((node) => ({
+        messageId: `message-${node.nodeId}`,
+        originDomainId: 1,
+        destinationDomainId: 1,
+        destinationChain: node.chainName,
+        destinationNodeId: node.nodeId,
+        destinationRouter: node.routerAddress,
+        amountBaseUnits: 5n,
+      })),
+    );
+  const priceRead = sinon.stub().resolves(2);
+  const ctx: SharedMonitorContext = {
+    multiProtocolProvider: provider,
+    chainMetadata: provider.metadata,
+    priceGetter: { tryGetTokenPrice: priceRead },
+    prefetchPrices: async () => {},
+  };
+  const route: RouteRuntime = {
+    warpRouteId: 'TEST/efficiency',
+    warpCore: new WarpCore(provider, tokens),
+    warpDeployConfig: null,
+    routerNodes,
+    pendingTransfersClient,
+    explorerQueryLimit: 200,
+    inventoryAddress: '0x0000000000000000000000000000000000000009',
+    skipSharedBalanceMetrics: false,
+  };
+  return { ctx, route, supplyReads, inventoryReads, pendingReads, priceRead };
+}
+
+async function monitorOnlyMetrics() {
+  return (await metricsRegister.metrics())
+    .split('\n')
+    .filter((line) =>
+      /^hyperlane_warp_route_(pending_destination_|projected_deficit|inventory_balance)/.test(
+        line,
+      ),
+    )
+    .sort();
+}
+
+describe('delegated shared balance collection', () => {
+  beforeEach(() => {
+    resetInventoryBalanceMetrics();
+    resetPendingDestinationMetrics();
+  });
+  afterEach(() => {
+    sinon.restore();
+    resetInventoryBalanceMetrics();
+    resetPendingDestinationMetrics();
+  });
+
+  it('skips synthetic supply but preserves monitor-only metrics and fresh reads', async () => {
+    const { ctx, route, supplyReads, inventoryReads, pendingReads, priceRead } =
+      fixture();
+    await runRouteCycle(ctx, route);
+    expect(supplyReads.map((read) => read.callCount)).to.deep.equal([1, 1]);
+    const expected = await monitorOnlyMetrics();
+    expect(expected).to.have.length(9); // Six pending, one deficit, two inventory.
+    expect(
+      expected.some(
+        (line) =>
+          line.startsWith('hyperlane_warp_route_projected_deficit{') &&
+          line.endsWith(' 2'),
+      ),
+    ).to.equal(true);
+    route.skipSharedBalanceMetrics = true;
+    for (let cycle = 0; cycle < 5; cycle++) {
+      await runRouteCycle(ctx, route);
+      expect(await monitorOnlyMetrics()).to.deep.equal(expected);
+    }
+    expect(supplyReads.map((read) => read.callCount)).to.deep.equal([6, 1]);
+    expect(inventoryReads.map((read) => read.callCount)).to.deep.equal([6, 6]);
+    expect(pendingReads.callCount).to.equal(6);
+    expect(priceRead.callCount).to.equal(1);
+    supplyReads[0].resolves(1n);
+    inventoryReads[1].resolves(9n);
+    await runRouteCycle(ctx, route);
+    const changed = await monitorOnlyMetrics();
+    expect(
+      changed.some(
+        (line) =>
+          line.startsWith('hyperlane_warp_route_projected_deficit{') &&
+          line.endsWith(' 4'),
+      ),
+    ).to.equal(true);
+    expect(
+      changed.some(
+        (line) =>
+          line.startsWith('hyperlane_warp_route_inventory_balance{') &&
+          line.includes('token_symbol="TOKEN1"') &&
+          line.endsWith(' 9'),
+      ),
+    ).to.equal(true);
+  });
+
+  it('prefetches prices only for routes that emit USD metrics, retaining shared IDs', () => {
+    const { route } = fixture();
+    const delegated = { ...route, skipSharedBalanceMetrics: true };
+    expect(collectCoinGeckoIds([delegated])).to.deep.equal([]);
+    expect(collectCoinGeckoIds([delegated, route])).to.deep.equal([
+      'price-0',
+      'price-1',
+    ]);
+    expect(collectCoinGeckoIds([route, delegated, route])).to.deep.equal([
+      'price-0',
+      'price-1',
+    ]);
+  });
+});

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -425,7 +425,7 @@ export async function updatePendingAndInventoryMetrics(
 }
 
 // Updates the metrics for a single token in a warp route. Always computes the
-// router collateral snapshot (needed for projected-deficit, a monitor-only
+// collateralized router snapshot (needed for projected-deficit, a monitor-only
 // metric) but skips emitting shared balance metrics when the route delegates
 // those to a rebalancer.
 async function updateTokenMetrics(
@@ -436,6 +436,10 @@ async function updateTokenMetrics(
   const logger = getLogger();
   const { warpCore, warpDeployConfig, warpRouteId, skipSharedBalanceMetrics } =
     route;
+  // Non-collateralized supply is only consumed by shared balance metrics.
+  // Pending and inventory collection runs separately for every router node.
+  if (skipSharedBalanceMetrics && !token.isCollateralized()) return null;
+
   let collateralSnapshot: RouterCollateralSnapshot | null = null;
 
   const promises = [
@@ -706,6 +710,8 @@ function getCachedTokenPrice(
 export function collectCoinGeckoIds(routes: RouteRuntime[]): string[] {
   const ids = new Set<string>();
   for (const route of routes) {
+    // Monitor-only metrics use base/token amounts, never USD prices.
+    if (route.skipSharedBalanceMetrics) continue;
     for (const token of route.warpCore.tokens) {
       if (token.coinGeckoId) ids.add(token.coinGeckoId);
     }

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -608,6 +608,7 @@ async function updateTokenMetrics(
                   warpCore.multiProvider,
                   token,
                   lockbox.lockbox,
+                  balance.tokenAddress,
                 );
 
               updateManagedLockboxBalanceMetrics(


### PR DESCRIPTION
## Problem

Warp monitoring fetched values unused by delegated metrics, repeatedly resolved xERC20/managed-lockbox addresses within an observation, and emitted per-chain or separate value records that duplicated ordinary balance logging.

## Solution

Skip data used only by delegated shared metrics, reuse addresses within each observation, move detailed value-at-risk records to DEBUG, and include USD value in the existing balance record. Preserve monitored values/labels, fresh reads on subsequent cycles, standalone metadata behavior and failure handling. Managed-lockbox metadata follows the collateral address observed by the balance read if that address changes between reads; the next observation reads afresh, and no atomic-block snapshot is promised. Shared metrics changes also affect rebalancer.

Consolidates #9464, #9470, #9473, #9503, #9504. Earlier PRs retain their original descriptions and detailed benchmark references.

## Performance evidence

| Component | Evidence and scope |
| --- | --- |
| skip unused reads for delegated metrics | 10 → 5 supply reads over five mixed-token cycles; 2 → 0 unused price IDs |
| reduce per-chain value-at-risk log amplification | 20-chain fixture: 22 → 2 INFO records; 20 metric series unchanged. Observed mix models 5,487 records / 3.46 MB less text per hour; DEBUG unchanged. |
| resolve xERC20 once per limit observation | Regular xERC20 observation: 9 → 5 contract reads. 51 observed bridge label sets model 204 avoided reads/pass; not measured network traffic. |
| reuse observed managed-lockbox collateral | Successful managed-lockbox balance + metadata observation: 6 → 5 contract reads. Outputs match; standalone metadata remains 4 reads. |
| consolidate token balance observations | Observed mix: 7,466 → 4,688 INFO records modeled (37.2% less). Explicit field-size assumption models 1.75 MB/hour net JSON reduction; not deployed or billing savings. |

These measurements describe separate workloads and scopes. Percentages must not be added; local or modeled results are not deployed speedups. The individual benchmark artifacts remain in this branch.

## Validation

The unchanged cumulative source at 4165e4aa0dfb272b7663134374907397d22aa78b retains all five layers and their changesets. The affected integration passed 20 build tasks and 462 tests (29 metrics, 42 warp-monitor, 391 rebalancer); the subsequent log layer passed metrics build and all 29 tests. Provider tests exercise supported EVM/Tron standards and changing addresses/values; log tests preserve metric exports and debug detail. Consolidation only retargets the existing head to main; its source tree is unchanged.

No runtime behavior was added during consolidation. The PR remains a draft.

Reproduction: [managed-lockbox read evidence](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/4165e4aa0dfb272b7663134374907397d22aa78b/typescript/metrics/docs/managed-lockbox-reads.md), [balance log evidence](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/4165e4aa0dfb272b7663134374907397d22aa78b/typescript/metrics/docs/balance-log-volume.md).
