### PR TITLE
perf(scraper): skip redundant single-insert transactions

### DIFF
--- a/rust/main/agents/scraper/src/db/dispatch_transactions.rs
+++ b/rust/main/agents/scraper/src/db/dispatch_transactions.rs
@@ -1,0 +1,153 @@
+//! Single-statement atomicity and multi-chunk transaction boundaries.
+use std::collections::BTreeMap;
+
+use hyperlane_core::{HyperlaneMessage, LogMeta, H256};
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::{ScraperDb, StorableMessage, StorableRawMessageDispatch};
+
+fn messages(count: u32) -> Vec<HyperlaneMessage> {
+    (0..count)
+        .map(|nonce| HyperlaneMessage {
+            version: 3,
+            nonce,
+            origin: 1,
+            destination: 1,
+            body: vec![1],
+            ..Default::default()
+        })
+        .collect()
+}
+
+async fn store(db: &ScraperDb, raw: bool, messages: &[HyperlaneMessage]) -> eyre::Result<u64> {
+    let meta = LogMeta::default();
+    if raw {
+        db.store_raw_message_dispatches(
+            1,
+            &H256::zero(),
+            messages
+                .iter()
+                .map(|msg| StorableRawMessageDispatch { msg, meta: &meta }),
+        )
+        .await
+    } else {
+        db.store_dispatched_messages(
+            1,
+            &H256::zero(),
+            messages.iter().cloned().map(|msg| StorableMessage {
+                msg,
+                meta: &meta,
+                txn_id: None,
+                id_override: None,
+            }),
+        )
+        .await
+    }
+}
+
+#[tokio::test]
+async fn dispatch_statement_counts_preserve_multi_chunk_transactions() {
+    for raw in [false, true] {
+        let bound = if raw { 2_954 } else { 3_250 };
+        for count in [0, 1, bound, bound + 1] {
+            let chunks = if count <= bound { 1 } else { 2 };
+            let row = |name: &str, value: i64| {
+                vec![BTreeMap::from([(
+                    name.to_owned(),
+                    Value::BigInt(Some(value)),
+                )])]
+            };
+            let mut results = vec![row("max_id", 0)];
+            results.extend((0..chunks).map(|_| row("id", 1)));
+            results.push(row("num_items", i64::from(count)));
+            let db = ScraperDb::with_connection(
+                MockDatabase::new(DatabaseBackend::Postgres)
+                    .append_query_results(results)
+                    .into_connection(),
+            );
+            assert_eq!(
+                store(&db, raw, &messages(count)).await.unwrap(),
+                u64::from(count)
+            );
+            let log = db.0.into_transaction_log();
+            let sql: Vec<_> = log
+                .iter()
+                .flat_map(|transaction| transaction.statements())
+                .map(|statement| statement.sql.as_str())
+                .collect();
+            if count == 0 {
+                assert!(sql.is_empty());
+            } else if count <= bound {
+                assert_eq!(sql.len(), 3);
+                assert!(sql[0].starts_with("SELECT MAX("));
+                assert!(sql[1].starts_with("INSERT"));
+                assert!(sql[2].starts_with("SELECT COUNT("));
+            } else {
+                assert_eq!(sql.len(), 6);
+                assert_eq!(sql[1], "BEGIN");
+                assert!(sql[2].starts_with("INSERT"));
+                assert!(sql[3].starts_with("INSERT"));
+                assert_eq!(sql[4], "COMMIT");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn dispatch_writes_preserve_atomicity_and_replay_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    for raw in [false, true] {
+        let (table, bound) = if raw {
+            ("raw_message_dispatch", 2_954)
+        } else {
+            ("message", 3_250)
+        };
+        for count in [2, bound + 1] {
+            db.0.execute_unprepared(&format!("TRUNCATE {table}"))
+                .await?;
+            let rows = messages(count);
+            assert_eq!(store(&db, raw, &rows[..1]).await?, 1);
+            // Keep an existing conflict row to prove failed batches roll back updates too.
+            db.0.execute_unprepared(&format!(
+                "UPDATE {table} SET msg_body = decode('09', 'hex')"
+            ))
+            .await?;
+            // A repeated conflict key must still reject the entire one-statement batch.
+            assert!(store(&db, raw, &[rows[0].clone(), rows[0].clone()])
+                .await
+                .is_err());
+            db.0.execute_unprepared(&format!(
+                "ALTER TABLE {table} ADD CONSTRAINT reject_dispatch_tail CHECK (nonce <> {})",
+                count - 1
+            ))
+            .await?;
+            assert!(store(&db, raw, &rows).await.is_err());
+            let stored = db.0.query_one(sea_orm::Statement::from_string(DatabaseBackend::Postgres, format!("SELECT COUNT(*) AS row_count, MIN(encode(msg_body, 'hex')) AS body FROM {table}"))).await?.unwrap();
+            assert_eq!(stored.try_get::<i64>("", "row_count")?, 1);
+            assert_eq!(stored.try_get::<String>("", "body")?, "09");
+            db.0.execute_unprepared(&format!(
+                "ALTER TABLE {table} DROP CONSTRAINT reject_dispatch_tail"
+            ))
+            .await?;
+            assert_eq!(store(&db, raw, &rows).await?, u64::from(count - 1));
+            assert_eq!(store(&db, raw, &rows).await?, 0);
+            let stored = db.0.query_one(sea_orm::Statement::from_string(DatabaseBackend::Postgres, format!("SELECT COUNT(*) AS row_count, COUNT(*) FILTER (WHERE msg_body = decode('01', 'hex')) AS expected_bodies FROM {table}"))).await?.unwrap();
+            assert_eq!(stored.try_get::<i64>("", "row_count")?, i64::from(count));
+            assert_eq!(
+                stored.try_get::<i64>("", "expected_bodies")?,
+                i64::from(count)
+            );
+        }
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -346,55 +346,26 @@ impl ScraperDb {
 
         trace!(?models, "Writing messages to database");
 
-        // ensure all chunks are inserted or none at all
-        self.0
-            .transaction::<_, (), DbErr>(|txn| {
-                Box::pin(async move {
-                    // insert messages in chunks, to not run into
-                    // "Too many arguments" error
-                    let mut models = models.into_iter();
-                    while !models.as_slice().is_empty() {
-                        let chunk: Vec<_> = models
-                            .by_ref()
-                            .take(Self::STORE_MESSAGE_CHUNK_SIZE)
-                            .collect();
-                        Insert::many(chunk)
-                            .on_conflict(
-                                OnConflict::columns([
-                                    message::Column::Origin,
-                                    message::Column::OriginMailbox,
-                                    message::Column::Nonce,
-                                ])
-                                .update_columns([
-                                    message::Column::Destination,
-                                    message::Column::Sender,
-                                    message::Column::Recipient,
-                                    message::Column::MsgBody,
-                                ])
-                                // Prefer resolved transaction metadata over a
-                                // NULL value from a later fallback replay.
-                                .value(
-                                    message::Column::OriginTxId,
-                                    Func::if_null(
-                                        Expr::col((
-                                            Alias::new("excluded"),
-                                            message::Column::OriginTxId,
-                                        )),
-                                        Expr::col((
-                                            Alias::new("message"),
-                                            message::Column::OriginTxId,
-                                        )),
-                                    ),
-                                )
-                                .to_owned(),
-                            )
-                            .exec(txn)
-                            .await?;
-                    }
-                    Ok(())
+        // A single INSERT is atomic; multiple chunks need one shared transaction.
+        if models.len() <= Self::STORE_MESSAGE_CHUNK_SIZE {
+            dispatch_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_MESSAGE_CHUNK_SIZE)
+                                .collect();
+                            dispatch_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
                 })
-            })
-            .await?;
+                .await?;
+        }
 
         let new_dispatch_count = self
             .dispatch_count_since_id(domain, origin_mailbox, latest_id_before)
@@ -430,6 +401,32 @@ fn delivery_insert_query(
                 ),
             )
             .to_owned(),
+    )
+}
+
+fn dispatch_insert_query(models: Vec<message::ActiveModel>) -> Insert<message::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([
+            message::Column::Origin,
+            message::Column::OriginMailbox,
+            message::Column::Nonce,
+        ])
+        .update_columns([
+            message::Column::Destination,
+            message::Column::Sender,
+            message::Column::Recipient,
+            message::Column::MsgBody,
+        ])
+        // Prefer resolved transaction metadata over a
+        // NULL value from a later fallback replay.
+        .value(
+            message::Column::OriginTxId,
+            Func::if_null(
+                Expr::col((Alias::new("excluded"), message::Column::OriginTxId)),
+                Expr::col((Alias::new("message"), message::Column::OriginTxId)),
+            ),
+        )
+        .to_owned(),
     )
 }
 

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -74,3 +74,6 @@ mod lookup_batches;
 
 #[cfg(test)]
 mod sequence_reads;
