### PR TITLE
perf(rebalancer): eliminate duplicate reads and unused initialization

### DIFF
--- a/.changeset/empty-bridge-discovery.md
+++ b/.changeset/empty-bridge-discovery.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Skipped Explorer rebalance-action discovery when no bridge addresses were configured, avoiding an empty-result HTTP query while retaining tracked-action delivery checks.

--- a/.changeset/lazy-external-bridge.md
+++ b/.changeset/lazy-external-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Deferred LiFi SDK initialization until a configured external bridge was needed, reducing startup work for rebalancers without LiFi inventory execution.

--- a/.changeset/quiet-gas-quote.md
+++ b/.changeset/quiet-gas-quote.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Reused the transfer gas quote within native-token cost estimation, avoiding a duplicate quote request while preserving fee reservations and standalone estimation behavior.

--- a/.changeset/tidy-prices-share.md
+++ b/.changeset/tidy-prices-share.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Coalesced concurrent CoinGecko lookups for the same token ID, reducing duplicate metrics price requests while preserving cache expiry and retries after failures.

--- a/typescript/rebalancer/docs/performance/lazy-lifi.md
+++ b/typescript/rebalancer/docs/performance/lazy-lifi.md
@@ -1,0 +1,52 @@
+# Load LiFi only when configured
+
+The factory imported LiFiBridge eagerly, initializing its SDK even for movable-only rebalancers. It now imports the module inside the configured LiFi branch of the existing awaited initialization chain. An external bridge override, including an empty override, still bypasses normal bridge construction. Configured LiFi initialization failures still abort service initialization before monitoring or execution starts.
+
+## Observed deployment coverage
+
+Read-only mainnet3 ConfigMap inspection on 2026-09-05 found 14 rebalancer configurations: four configured a LiFi integrator, ten did not. Nine of those ten had no inventory signer configuration; the other had inventory configuration without a LiFi bridge. No configuration, signer or workload was changed.
+
+## Local measurement
+
+Node 24.13.0, macOS, five alternating fresh-process pairs after one discarded warmup pair, same dependency installation. Each process imported the compiled RebalancerContextFactory module. The baseline was the parent compiled module preserved alongside the changed module so its relative dependencies resolved identically. Node module-load hooks counted LiFi files; no service, RPC, quote or signing operation was run.
+
+| Median                       | Parent     | Lazy import | Difference        |
+| ---------------------------- | ---------- | ----------- | ----------------- |
+| Factory import wall time     | 1484.18 ms | 1356.74 ms  | -127.44 ms / 8.6% |
+| Import CPU time              | 2016.92 ms | 1866.27 ms  | -150.65 ms / 7.5% |
+| Resident memory after import | 645.64 MiB | 629.75 MiB  | -15.89 MiB / 2.5% |
+| LiFi module loads            | 122        | 0           | -122 / 100%       |
+
+These are local unbundled module-import measurements on a shared host. RSS is current resident memory, not peak memory or retained heap. The percentages are neither deployed startup measurements nor steady-state fleet memory savings. Inventory configurations that need LiFi pay its import cost during initialization.
+
+## Reproduction
+
+Use separate parent and PR checkouts with the same Node version and frozen dependencies. Build workspace dependencies and the rebalancer package, then run the following from each repository root in alternating fresh processes. Discard the first pair and compare at least five pairs. The module-load hook requires a Node release supporting registerHooks (measurement used 24.13.0).
+
+```sh
+node --input-type=module <<'JS'
+import { registerHooks } from 'node:module';
+let lifiModules = 0;
+registerHooks({
+  load(url, context, nextLoad) {
+    if (url.includes('/@lifi/')) lifiModules++;
+    return nextLoad(url, context);
+  },
+});
+const started = performance.now();
+const cpu = process.cpuUsage();
+await import('./typescript/rebalancer/dist/factories/RebalancerContextFactory.js');
+console.log(JSON.stringify({
+  wallMs: performance.now() - started,
+  cpuMs: Object.values(process.cpuUsage(cpu)).reduce((a, b) => a + b, 0) / 1000,
+  rssMiB: process.memoryUsage().rss / 1048576,
+  lifiModules,
+}));
+JS
+```
+
+## Validation
+
+391 unit tests passed, including configured bridge construction and absent-configuration behavior. Package build and lint passed (three existing warnings). The normal production ncc bundle built and reached its expected missing-config guard with an empty environment, before external operations. A separate offline ncc fixture also exercises the dynamically imported bridge constructor, with empty chain metadata and no quote or signing call. No deployment was performed.
+
+Local runtime imports needed the previously identified ignored node_modules core-js compatibility entry for the pinned Provable SDK; no dependency or lockfile change is included.

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -156,6 +156,52 @@ describe('RebalancerContextFactory', () => {
     sandbox.restore();
   });
 
