### PR TITLE
perf(scraper): compact transaction enrichment maps

### DIFF
--- a/rust/main/agents/scraper/src/store/deliveries.rs
+++ b/rust/main/agents/scraper/src/store/deliveries.rs
@@ -8,7 +8,7 @@ use hyperlane_core::{
 };
 
 use crate::db::StorableDelivery;
-use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore, TxnWithId};
+use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore};
 
 #[async_trait]
 impl HyperlaneLogStore<Delivery> for HyperlaneDbStore {
@@ -21,10 +21,9 @@ impl HyperlaneLogStore<Delivery> for HyperlaneDbStore {
         if deliveries.is_empty() {
             return Ok(0);
         }
-        let txns: HashMap<H512, TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(deliveries.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         let storable = deliveries
             .iter()

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -10,7 +10,7 @@ use time::OffsetDateTime;
 use tracing::warn;
 
 use crate::db::{StorableMessage, StorableRawMessageDispatch};
-use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore, TxnWithId};
+use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore};
 
 /// Label for raw message dispatch metrics
 const RAW_MESSAGE_DISPATCH_LABEL: &str = "raw_message_dispatch";
@@ -116,10 +116,9 @@ impl HyperlaneDbStore {
         &self,
         messages: &[(Indexed<HyperlaneMessage>, LogMeta)],
     ) -> Result<u32> {
-        let txns: HashMap<H512, TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(messages.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         let (storable, missing_txns) = storable_messages_for_available_txns(messages, &txns);
         let stored = self
@@ -196,10 +195,9 @@ impl HyperlaneDbStore {
             });
         }
 
-        let txns: HashMap<H512, TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(raw_dispatches_to_attempt.iter().map(|r| &r.meta))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
 
         let mut missing_tx_hashes = Vec::new();
@@ -285,7 +283,7 @@ struct MissingDispatchTxns {
 
 fn storable_messages_for_available_txns<'a>(
     messages: &'a [(Indexed<HyperlaneMessage>, LogMeta)],
-    txns: &HashMap<H512, TxnWithId>,
+    txns: &HashMap<H512, i64>,
 ) -> (Vec<StorableMessage<'a>>, Option<MissingDispatchTxns>) {
     let mut missing_dispatches: usize = 0;
     let mut missing_tx_hashes = Vec::new();
@@ -360,13 +358,7 @@ mod tests {
             (indexed_message(0), log_meta(txn_hash)),
             (indexed_message(1), log_meta(txn_hash)),
         ];
-        let txns = HashMap::from([(
-            txn_hash,
-            TxnWithId {
-                hash: txn_hash,
-                id: 7,
-            },
-        )]);
+        let txns = HashMap::from([(txn_hash, 7)]);
 
         let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 
@@ -385,22 +377,7 @@ mod tests {
             (indexed_message(1), log_meta(missing_txn_hash)),
             (indexed_message(2), log_meta(later_found_txn_hash)),
         ];
-        let txns = HashMap::from([
-            (
-                found_txn_hash,
-                TxnWithId {
-                    hash: found_txn_hash,
-                    id: 7,
-                },
-            ),
-            (
-                later_found_txn_hash,
-                TxnWithId {
-                    hash: later_found_txn_hash,
-                    id: 8,
-                },
-            ),
-        ]);
+        let txns = HashMap::from([(found_txn_hash, 7), (later_found_txn_hash, 8)]);
 
         let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 

--- a/rust/main/agents/scraper/src/store/payments.rs
+++ b/rust/main/agents/scraper/src/store/payments.rs
@@ -27,10 +27,9 @@ impl HyperlaneLogStore<InterchainGasPayment> for HyperlaneDbStore {
         if payments.is_empty() {
             return Ok(0);
         }
-        let txns: HashMap<H512, crate::store::storage::TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(payments.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         let storable = payments
             .iter()

--- a/rust/main/agents/scraper/src/store/same_chain_ccr_swaps.rs
+++ b/rust/main/agents/scraper/src/store/same_chain_ccr_swaps.rs
@@ -15,10 +15,9 @@ impl HyperlaneLogStore<SameChainCcrSwap> for HyperlaneDbStore {
         if swaps.is_empty() {
             return Ok(0);
         }
-        let txns: HashMap<H512, crate::store::storage::TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(swaps.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
 
         // filter_map mirrors the dispatch/payment store_logs pattern: if
@@ -38,7 +37,7 @@ impl HyperlaneLogStore<SameChainCcrSwap> for HyperlaneDbStore {
                 txn.map(|t| StorableCcrSwap {
                     swap: swap.inner(),
                     meta,
-                    txn_id: t.id,
+                    txn_id: *t,
                 })
             })
             .collect();

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -82,7 +82,7 @@ impl HyperlaneDbStore {
     pub(crate) async fn ensure_blocks_and_txns(
         &self,
         log_meta: impl Iterator<Item = &LogMeta>,
-    ) -> Result<impl Iterator<Item = TxnWithId>> {
+    ) -> Result<impl Iterator<Item = (H512, i64)>> {
         let block_id_by_txn_hash: HashMap<H512, BlockId> = log_meta
             .filter(|meta| !meta.transaction_id.is_zero() && !meta.block_hash.is_zero())
             .map(|meta| {
@@ -123,7 +123,7 @@ impl HyperlaneDbStore {
     async fn ensure_txns(
         &self,
         txns: impl Iterator<Item = TxnWithBlockId>,
-    ) -> Result<impl Iterator<Item = TxnWithId>> {
+    ) -> Result<impl Iterator<Item = (H512, i64)>> {
         // mapping of txn hash to (txn_id, block_id).
         let mut txns: HashMap<H512, (Option<i64>, i64)> = txns
             .map(|TxnWithBlockId { txn_hash, block_id }| (txn_hash, (None, block_id)))
@@ -183,8 +183,7 @@ impl HyperlaneDbStore {
 
         let ensured_txns = txns
             .into_iter()
-            .filter_map(|(hash, (txn_id, _))| txn_id.map(|id| (hash, id)))
-            .map(|(hash, id)| TxnWithId { hash, id });
+            .filter_map(|(hash, (txn_id, _))| txn_id.map(|id| (hash, id)));
 
         Ok(ensured_txns)
     }
@@ -299,12 +298,6 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct TxnWithId {
-    pub hash: H512,
-    pub id: i64,
-}
-
 /// Resolves the database transaction id for a log's meta.
 ///
 /// - `Some(Some(id))` when the transaction was ensured in the database.
@@ -314,14 +307,11 @@ pub(crate) struct TxnWithId {
 ///   a NULL transaction relation so it remains retrievable by sequence.
 /// - `None` when the transaction could not be fetched; the event is skipped
 ///   and retried later.
-pub(crate) fn txn_id_for_meta(
-    txns: &HashMap<H512, TxnWithId>,
-    meta: &LogMeta,
-) -> Option<Option<i64>> {
+pub(crate) fn txn_id_for_meta(txns: &HashMap<H512, i64>, meta: &LogMeta) -> Option<Option<i64>> {
     if meta.transaction_id.is_zero() && meta.block_hash.is_zero() {
         Some(None)
     } else {
-        txns.get(&meta.transaction_id).map(|txn| Some(txn.id))
+        txns.get(&meta.transaction_id).copied().map(Some)
     }
 }
 

--- a/rust/main/agents/scraper/src/store/tests.rs
+++ b/rust/main/agents/scraper/src/store/tests.rs
@@ -24,10 +24,7 @@ use crate::db::{
     StorableTxn,
 };
 
-use super::{
-    storage::{txn_id_for_meta, TxnWithId},
-    HyperlaneDbStore,
-};
+use super::{storage::txn_id_for_meta, HyperlaneDbStore};
 
 /// Domain id seeded by the domain table migration (`sealeveltest1`).
 const TEST_DOMAIN_ID: u32 = 13375;
@@ -306,13 +303,7 @@ fn null_transaction_relation_requires_exact_fallback_sentinel() {
         block_hash: H256::from_low_u64_be(1),
         ..fallback
     };
-    let txns = HashMap::from([(
-        tx_hash,
-        TxnWithId {
-            hash: tx_hash,
-            id: 7,
-        },
-    )]);
+    let txns = HashMap::from([(tx_hash, 7)]);
     assert_eq!(txn_id_for_meta(&txns, &resolved), Some(Some(7)));
 }
 


### PR DESCRIPTION
Consolidated into #9468 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stacked on #9506; review the child diff.

## Problem

Five scraper enrichment consumers collect transactions into `HashMap<H512, TxnWithId>`. Every value repeats the same 64-byte transaction hash already stored as its key, although consumers only read the database ID. The redundant hash increases the temporary map's allocation traffic and retained entry size.

## Solution

Return `(H512, i64)` entries directly from transaction enrichment and collect `HashMap<H512, i64>` in dispatch, raw reconciliation, delivery, payment and same-chain swap consumers. Remove the private `TxnWithId` type. Preserve missing-transaction filtering and the exact zero-hash sentinel that permits NULL transaction metadata.

## Numerical impact

Measured local 64-bit Rust key/value layout: **136 → 72 bytes**, removing **64 bytes per logical entry (47.1%)**.

A synthetic counting-allocator probe uses the actual core H512 type, the previous TxnWithId definition and collection pipelines with the same filter iterator size hints:

| Input entries / distinct hashes | Requested allocation bytes before → after | Allocation calls before → after |
| --- | --- | --- |
| 1,000 / 1,000 | 560,684 → 298,796 | 10 → 10 |
| 100,000 / 100,000 | 35,913,308 → 19,136,348 | 16 → 16 |
| 1,000 / 10 | 3,860 → 2,068 | 3 → 3 |
| 100,000 / 100 | 34,572 → 18,444 | 6 → 6 |

Map capacities and resulting hash-to-ID mappings match. Requested bytes include intermediate table growth allocations, not retained memory or RSS. The duplicate cases test overwrite equivalence; actual enrichment already deduplicates its output. RPCs, SQL queries and retained upstream maps are unchanged. No measured CPU, latency or fleet-memory percentage is claimed.

## Verification

- Existing tests cover multiple messages sharing a transaction, a missing transaction followed by a resolved transaction, and exact NULL-metadata sentinel behavior.
- Full scraper suite: **57 passed, 0 failed, 1 existing ignored**; includes actual PostgreSQL fallback/restart and resolved-metadata replay tests. Strict production scraper Clippy passed.
- Root self-review and independent validator/relayer source reviews found no blockers. Normal commit hooks passed.
- The excluded #9449 retry optimization intersects the raw reconciliation caller mechanically; its retry/query behavior is unchanged and this removes no acquisition work.
- No production writes.