+
+#[cfg(test)]
+mod dispatch_transactions;

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -134,100 +134,26 @@ impl ScraperDb {
             .latest_raw_dispatch_id(origin_domain, origin_mailbox.clone())
             .await?;
 
-        // Ensure all chunks are inserted or none at all
-        self.0
-            .transaction::<_, (), DbErr>(|txn| {
-                Box::pin(async move {
-                    // Insert raw message dispatches in chunks, to not run into
-                    // "Too many arguments" error
-                    let mut models = models.into_iter();
-                    while !models.as_slice().is_empty() {
-                        let chunk: Vec<_> = models
-                            .by_ref()
-                            .take(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE)
-                            .collect();
-                        Insert::many(chunk)
-                            .on_conflict(
-                                OnConflict::column(raw_message_dispatch::Column::MsgId)
-                                    .update_columns([
-                                        raw_message_dispatch::Column::TimeUpdated,
-                                        raw_message_dispatch::Column::DestinationDomain,
-                                        raw_message_dispatch::Column::Sender,
-                                        raw_message_dispatch::Column::Recipient,
-                                        raw_message_dispatch::Column::MsgBody,
-                                    ])
-                                    // Preserve resolved hashes across a later
-                                    // basic-meta fallback, while still updating
-                                    // the body and other fields on legacy rows.
-                                    .value(
-                                        raw_message_dispatch::Column::OriginTxHash,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            ))
-                                            .ne(h512_to_bytes(&H512::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            )),
-                                        ),
-                                    )
-                                    .value(
-                                        raw_message_dispatch::Column::OriginBlockHash,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            ))
-                                            .ne(h256_to_bytes(&H256::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            )),
-                                        ),
-                                    )
-                                    .value(
-                                        raw_message_dispatch::Column::OriginBlockHeight,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            ))
-                                            .ne(h256_to_bytes(&H256::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHeight,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginBlockHeight,
-                                            )),
-                                        ),
-                                    )
-                                    .to_owned(),
-                            )
-                            .exec(txn)
-                            .await?;
-                    }
-                    Ok(())
+        // A single INSERT is atomic; multiple chunks need one shared transaction.
+        if models.len() <= Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE {
+            raw_dispatch_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE)
+                                .collect();
+                            raw_dispatch_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
                 })