+  describe('external bridge initialization', () => {
+    async function factoryWithBridges(
+      externalBridges?: RebalancerConfig['externalBridges'],
+    ) {
+      const { multiProvider } = createMockMultiProvider([
+        { name: 'ethereum', protocol: ProtocolType.Ethereum },
+        { name: 'arbitrum', protocol: ProtocolType.Ethereum },
+      ]);
+      return createFactory(
+        { ...createMockConfig(), externalBridges },
+        multiProvider,
+        {
+          tokens: [
+            createToken(
+              'ethereum',
+              TEST_ADDRESSES.ethereum,
+              TokenStandard.EvmHypCollateral,
+            ),
+            createToken(
+              'arbitrum',
+              TEST_ADDRESSES.arbitrum,
+              TokenStandard.EvmHypCollateral,
+            ),
+          ],
+        },
+      );
+    }
+
+    it('returns no bridges when no external bridge is configured', async () => {
+      const factory = await factoryWithBridges();
+      expect(await factory['buildExternalBridgeRegistry']()).to.deep.equal({});
+    });
+
+    it('awaits the configured LiFi bridge before returning the registry', async () => {
+      const factory = await factoryWithBridges({
+        lifi: { integrator: 'test-rebalancer' },
+      });
+      const registry = await factory['buildExternalBridgeRegistry']();
+      expect(Object.keys(registry)).to.deep.equal(['lifi']);
+      expect(registry.lifi?.externalBridgeId).to.equal('lifi');
+      expect(registry.lifi?.getNativeTokenAddress?.()).to.equal(
+        '0x0000000000000000000000000000000000000000',
+      );
+    });
+  });
+
   describe('create() — non-EVM chain handling', () => {
     it('should skip provider initialization for StarkNet chains', async () => {
       const { multiProvider } = createMockMultiProvider([

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -199,7 +199,7 @@ describe('RebalancerContextFactory', () => {
       expect(registry.lifi?.getNativeTokenAddress?.()).to.equal(
         '0x0000000000000000000000000000000000000000',
       );
-    });
+    }).timeout(10_000);
   });
 
   describe('create() — non-EVM chain handling', () => {

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -19,7 +19,6 @@ import {
   objMap,
 } from '@hyperlane-xyz/utils';
 
-import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -528,7 +527,8 @@ export class RebalancerContextFactory {
     }
 
     const externalBridgeRegistry: Partial<ExternalBridgeRegistry> =
-      externalBridgeRegistryOverride ?? this.buildExternalBridgeRegistry();
+      externalBridgeRegistryOverride ??
+      (await this.buildExternalBridgeRegistry());
 
     if (Object.keys(externalBridgeRegistry).length === 0) {
       if (externalBridgeRegistryOverride !== undefined) {
@@ -627,7 +627,9 @@ export class RebalancerContextFactory {
     return { inventoryRebalancer, externalBridgeRegistry, inventoryConfig };
   }
 
-  private buildExternalBridgeRegistry(): Partial<ExternalBridgeRegistry> {
+  private async buildExternalBridgeRegistry(): Promise<
+    Partial<ExternalBridgeRegistry>
+  > {
     const { externalBridges } = this.config;
     const registry: Partial<ExternalBridgeRegistry> = {};
 
@@ -636,6 +638,7 @@ export class RebalancerContextFactory {
         case ExternalBridgeType.LiFi: {
           const lifiConfig = externalBridges?.lifi;
           if (lifiConfig?.integrator) {
+            const { LiFiBridge } = await import('../bridges/LiFiBridge.js');
             registry[ExternalBridgeType.LiFi] = new LiFiBridge(
               {
                 integrator: lifiConfig.integrator,

--- a/typescript/rebalancer/src/metrics/PriceGetter.test.ts
+++ b/typescript/rebalancer/src/metrics/PriceGetter.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import { CoinGeckoTokenPriceGetter } from '@hyperlane-xyz/sdk';
+
+import { PriceGetter } from './PriceGetter.js';
+
+const logger = pino({ level: 'silent' });
+const response = (price = 1) =>
+  new Response(
+    JSON.stringify({
+      'usd-coin': { usd: price },
+      tether: { usd: price },
+    }),
+  );
+
+describe('PriceGetter concurrent lookups', () => {
+  afterEach(() => Sinon.restore());
+
+  it('reduces twelve concurrent same-ID HTTP requests to one', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const baseline = new CoinGeckoTokenPriceGetter({
+      chainMetadata: {},
+      sleepMsBetweenRequests: 0,
+    });
+    const before = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        baseline.getTokenPriceByIds(['usd-coin']),
+      ),
+    );
+    expect(fetch.callCount).to.equal(12);
+    fetch.resetHistory();
+
+    const getter = PriceGetter.create({}, logger, undefined, undefined, 0);
+    const after = await Promise.all(
+      Array.from({ length: 12 }, () => getter.getCoingeckoPrice('usd-coin')),
+    );
+    expect(fetch.callCount).to.equal(1);
+    expect(after).to.deep.equal(before.map((prices) => prices?.[0]));
+  });
+
+  it('looks up distinct IDs independently', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const getter = PriceGetter.create({}, logger, undefined, undefined, 0);
+    expect(
+      await Promise.all([
+        getter.getCoingeckoPrice('usd-coin'),
+        getter.getCoingeckoPrice('tether'),
+        getter.getCoingeckoPrice('usd-coin'),
+        getter.getCoingeckoPrice('tether'),
+      ]),
+    ).to.deep.equal([1, 1, 1, 1]);
+    expect(fetch.callCount).to.equal(2);
+  });
+
+  it('keeps the SDK cache behavior after a successful lookup', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const getter = PriceGetter.create({}, logger, undefined, 60, 0);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(fetch.callCount).to.equal(1);
+  });
+
+  it('does not retain settled results beyond the SDK cache lifetime', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch');
+    fetch.onFirstCall().resolves(response(1));
+    fetch.onSecondCall().resolves(response(2));
+    const getter = PriceGetter.create({}, logger, undefined, 0, 0);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(2);
+    expect(fetch.callCount).to.equal(2);
+  });
+
+  it('retries after an unavailable price instead of retaining undefined', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch');
+    fetch.onFirstCall().resolves(new Response('{}'));
+    fetch.onSecondCall().resolves(response());
+    const getter = PriceGetter.create({}, logger, undefined, undefined, 0);
+    expect(
+      await Promise.all([
+        getter.getCoingeckoPrice('usd-coin'),
+        getter.getCoingeckoPrice('usd-coin'),
+      ]),
+    ).to.deep.equal([undefined, undefined]);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(fetch.callCount).to.equal(2);
+  });
+
+  it('propagates rejected lookups to all callers and allows a retry', async () => {
+    const getter = PriceGetter.create({}, logger);
+    const lookup = Sinon.stub(getter, 'getTokenPriceByIds');
+    const error = new Error('price lookup rejected');
+    lookup.onFirstCall().rejects(error);
+    lookup.onSecondCall().resolves([2]);
+    const results = await Promise.allSettled([
+      getter.getCoingeckoPrice('usd-coin'),
+      getter.getCoingeckoPrice('usd-coin'),
+    ]);
+    expect(results).to.deep.equal([
+      { status: 'rejected', reason: error },
+      { status: 'rejected', reason: error },
+    ]);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(2);
+    expect(lookup.callCount).to.equal(2);
+  });
+});

--- a/typescript/rebalancer/src/metrics/PriceGetter.ts
+++ b/typescript/rebalancer/src/metrics/PriceGetter.ts
@@ -9,6 +9,10 @@ import {
 
 export class PriceGetter extends CoinGeckoTokenPriceGetter {
   private readonly logger: Logger;
+  private readonly pendingPrices = new Map<
+    string,
+    Promise<number | undefined>
+  >();
 
   private constructor({
     chainMetadata,
@@ -67,8 +71,19 @@ export class PriceGetter extends CoinGeckoTokenPriceGetter {
   }
 
   async getCoingeckoPrice(coingeckoId: string): Promise<number | undefined> {
-    const prices = await this.getTokenPriceByIds([coingeckoId]);
-    if (!prices) return undefined;
-    return prices[0];
+    const pending = this.pendingPrices.get(coingeckoId);
+    if (pending) return pending;
+
+    // Multiple route tokens can share an ID. Share only the active lookup;
+    // the SDK remains responsible for cache freshness and failed-price handling.
+    const request = this.getTokenPriceByIds([coingeckoId]).then(
+      (prices) => prices?.[0],
+    );
+    this.pendingPrices.set(coingeckoId, request);
+    try {
+      return await request;
+    } finally {
+      this.pendingPrices.delete(coingeckoId);
+    }
   }
 }

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -4,13 +4,17 @@ import { pino } from 'pino';
 import Sinon from 'sinon';
 
 import { EthJsonRpcBlockParameterTag } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import {
   DEFAULT_INTENT_TTL_MS,
   DEFAULT_MOVEMENT_STALENESS_MS,
   ExternalBridgeType,
 } from '../config/types.js';
-import type { ExplorerMessage } from '../utils/ExplorerClient.js';
+import {
+  ExplorerClient,
+  type ExplorerMessage,
+} from '../utils/ExplorerClient.js';
 
 import { ActionTracker, type ActionTrackerConfig } from './ActionTracker.js';
 import { InMemoryStore } from './store/InMemoryStore.js';
@@ -1522,6 +1526,66 @@ describe('ActionTracker', () => {
       mailboxStub.isDelivered.resolves(true);
 
       await tracker.syncRebalanceActions();
+
+      expect(mailboxStub.isDelivered.calledOnce).to.be.true;
+      const call = mailboxStub.isDelivered.firstCall;
+      expect(call.args[0]).to.equal('0xmsg1');
+
+      const updatedAction = await rebalanceActionStore.get('action-1');
+      expect(updatedAction?.status).to.equal('complete');
+    });
+
+    it('checks tracked delivery with the real Explorer client and no bridges', async () => {
+      const intent: RebalanceIntent = {
+        id: 'intent-1',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const action: RebalanceAction = {
+        id: 'action-1',
+        type: 'inventory_deposit',
+        status: 'in_progress',
+        intentId: 'intent-1',
+        messageId: '0xmsg1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await rebalanceIntentStore.save(intent);
+      await rebalanceActionStore.save(action);
+
+      config.bridges = [];
+      const fetchStub = Sinon.stub(globalThis, 'fetch').rejects(
+        new Error('unexpected HTTP'),
+      );
+      tracker = new ActionTracker(
+        transferStore,
+        rebalanceIntentStore,
+        rebalanceActionStore,
+        new ExplorerClient(
+          'https://explorer.test',
+          () => ProtocolType.Ethereum,
+        ),
+        core,
+        config,
+        testLogger,
+      );
+      mailboxStub.isDelivered.resolves(true);
+
+      try {
+        await tracker.syncRebalanceActions();
+        expect(fetchStub.called).to.be.false;
+      } finally {
+        fetchStub.restore();
+      }
 
       expect(mailboxStub.isDelivered.calledOnce).to.be.true;
       const call = mailboxStub.isDelivered.firstCall;

--- a/typescript/rebalancer/src/utils/ExplorerClient.test.ts
+++ b/typescript/rebalancer/src/utils/ExplorerClient.test.ts
@@ -157,6 +157,48 @@ describe('ExplorerClient', () => {
   });
 
   describe('getInflightRebalanceActions address encoding', () => {
+    it('skips empty bridge discovery and queries freshly for supplied bridges', async () => {
+      const client = new ExplorerClient(
+        'https://explorer.test',
+        () => ProtocolType.Ethereum,
+      );
+      const bridges: string[] = [];
+      const params = {
+        bridges,
+        routersByDomain: { 1: '0x1234567890abcdef1234567890abcdef12345678' },
+        rebalancerAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      };
+      fetchStub.rejects(new Error('offline'));
+      expect(
+        await client.getInflightRebalanceActions(params, testLogger),
+      ).to.deep.equal([]);
+      expect(fetchStub.called).to.be.false;
+      bridges.push('0x1234567890abcdef1234567890abcdef12345678');
+      await expect(
+        client.getInflightRebalanceActions(params, testLogger),
+      ).to.be.rejectedWith('offline');
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    it('preserves HTTP failures for nonempty bridge discovery', async () => {
+      const client = new ExplorerClient(
+        'https://explorer.test',
+        () => ProtocolType.Ethereum,
+      );
+      fetchStub.resolves(new Response('unavailable', { status: 503 }));
+      await expect(
+        client.getInflightRebalanceActions(
+          {
+            bridges: ['0x1234567890abcdef1234567890abcdef12345678'],
+            routersByDomain: {},
+            rebalancerAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+          },
+          testLogger,
+        ),
+      ).to.be.rejectedWith('Explorer query failed: 503');
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
     it('encodes mixed EVM+Solana routersByDomain in originTxRecipients', async () => {
       const evmAddr = '0x5a0e13290ec57f5e9031d01d03c6a40029cc24ea';
       const solAddr = 'E5rVV8zXwtc4TKGypCJvSBaYbgxa4XaYg5MS6N9QGdeo';

--- a/typescript/rebalancer/src/utils/ExplorerClient.ts
+++ b/typescript/rebalancer/src/utils/ExplorerClient.ts
@@ -337,6 +337,9 @@ export class ExplorerClient implements IExplorerClient {
       limit = 100,
     } = params;
 
+    // Both sender and recipient must belong to bridges; an empty set cannot match.
+    if (bridges.length === 0) return [];
+
     // Derive routers and domains from routersByDomain
     const routerEntries = Object.entries(routersByDomain);
     const domains = Object.keys(routersByDomain).map(Number);

--- a/typescript/rebalancer/src/utils/gasEstimation.test.ts
+++ b/typescript/rebalancer/src/utils/gasEstimation.test.ts
@@ -7,7 +7,10 @@ import type { ChainName, MultiProvider, Token } from '@hyperlane-xyz/sdk';
 import { TokenStandard } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
-import { calculateTransferCosts } from './gasEstimation.js';
+import {
+  calculateTransferCosts,
+  estimateTransferRemoteGas,
+} from './gasEstimation.js';
 
 const testLogger = pino({ level: 'silent' });
 
@@ -34,23 +37,113 @@ describe('calculateTransferCosts — Tron vs Sealevel protocol path', () => {
       getHypAdapter: Sinon.stub().returns(mockAdapter),
     } as unknown as Token;
 
+    const mockProvider = {
+      estimateGas: Sinon.stub().resolves(BigNumber.from(200000)),
+      getFeeData: Sinon.stub().resolves({
+        maxFeePerGas: BigNumber.from(10_000_000_000n),
+        gasPrice: BigNumber.from(10_000_000_000n),
+      }),
+    };
     const multiProvider = {
       getDomainId: Sinon.stub().returns(42161),
       getProtocol: Sinon.stub().returns(protocol),
-      getProvider: Sinon.stub().returns({
-        estimateGas: Sinon.stub().resolves(BigNumber.from(200000)),
-        getFeeData: Sinon.stub().resolves({
-          maxFeePerGas: BigNumber.from(10_000_000_000n),
-          gasPrice: BigNumber.from(10_000_000_000n),
-        }),
-      }),
+      getProvider: Sinon.stub().returns(mockProvider),
     } as unknown as MultiProvider;
 
     const getTokenForChain = Sinon.stub().returns(mockToken);
     const isNativeTokenStandard = Sinon.stub().returns(true);
 
-    return { multiProvider, getTokenForChain, isNativeTokenStandard };
+    return {
+      multiProvider,
+      getTokenForChain,
+      isNativeTokenStandard,
+      mockAdapter,
+      mockProvider,
+    };
   }
+
+  it('uses one quote consistently for EVM-native reservation and estimation', async () => {
+    const {
+      multiProvider,
+      getTokenForChain,
+      isNativeTokenStandard,
+      mockAdapter,
+    } = createMockDeps(ProtocolType.Ethereum);
+    mockAdapter.quoteTransferRemoteGas
+      .onSecondCall()
+      .rejects(new Error('duplicate quote'));
+    const result = await calculateTransferCosts(
+      'ethereum',
+      'arbitrum',
+      3_000_000_000_000_000n,
+      3_000_000_000_000_000n,
+      multiProvider,
+      {},
+      getTokenForChain,
+      '0xInventorySigner',
+      isNativeTokenStandard,
+      testLogger,
+    );
+    expect(mockAdapter.quoteTransferRemoteGas.callCount).to.equal(1);
+    expect(
+      mockAdapter.populateTransferRemoteTx.firstCall.args[0].interchainGas,
+    ).to.equal(result.gasQuote);
+    expect(result.igpCost).to.equal(1000n);
+    expect(result.gasCost).to.equal(2_200_000_000_000_000n);
+    expect(result.totalCost).to.equal(2_200_000_000_001_000n);
+    expect(result.maxTransferable).to.equal(799_999_999_999_000n);
+    expect(result.minViableTransfer).to.equal(4_400_000_000_002_000n);
+  });
+
+  it('retains the fallback gas reserve when estimation fails', async () => {
+    const {
+      multiProvider,
+      getTokenForChain,
+      isNativeTokenStandard,
+      mockAdapter,
+      mockProvider,
+    } = createMockDeps(ProtocolType.Ethereum);
+    mockProvider.estimateGas.rejects(new Error('estimate unavailable'));
+    const result = await calculateTransferCosts(
+      'ethereum',
+      'arbitrum',
+      10_000_000_000_000_000n,
+      5_000_000_000_000_000n,
+      multiProvider,
+      {},
+      getTokenForChain,
+      '0xInventorySigner',
+      isNativeTokenStandard,
+      testLogger,
+    );
+    expect(mockAdapter.quoteTransferRemoteGas.callCount).to.equal(1);
+    expect(result.gasCost).to.equal(3_300_000_000_000_000n);
+    expect(result.igpCost).to.equal(1000n);
+  });
+
+  it('still obtains a quote for standalone gas estimation', async () => {
+    const { multiProvider, getTokenForChain, mockAdapter } = createMockDeps(
+      ProtocolType.Ethereum,
+    );
+    const estimate = await estimateTransferRemoteGas(
+      'ethereum',
+      'arbitrum',
+      100n,
+      multiProvider,
+      {},
+      getTokenForChain,
+      '0xInventorySigner',
+      testLogger,
+    );
+    expect(estimate).to.equal(200000n);
+    expect(mockAdapter.quoteTransferRemoteGas.callCount).to.equal(1);
+    expect(mockAdapter.quoteTransferRemoteGas.firstCall.args[0]).to.deep.equal({
+      destination: 42161,
+      sender: '0xInventorySigner',
+      recipient: '0xInventorySigner',
+      amount: 100n,
+    });
+  });
 
   it('Tron origin (EVM-like) produces non-zero gasCost for native tokens', async () => {
     const { multiProvider, getTokenForChain, isNativeTokenStandard } =

--- a/typescript/rebalancer/src/utils/gasEstimation.ts
+++ b/typescript/rebalancer/src/utils/gasEstimation.ts
@@ -60,6 +60,7 @@ export interface TransferCostEstimate {
  * @param getTokenForChain - Function to get token for a chain
  * @param inventorySigner - Address of the inventory signer
  * @param logger - Logger instance
+ * @param providedGasQuote - Quote already obtained for this exact transfer-cost calculation
  * @returns Estimated gas limit for the transaction
  */
 export async function estimateTransferRemoteGas(
@@ -71,6 +72,7 @@ export async function estimateTransferRemoteGas(
   getTokenForChain: (chain: ChainName) => Token | undefined,
   inventorySigner: string,
   logger: Logger,
+  providedGasQuote?: InterchainGasQuote,
 ): Promise<bigint> {
   const originToken = getTokenForChain(originChain);
   if (!originToken) {
@@ -85,13 +87,16 @@ export async function estimateTransferRemoteGas(
     const destinationDomain = multiProvider.getDomainId(destinationChain);
     const adapter = originToken.getHypAdapter(warpCoreMultiProvider);
 
-    // Quote the IGP gas first (needed for the full transaction)
-    const gasQuote = await adapter.quoteTransferRemoteGas({
-      destination: destinationDomain,
-      sender: inventorySigner,
-      recipient: inventorySigner,
-      amount,
-    });
+    // Reuse the quote from this cost calculation when supplied; standalone
+    // estimation still obtains a fresh quote for its own transfer parameters.
+    const gasQuote =
+      providedGasQuote ??
+      (await adapter.quoteTransferRemoteGas({
+        destination: destinationDomain,
+        sender: inventorySigner,
+        recipient: inventorySigner,
+        amount,
+      }));
 
     // Populate with minimal amount for gas estimation
     // Gas cost is independent of transfer size (just a require check in _transferFromSender),
@@ -251,6 +256,7 @@ export async function calculateTransferCosts(
     getTokenForChain,
     inventorySigner,
     logger,
+    gasQuote,
   );
   const bufferedGasLimit = addBufferToGasLimit(
     BigNumber.from(estimatedGasLimit.toString()),


### PR DESCRIPTION
## Problem

Concurrent metrics callers repeated same-feed price requests, native execution costing requested the same adapter gas quote twice, unused LiFi dependencies loaded at startup, and empty bridge configurations still queried discovery.

## Solution

Share only pending same-feed price requests; reuse the gas quote inside one cost calculation; initialize LiFi only when configured; and return immediately when bridge discovery has no bridges. Preserve cache freshness, failure retries, execution calculations and nonempty discovery behavior. Shared image packaging is a separate child PR #9497.

Consolidates #9465, #9474, #9483, #9507. Earlier PRs retain their original descriptions and detailed benchmark references.

## Performance evidence

| Component | Evidence and scope |
| --- | --- |
| coalesce concurrent token price lookups | 12 → 1 mocked HTTP requests (91.7% fewer) |
| reuse gas quote within cost estimation | EVM-native cost calculation: 2 → 1 adapter gas-quote calls. Underlying RPC/latency savings unmeasured; conditional execution path. |
| load LiFi only when configured | Local unbundled factory import: 1,484.18 → 1,356.74 ms; LiFi module loads 122 → 0 when unused. Configurations needing LiFi still pay initialization cost. |
| skip empty bridge discovery queries | Empty bridge discovery: 1 → 0 HTTP requests/invocation. Verified empty live configuration + 60 sync events/hour models 60 avoided requests/hour, plus startup. |

These measurements describe separate workloads and scopes. Percentages must not be added; local or modeled results are not deployed speedups. The individual benchmark artifacts remain in this branch.

## Validation

The four runtime changes were regrouped without changing runtime/package/test source; only the shared Docker packaging layer moves into child #9497. Rebalancer build and lint passed, as did five packaging tests. The default local test run passed 393 tests but hit the unchanged LiFi cold-import test's 2-second timeout; all 394 tests then passed with a 10-second harness timeout (`pnpm -C typescript/rebalancer test --timeout 10000`). No source or test timeout was changed during consolidation. The runtime group merges cleanly with main. Applying #9497 produces a Git tree exactly equal to the former final #9507 tree, preserving all source, tests, changesets and benchmark artifacts. Existing independent review and regression evidence remain applicable; consolidation includes a separate review of grouping and tree parity.

No runtime behavior was added during consolidation. The PR remains a draft.

Reproduction: [lazy LiFi benchmark](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/63b67961f8e3a7cdc87a7b4d1b7a5ca870e0a016/typescript/rebalancer/docs/performance/lazy-lifi.md).
