### PR TITLE
perf(storage): decode Lander JSON directly from database slices

### DIFF
--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -130,7 +130,7 @@ impl DB {
             if !key.starts_with(prefix) {
                 break;
             }
-            values.push(value.to_vec());
+            values.push(value.into_vec());
         }
         Ok(values)
     }

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -68,7 +68,7 @@ impl TypedDB {
     ) -> Result<Option<V>> {
         self.db
             .retrieve_pinned(&self.prefixed_key(prefix.as_ref(), key.as_ref()))?
-            .map(|v| V::read_from(&mut v.as_ref()))
+            .map(|v| V::read_from_slice(v.as_ref()))
             .transpose()
             .map_err(Into::into)
     }
@@ -101,7 +101,7 @@ impl TypedDB {
         self.db
             .retrieve_values_by_prefix(&prefix)?
             .into_iter()
-            .map(|value| V::read_from(&mut value.as_slice()).map_err(Into::into))
+            .map(|value| V::read_from_slice(&value).map_err(Into::into))
             .collect()
     }
 
@@ -188,6 +188,79 @@ impl TypedDbBatch {
 mod tests {
     use super::*;
     use hyperlane_core::{HyperlaneMessage, KnownHyperlaneDomain, MerkleTreeInsertion, H256};
+
+    #[test]
+    fn pinned_typed_read_dispatches_slice_override() {
+        #[derive(Debug, PartialEq)]
+        struct SliceDecoded(u32);
+        impl Decode for SliceDecoded {
+            fn read_from<R: std::io::Read>(
+                _: &mut R,
+            ) -> std::result::Result<Self, hyperlane_core::HyperlaneProtocolError> {
+                panic!("typed read must dispatch the slice override");
+            }
+            fn read_from_slice(
+                bytes: &[u8],
+            ) -> std::result::Result<Self, hyperlane_core::HyperlaneProtocolError> {
+                u32::read_from_slice(bytes).map(Self)
+            }
+        }
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let typed = TypedDB::new(&HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum), db);
+        typed.store_encodable(b"slice_", b"key", &42u32).unwrap();
+        assert_eq!(
+            typed
+                .retrieve_decodable::<SliceDecoded>(b"slice_", b"key")
+                .unwrap(),
+            Some(SliceDecoded(42))
+        );
+        assert_eq!(
+            typed
+                .retrieve_decodables_by_prefix::<SliceDecoded>(b"slice_")
+                .unwrap(),
+            vec![SliceDecoded(42)]
+        );
+    }
+
+    #[test]
+    fn prefix_reads_preserve_order_errors_and_owned_results() {
+        let directory = tempfile::tempdir().unwrap();
+        let db = DB::from_path(directory.path()).unwrap();
+        let typed = TypedDB::new(
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+            db.clone(),
+        );
+        for key in [3u32, 1, 2] {
+            typed
+                .store_keyed_encodable(b"ordered_", &key, &vec![key; 4])
+                .unwrap();
+        }
+        typed
+            .store_keyed_encodable(b"other_", &0u32, &vec![9u32])
+            .unwrap();
+        let values = typed
+            .retrieve_decodables_by_prefix::<Vec<u32>>(b"ordered_")
+            .unwrap();
+        assert_eq!(values, vec![vec![1; 4], vec![2; 4], vec![3; 4]]);
+        let malformed_key = typed.prefixed_key(b"ordered_", &2u32.to_vec());
+        db.store(&malformed_key, &[0]).unwrap();
+        assert!(typed
+            .retrieve_decodables_by_prefix::<Vec<u32>>(b"ordered_")
+            .is_err());
+        typed
+            .store_keyed_encodable(b"ordered_", &2u32, &vec![2u32; 4])
+            .unwrap();
+        assert_eq!(
+            typed
+                .retrieve_decodables_by_prefix::<Vec<u32>>(b"ordered_")
+                .unwrap(),
+            values
+        );
+        drop(typed);
+        drop(db);
+        assert_eq!(values[1], vec![2; 4]);
+    }
 
     #[test]
     fn pinned_typed_reads_preserve_values_and_domain_isolation() {

--- a/rust/main/hyperlane-core/src/traits/encode.rs
+++ b/rust/main/hyperlane-core/src/traits/encode.rs
@@ -29,6 +29,18 @@ pub trait Decode {
     where
         R: std::io::Read,
         Self: Sized;
+
+    /// Decode an owned value from an available byte slice.
+    ///
+    /// The default retains the reader decoder's trailing-byte behavior. Types
+    /// with a slice-aware decoder may override this while preserving the accepted
+    /// format and failure contract; parser diagnostic positions may differ.
+    fn read_from_slice(mut bytes: &[u8]) -> Result<Self, HyperlaneProtocolError>
+    where
+        Self: Sized,
+    {
+        Self::read_from(&mut bytes)
+    }
 }
 
 #[cfg(feature = "ethers")]
@@ -343,6 +355,18 @@ mod test {
     use std::io::Cursor;
 
     use crate::{Decode, Encode, Indexed, H256};
+
+    #[test]
+    fn slice_decode_default_preserves_binary_trailing_bytes_and_errors() {
+        let bytes = [0, 0, 0, 42, 99];
+        assert_eq!(u32::read_from_slice(&bytes).unwrap(), 42);
+        assert_eq!(u32::read_from(&mut bytes.as_slice()).unwrap(), 42);
+        for bytes in [&[][..], &[0, 0, 0][..]] {
+            let reader = u32::read_from(&mut &bytes[..]).unwrap_err();
+            let slice = u32::read_from_slice(bytes).unwrap_err();
+            assert_eq!(reader.to_string(), slice.to_string());
+        }
+    }
 
     #[test]
     fn test_encoding_indexed() {

--- a/rust/main/lander/src/dispatcher/db.rs
+++ b/rust/main/lander/src/dispatcher/db.rs
@@ -5,3 +5,6 @@ mod transaction;
 pub use loader::*;
 pub use payload::*;
 pub use transaction::*;
+
+#[cfg(test)]
+mod json_decode_tests;

--- a/rust/main/lander/src/dispatcher/db/json_decode_tests.rs
+++ b/rust/main/lander/src/dispatcher/db/json_decode_tests.rs
@@ -1,0 +1,145 @@
+use std::fmt::Debug;
+
+use hyperlane_base::db::{HyperlaneRocksDB, DB};
+use hyperlane_core::{Decode, HyperlaneProtocolError, KnownHyperlaneDomain};
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::{PayloadDb, TransactionDb};
+use crate::adapter::chains::ethereum::tests::{dummy_evm_tx, ExpectedTxType};
+use crate::{payload::FullPayload, tests::test_utils::dummy_tx, transaction::TransactionStatus};
+
+fn assert_json_decode_equivalence<T>(value: &T)
+where
+    T: Decode + Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    let bytes = serde_json::to_vec(value).unwrap();
+    let json = String::from_utf8(bytes.clone()).unwrap();
+    let mut invalid_utf8 = bytes.clone();
+    let at = bytes
+        .windows(12)
+        .position(|s| s == b"probe marker")
+        .unwrap();
+    invalid_utf8[at] = 255;
+    let duplicate_status =
+        serde_json::to_string(&serde_json::to_value(value).unwrap()["status"]).unwrap();
+    let cases = [
+        ("valid", bytes.clone()),
+        ("truncated", bytes[..bytes.len() - 1].to_vec()),
+        ("whitespace", [bytes.as_slice(), b" \n\t"].concat()),
+        ("trailing JSON", [bytes.as_slice(), b"{}"].concat()),
+        ("trailing junk", [bytes.as_slice(), b"x"].concat()),
+        ("trailing invalid byte", [bytes.as_slice(), &[255]].concat()),
+        ("wrong type", b"[]".to_vec()),
+        ("empty", vec![]),
+        (
+            "unknown field",
+            [b"{\"unused_probe\":true,".as_slice(), &bytes[1..]].concat(),
+        ),
+        (
+            "duplicate field",
+            [
+                format!("{{\"status\":{duplicate_status},").as_bytes(),
+                &bytes[1..],
+            ]
+            .concat(),
+        ),
+        (
+            "invalid escape",
+            json.replace("probe marker", r"\q").into_bytes(),
+        ),
+        (
+            "invalid surrogate",
+            json.replace("probe marker", r"\uD800").into_bytes(),
+        ),
+        (
+            "escaped Unicode",
+            json.replace("probe marker", r"line\n\uD83D\uDE00")
+                .into_bytes(),
+        ),
+        ("invalid UTF-8 string", invalid_utf8),
+    ];
+    for (name, input) in cases {
+        let reader = T::read_from(&mut input.as_slice());
+        let slice = T::read_from_slice(&input);
+        match (reader, slice) {
+            (Ok(reader), Ok(slice)) => assert_eq!(reader, slice, "{name}"),
+            (
+                Err(HyperlaneProtocolError::IoError(reader)),
+                Err(HyperlaneProtocolError::IoError(slice)),
+            ) => {
+                assert_eq!(reader.kind(), slice.kind(), "{name}");
+                assert!(reader
+                    .to_string()
+                    .starts_with("Failed to deserialize. Error: "));
+                assert!(slice
+                    .to_string()
+                    .starts_with("Failed to deserialize. Error: "));
+                // Serde's reader and slice parser can report different source
+                // columns; preserve acceptance/category rather than exact text.
+                let reader = serde_json::from_reader::<_, T>(input.as_slice()).unwrap_err();
+                let slice = serde_json::from_slice::<T>(&input).unwrap_err();
+                assert_eq!(reader.classify(), slice.classify(), "{name}");
+            }
+            outcomes => panic!("{name}: inconsistent decode outcomes: {outcomes:?}"),
+        }
+    }
+}
+
+#[test]
+fn payload_and_transaction_slice_decoders_match_reader_contracts() {
+    for length in [0, 32, 4096] {
+        let mut payload = FullPayload::default();
+        payload.data = vec![17; length];
+        payload.details.metadata = "probe marker".to_owned();
+        payload.details.success_criteria = Some(vec![17; length]);
+        let transaction = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
+        assert_json_decode_equivalence(&payload);
+        assert_json_decode_equivalence(&transaction);
+        let evm = dummy_evm_tx(
+            ExpectedTxType::Eip1559,
+            vec![payload],
+            TransactionStatus::PendingInclusion,
+            ethers::types::H160::zero(),
+        );
+        assert_json_decode_equivalence(&evm);
+    }
+}
+
+#[tokio::test]
+async fn slice_decoded_records_survive_database_reopen() {
+    let directory = tempfile::tempdir().unwrap();
+    let domain = KnownHyperlaneDomain::Arbitrum.into();
+    let db = HyperlaneRocksDB::new(&domain, DB::from_path(directory.path()).unwrap());
+    let mut payload = FullPayload::random();
+    payload.data = vec![17; 4096];
+    payload.details.metadata = "Unicode payload 🦀".to_owned();
+    let transaction = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
+    db.store_payload_by_uuid(&payload).await.unwrap();
+    db.store_transaction_by_uuid(&transaction).await.unwrap();
+    let read_payload = db
+        .retrieve_payload_by_uuid(&payload.details.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    let read_transaction = db
+        .retrieve_transaction_by_uuid(&transaction.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    drop(db);
+    assert_eq!(read_payload, payload);
+    assert_eq!(read_transaction, transaction);
+    let db = HyperlaneRocksDB::new(&domain, DB::from_path(directory.path()).unwrap());
+    assert_eq!(
+        db.retrieve_payload_by_uuid(&payload.details.uuid)
+            .await
+            .unwrap(),
+        Some(payload)
+    );
+    assert_eq!(
+        db.retrieve_transaction_by_uuid(&transaction.uuid)
+            .await
+            .unwrap(),
+        Some(transaction)
+    );
+}

--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -418,6 +418,14 @@ impl Decode for FullPayload {
             )))
         })
     }
