### PR TITLE
perf(lander): move transaction batches and borrow status query inputs

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -172,10 +172,17 @@ impl FinalityStage {
             buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY).boxed()
         } else {
             let status_batch_concurrency = STATUS_READ_CONCURRENCY.div_ceil(status_batch_size);
-            let status_batches = pool_snapshot
-                .chunks(status_batch_size)
-                .map(<[Transaction]>::to_vec)
+            let batch_count = pool_snapshot.len().div_ceil(status_batch_size);
+            let mut remaining_txs = pool_snapshot.into_iter();
+            let status_batches = (0..batch_count)
+                .map(|_| {
+                    remaining_txs
+                        .by_ref()
+                        .take(status_batch_size)
+                        .collect::<Vec<_>>()
+                })
                 .collect::<Vec<_>>();
+            drop(remaining_txs);
             let status_reads = status_batches.into_iter().map(|batch| {
                 read_transaction_status_batch(state, batch, FinalizedStatusRead::TrustPersisted)
             });

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -206,10 +206,17 @@ impl InclusionStage {
             .tx_status_batch_size()
             .clamp(1, STATUS_READ_CONCURRENCY);
         let status_batch_concurrency = STATUS_READ_CONCURRENCY.div_ceil(status_batch_size);
-        let status_batches = eligible_txs
-            .chunks(status_batch_size)
-            .map(<[Transaction]>::to_vec)
+        let batch_count = eligible_txs.len().div_ceil(status_batch_size);
+        let mut remaining_txs = eligible_txs.into_iter();
+        let status_batches = (0..batch_count)
+            .map(|_| {
+                remaining_txs
+                    .by_ref()
+                    .take(status_batch_size)
+                    .collect::<Vec<_>>()
+            })
             .collect::<Vec<_>>();
+        drop(remaining_txs);
         let status_reads = status_batches
             .into_iter()
             .map(|batch| read_transaction_status_batch(state, batch, FinalizedStatusRead::Query));

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::{future::Future, time::Duration};
 
 use futures_util::{stream, Stream, StreamExt};
@@ -53,7 +54,6 @@ pub(super) async fn read_transaction_status_batch(
     for tx in &mut checked_txs {
         tx.last_status_check = Some(checked_at);
     }
-    let mut query_txs = Vec::new();
     let status_slots = checked_txs
         .iter()
         .map(|tx| {
@@ -62,11 +62,24 @@ pub(super) async fn read_transaction_status_batch(
             {
                 Some(Ok(TransactionStatus::Finalized))
             } else {
-                query_txs.push(tx.clone());
                 None
             }
         })
         .collect::<Vec<_>>();
+    // Most batches query every transaction. Borrow their checked copies; only
+    // mixed/finalized batches need a separate filtered, owned query buffer.
+    let query_txs: Cow<'_, [Transaction]> = if status_slots.iter().any(Option::is_some) {
+        Cow::Owned(
+            checked_txs
+                .iter()
+                .zip(&status_slots)
+                .filter(|(_, status)| status.is_none())
+                .map(|(tx, _)| tx.clone())
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(&checked_txs)
+    };
     let queried_statuses = state.adapter.tx_statuses(&query_txs).await;
     assert_eq!(
         queried_statuses.len(),
@@ -285,3 +298,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod status_batch_tests;

--- a/rust/main/lander/src/dispatcher/stages/utils/status_batch_tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils/status_batch_tests.rs
@@ -1,0 +1,221 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::Semaphore;
+
+use crate::adapter::{AdaptsChain, GasLimit, TxBuildingResult};
+use crate::dispatcher::{DispatcherMetrics, DispatcherState};
+use crate::tests::test_utils::{dummy_tx, tmp_dbs};
+use crate::transaction::{Transaction, TransactionStatus, TransactionUuid};
+use crate::{FullPayload, LanderError};
+use hyperlane_core::H512;
+
+use super::{read_transaction_status_batch, FinalizedStatusRead};
+
+#[derive(Default)]
+struct BatchAdapter {
+    calls: Mutex<Vec<Vec<(TransactionUuid, usize)>>>,
+    gate: Option<Arc<Semaphore>>,
+    wrong_count: bool,
+}
+
+#[async_trait]
+impl AdaptsChain for BatchAdapter {
+    async fn estimate_gas_limit(&self, _: &FullPayload) -> Result<Option<GasLimit>, LanderError> {
+        unimplemented!()
+    }
+    async fn build_transactions(&self, _: &[FullPayload]) -> Vec<TxBuildingResult> {
+        unimplemented!()
+    }
+    async fn estimate_tx(&self, _: &mut Transaction) -> Result<(), LanderError> {
+        unimplemented!()
+    }
+    async fn submit(&self, _: &mut Transaction) -> Result<(), LanderError> {
+        unimplemented!()
+    }
+    async fn get_tx_hash_status(&self, _: H512) -> Result<TransactionStatus, LanderError> {
+        unimplemented!()
+    }
+    fn estimated_block_time(&self) -> &Duration {
+        unimplemented!()
+    }
+    fn update_vm_specific_metrics(&self, _: &Transaction, _: &DispatcherMetrics) {
+        unimplemented!()
+    }
+    async fn tx_statuses(
+        &self,
+        txs: &[Transaction],
+    ) -> Vec<Result<TransactionStatus, LanderError>> {
+        self.calls.lock().unwrap().push(
+            txs.iter()
+                .map(|tx| (tx.uuid.clone(), buffer_pointer(tx)))
+                .collect(),
+        );
+        if let Some(gate) = &self.gate {
+            gate.acquire().await.unwrap().forget();
+        }
+        if self.wrong_count {
+            return vec![];
+        }
+        txs.iter()
+            .enumerate()
+            .map(|(index, _)| {
+                if index == 0 {
+                    Err(LanderError::NetworkError("read failed".to_owned()))
+                } else {
+                    Ok(TransactionStatus::Mempool)
+                }
+            })
+            .collect()
+    }
+}
+
+fn buffer_pointer(tx: &Transaction) -> usize {
+    tx.payload_details[0]
+        .success_criteria
+        .as_ref()
+        .unwrap()
+        .as_ptr() as usize
+}
+
+fn fixture(status: TransactionStatus) -> Transaction {
+    let mut payload = FullPayload::default();
+    payload.details.success_criteria = Some(vec![7; 4096]);
+    payload.details.metadata = "status allocation fixture".to_owned();
+    dummy_tx(vec![payload], status)
+}
+
+fn state(adapter: Arc<BatchAdapter>) -> DispatcherState {
+    let (payload_db, tx_db, _) = tmp_dbs();
+    DispatcherState::new(
+        payload_db,
+        tx_db,
+        adapter,
+        DispatcherMetrics::dummy_instance(),
+        "test".to_owned(),
+    )
+}
+
+#[tokio::test]
+async fn status_batch_preserves_selection_snapshots_errors_and_borrowing() {
+    for (policy, statuses) in [
+        (FinalizedStatusRead::Query, vec![]),
+        (
+            FinalizedStatusRead::Query,
+            vec![
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Finalized,
+                TransactionStatus::Included,
+            ],
+        ),
+        (
+            FinalizedStatusRead::TrustPersisted,
+            vec![
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Included,
+            ],
+        ),
+        (
+            FinalizedStatusRead::TrustPersisted,
+            vec![
+                TransactionStatus::Finalized,
+                TransactionStatus::PendingInclusion,
+                TransactionStatus::Included,
+                TransactionStatus::Finalized,
+            ],
+        ),
+        (
+            FinalizedStatusRead::TrustPersisted,
+            vec![TransactionStatus::Finalized, TransactionStatus::Finalized],
+        ),
+    ] {
+        let originals: Vec<_> = statuses.into_iter().map(fixture).collect();
+        let input = originals.clone();
+        let input_pointers: Vec<_> = input.iter().map(buffer_pointer).collect();
+        let queries: Vec<_> = originals
+            .iter()
+            .filter(|tx| {
+                !matches!(policy, FinalizedStatusRead::TrustPersisted)
+                    || tx.status != TransactionStatus::Finalized
+            })
+            .map(|tx| tx.uuid.clone())
+            .collect();
+        let adapter = Arc::new(BatchAdapter::default());
+        let result = read_transaction_status_batch(&state(adapter.clone()), input, policy).await;
+        let calls = adapter.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1); // Even an empty/all-trusted batch calls the adapter.
+        assert_eq!(
+            calls[0]
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect::<Vec<_>>(),
+            queries
+        );
+        assert_eq!(result.len(), originals.len());
+        for (index, (snapshot, checked, status)) in result.iter().enumerate() {
+            assert_eq!(snapshot, &originals[index]);
+            assert_eq!(buffer_pointer(snapshot), input_pointers[index]);
+            assert_ne!(buffer_pointer(snapshot), buffer_pointer(checked));
+            assert!(checked.last_status_check.is_some());
+            let mut expected_checked = snapshot.clone();
+            expected_checked.last_status_check = checked.last_status_check;
+            assert_eq!(checked, &expected_checked);
+            if let Some(query_index) = queries.iter().position(|id| id == &snapshot.uuid) {
+                if queries.len() == originals.len() {
+                    assert_eq!(calls[0][query_index].1, buffer_pointer(checked));
+                } else {
+                    assert_ne!(calls[0][query_index].1, buffer_pointer(checked));
+                }
+                if query_index == 0 {
+                    assert!(matches!(status, Err(LanderError::NetworkError(_))));
+                } else {
+                    assert!(matches!(status, Ok(TransactionStatus::Mempool)));
+                }
+            } else {
+                assert!(matches!(status, Ok(TransactionStatus::Finalized)));
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "adapter returned a mismatched transaction status count")]
+async fn status_batch_rejects_mismatched_adapter_result_count() {
+    let adapter = Arc::new(BatchAdapter {
+        wrong_count: true,
+        ..Default::default()
+    });
+    read_transaction_status_batch(
+        &state(adapter),
+        vec![fixture(TransactionStatus::Included)],
+        FinalizedStatusRead::Query,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn cancelling_status_batch_keeps_the_original_snapshot_unchanged() {
+    let adapter = Arc::new(BatchAdapter {
+        gate: Some(Arc::new(Semaphore::new(0))),
+        ..Default::default()
+    });
+    let state = state(adapter.clone());
+    let original = fixture(TransactionStatus::Included);
+    let snapshot = original.clone();
+    let task = tokio::spawn(async move {
+        read_transaction_status_batch(&state, vec![snapshot], FinalizedStatusRead::Query).await
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while adapter.calls.lock().unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("status query should enter the adapter");
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(adapter.calls.lock().unwrap().len(), 1);
+    assert_eq!(original.status, TransactionStatus::Included);
+    assert!(original.last_status_check.is_none());
+}


### PR DESCRIPTION
Consolidated into #9496 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stack: follows #9501 on the relayer stack.

## Problem

Lander inclusion and batched finality status checks clone owned transaction snapshots into batches, then clone every queried transaction again before calling the adapter. These copies include retained payload details and are discarded after the read. The original-versus-checked snapshot copy is still required for stale-update protection.

## Solution

Move snapshots into exact-size owned batches. Borrow the checked transaction slice when every transaction needs a status query; retain the filtered owned query buffer when persisted finality excludes transactions. Preserve the original snapshot copy, configured batching/concurrency, query order, timestamps, error alignment, and empty adapter calls.

This builds on existing status RPC batching (#9429); it changes local ownership only.

## Numerical evidence

Synthetic allocation probe using actual Lander `Transaction` values, 16 transactions per batch with 4 KiB retained success criteria:

| Fixture / query selection | Allocation calls before → after | Total requested bytes before → after |
| --- | ---: | ---: |
| CosmWasm / all queried | 150 → 51 | 208,920 → 71,384 |
| CosmWasm / half trusted finalized | 125 → 77 | 173,240 → 106,488 |
| CosmWasm / all trusted finalized | 99 → 51 | 138,136 → 71,384 |
| EVM / all queried | 246 → 83 | 228,744 → 77,992 |

The probe models only the changed batch/query ownership portions: common initial input cloning is outside measurement; the required checked-snapshot clone remains inside. Status slots, result assembly, timestamps, adapter/RPC work are excluded. EVM fixtures also retain real calldata with its existing clone behavior. These are allocator traffic measurements, not latency, RSS, or fleet savings. All 18 sampled cases (32 B, 4 KiB, 64 KiB; two transaction variants; three query selections) reduced allocation calls and requested bytes.

## Validation

- 56 dispatcher stage tests passed, including existing ordered/bounded read and stale-update regressions.
- Added selection, snapshot identity/timestamp separation, borrowed versus filtered query pointers, per-result error ordering, empty/all-finalized calls, mismatched-result rejection, and bounded cancellation tests.
- Independent source and fixture review; strict production Lander Clippy passed; normal commit hooks passed.