-            })
-            .await?;
+                .await?;
+        }
 
         let new_dispatch_count = self
             .raw_dispatch_count_since_id(origin_domain, origin_mailbox, latest_id_before)
@@ -326,6 +252,79 @@ fn raw_dispatch_to_candidate(raw: raw_message_dispatch::Model) -> Result<RawDisp
             log_index: U256::zero(),
         },
     })
+}
+
+fn raw_dispatch_insert_query(
+    models: Vec<raw_message_dispatch::ActiveModel>,
+) -> Insert<raw_message_dispatch::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::column(raw_message_dispatch::Column::MsgId)
+            .update_columns([
+                raw_message_dispatch::Column::TimeUpdated,
+                raw_message_dispatch::Column::DestinationDomain,
+                raw_message_dispatch::Column::Sender,
+                raw_message_dispatch::Column::Recipient,
+                raw_message_dispatch::Column::MsgBody,
+            ])
+            // Preserve resolved hashes across a later
+            // basic-meta fallback, while still updating
+            // the body and other fields on legacy rows.
+            .value(
+                raw_message_dispatch::Column::OriginTxHash,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginTxHash,
+                    ))
+                    .ne(h512_to_bytes(&H512::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginTxHash,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginTxHash,
+                ))),
+            )
+            .value(
+                raw_message_dispatch::Column::OriginBlockHash,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    ))
+                    .ne(h256_to_bytes(&H256::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginBlockHash,
+                ))),
+            )
+            .value(
+                raw_message_dispatch::Column::OriginBlockHeight,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    ))
+                    .ne(h256_to_bytes(&H256::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHeight,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginBlockHeight,
+                ))),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stacked on #9502; review the child diff.

## Problem

Every nonempty raw or enriched dispatch write starts and commits an explicit database transaction, even when its entire write fits in one INSERT. The initial MAX(id) lookup and final count already run outside that transaction, so the single-statement wrapper adds two database commands without extending atomicity.

## Solution

Execute one INSERT directly when enriched dispatches fit within 3,250 rows or raw dispatches fit within 2,954 rows. Preserve one shared transaction for larger batches. Extract each existing INSERT builder so both paths use identical conflict updates, nullable transaction handling and raw metadata reconciliation.

PostgreSQL single-statement atomicity still rolls back both new rows and updates when any row fails. MAX/count remain outside the write transaction, and insert failures still return before the count query. Raw retry/acquisition logic is unchanged.

## Numerical impact

Source-derived command counts, verified by query logs:

| Successful store call | Before | After |
| --- | --- | --- |
| Empty | 0 | 0 |
| One chunk | MAX + BEGIN + INSERT + COMMIT + COUNT = 5 | MAX + INSERT + COUNT = 3 |
| Two chunks | MAX + BEGIN + 2 INSERTs + COMMIT + COUNT = 6 | 6 |

One-chunk calls issue two fewer database commands, a **40% reduction**. This removes explicit BEGIN/COMMIT round trips; the write statement still has an implicit PostgreSQL transaction. No measured latency, CPU, RPC or fleet-wide percentage is claimed. Multi-chunk statement counts, row limits and total batch materialization remain unchanged.

A one-hour mainnet scraper metric sample on 2026-09-05 at 04:49 UTC recorded approximately 107 enriched-dispatch and 85 raw-dispatch store calls/hour. The spans do not identify empty calls, retries or batch sizes, so these rates confirm recurring use but do not establish fleet-wide command savings.

## Verification

- Full scraper suite: **57 passed, 0 failed, 1 existing ignored**.
- SQL tests cover empty, one row, exact chunk boundary and boundary plus one for both writers.
- Actual PostgreSQL tests cover duplicate conflict-key rejection, failed tails within one statement and across chunks, rollback of existing-row updates, correct stored bodies and idempotent replay.
- Existing NULL-transaction fallback/restart and resolved-metadata replay tests pass.
- INSERT builders mechanically match their previous expressions after ignoring whitespace/trailing commas. Self-review and independent source review found no blockers.
- Strict production scraper Clippy, formatting and normal commit hooks passed (exit 0). No production database writes.