+
+    fn read_from_slice(bytes: &[u8]) -> Result<Self, HyperlaneProtocolError> {
+        serde_json::from_slice(bytes).map_err(|err| {
+            HyperlaneProtocolError::IoError(std::io::Error::other(format!(
+                "Failed to deserialize. Error: {err}"
+            )))
+        })
+    }
 }
 
 #[cfg(test)]

--- a/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
+++ b/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
@@ -166,6 +166,14 @@ impl Decode for Transaction {
             )))
         })
     }
+
+    fn read_from_slice(bytes: &[u8]) -> Result<Self, HyperlaneProtocolError> {
+        serde_json::from_slice(bytes).map_err(|err| {
+            HyperlaneProtocolError::IoError(std::io::Error::other(format!(
+                "Failed to deserialize. Error: {err}"
+            )))
+        })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Consolidated into #9489 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Typed RocksDB reads already have the complete encoded bytes, but Lander payload and transaction JSON decoders feed those bytes through `serde_json::from_reader`. The reader parser performs extra per-byte work and temporary allocations compared with slice parsing. Pending-payload startup scans also copy each RocksDB-owned boxed value into a second buffer before decoding.

## Solution

Add a provided `Decode::read_from_slice` method that delegates to the existing reader implementation by default. Dispatch available slices through it in typed point reads and eager prefix reads. Override only Lander `FullPayload` and `Transaction` with `serde_json::from_slice`, preserving their existing error wrapper. Convert owned prefix values with `Box::into_vec` to remove their extra copy.

Binary decoders keep their prior trailing-byte behavior. Pinned point-read values remain scoped to synchronous decoding; returned records own their data. Prefix traversal remains eager and ordered, so database errors still precede the decoding pass. No streaming or transaction-lifecycle changes.

## Numerical impact

Optimized local FullPayload probe, actual owned types/serde deserializers, Apple M3 Pro; 45 alternating paired batches across three runs. Per-record decode/drop time includes deserialized allocations and destruction, excludes fixture construction:

| Data bytes | JSON bytes | Reader median | Slice median | Median paired reduction |
|---|---:|---:|---:|---:|
|32|432|2,078 ns|1,125 ns|45.6%|
|4,096|14,970|52,852 ns|34,240 ns|35.2%|
|65,536|234,330|804,213 ns|528,135 ns|34.5%|

Paired reductions are medians of per-pair changes, not ratios of the displayed medians. A separate optimized allocation probe measured **five fewer allocations and 248 fewer requested bytes** per fixture. An additional 15-pair probe extracting the exact new method body, including its error wrapper, corroborated the reduction.

These are synthetic per-record FullPayload decoding results, not whole-database latency, fleet CPU or deployed performance. Transaction decoding was covered for compatibility but not benchmarked. Separately, the prefix conversion removes one full encoded-value allocation/copy per scanned pending-payload record; that startup-only saving is not included in these JSON timing/allocation figures, and the full encoded prefix collection remains materialized.

## Compatibility and validation

- Five new tests cover default binary trailing/short-input behavior, actual point/prefix override dispatch, prefix ordering/error/owned-result behavior, database close/reopen for both JSON records, and a **126-case oracle** across payload/CosmWasm/EIP-1559 records with varying retained bytes.
- Oracle inputs include malformed/truncated JSON, trailing whitespace/junk/JSON/invalid bytes, wrong types, unknown/duplicate fields, invalid escapes/surrogates, escaped Unicode and invalid UTF-8 strings. Successful values, acceptance, serde error categories and the existing `IoError`/message prefix match. Parser diagnostic positions can differ: a measured duplicate-field fixture reports column 199 through the reader versus 198 through the slice parser. Exact error-text equality is not claimed.
- **524 tests passed**: core 73, base 97, Lander 354; four existing ignored. One existing core fixture test needed the primary checkout working directory and passed there using the same emitted binary, without source changes.
- Qualified strict production Clippy passed for core/base/Lander using `--no-deps -D warnings`, established `dev`/`serde` cfg declarations, and qualifications for pre-existing hidden-lifetime, `Filter::Default` derivation and finality clone diagnostics. The finality clone cleanup already exists on the relayer stack and is not duplicated here; the manual `Filter::Default` implementation remains an unchanged baseline there too. No source suppressions; changed lines were reviewed independently. Normal commit hooks passed, including both Rust workspace formatting checks.
- Root and independent relayer/scraper review; existing Encode overrides on the relayer stack compose with these separate Decode overrides.

Stack: follows #9499 on the validator/shared-storage stack so pinned TypedDB reads (#9495) are ancestors. The measured beneficiary is Lander. This does not duplicate prior JSON encoding, snapshot, read-pooling or polling work, and its decode-only gain is not added to their end-to-end estimates.
