### PR TITLE
perf(scraper-proxy): reuse query normalization and cache metadata

### DIFF
--- a/typescript/scraper-proxy/benchmarks/README.md
+++ b/typescript/scraper-proxy/benchmarks/README.md
@@ -1,0 +1,36 @@
+# Cached GraphQL request benchmark
+
+`src/scripts/benchmark-cache-plugin.ts` exercises request normalization and Apollo execution with the production validation rule. Queries use one root field, no aliases and 50 or 250 total fields; both sizes are within production limits. Each variant warms 100 requests and times 1,000 cache hits, three times. Every result is checked and the resolver must execute exactly once per server.
+
+This is synthetic cached-request processing on Node 24.13.0, without HTTP transport, a database, realistic result sizes or concurrent clients. It does not measure deployed request latency or service capacity.
+
+## Reproduce
+
+After a frozen workspace install and building scraper-proxy dependencies, run from this package directory:
+
+```sh
+pnpm exec tsx src/scripts/benchmark-cache-plugin.ts
+```
+
+To compare the implementation before this change, temporarily place its module alongside its relative imports:
+
+```sh
+git show 58e16ce8:typescript/scraper-proxy/src/scraperdb/cache-plugin.ts > src/scraperdb/cache-plugin.benchmark-baseline.ts
+pnpm exec tsx src/scripts/benchmark-cache-plugin.ts src/scraperdb/cache-plugin.benchmark-baseline.ts
+rm src/scraperdb/cache-plugin.benchmark-baseline.ts
+```
+
+The optional argument loads a trusted local benchmark module. No production service imports this script.
+
+## Local measurements, 2026-09-05
+
+Elapsed milliseconds per 1,000 requests, including identical response assertions:
+
+| Total fields | Baseline runs          | Current runs           | Median reduction |
+| ------------ | ---------------------- | ---------------------- | ---------------- |
+| 50           | 205.30, 201.63, 200.37 | 79.05, 77.19, 74.89    | 61.7%            |
+| 250          | 816.16, 802.76, 813.01 | 298.48, 301.19, 300.61 | 63.0%            |
+
+The deterministic change is two cache-key reparses and two prints per reused document/request becoming zero after the first document preparation. Request normalization still parses/prints each request; variables still sort/serialize and hash on every request. Result-cache TTL, refresh and size limits remain unchanged.
+
+The WeakMap adds a normalized query string and used-variable set per reachable cached document. Entries become collectible with their documents, instead of retaining every query ever seen. Production document-cache eviction and result-cache hit rate determine the benefit; neither was measured here.

--- a/typescript/scraper-proxy/docs/performance/2026-09-05-query-normalization/README.md
+++ b/typescript/scraper-proxy/docs/performance/2026-09-05-query-normalization/README.md
@@ -1,0 +1,42 @@
+# GraphQL query normalization cache
+
+## Problem
+
+HTTP compatibility middleware calls `stripUnusedVariableDefinitions` before Apollo handles each request. Repeated query text is parsed, visited and printed even when Apollo's document and response caches are warm. The earlier cache-plugin metadata optimization does not cover this middleware work.
+
+## Solution
+
+Cache exact query text to its normalized text. Keep 64 entries in access order, each with at most 8,192 combined input/output UTF-16 code units: at most 1 MiB of string content, excluding object/Map overhead. Parse failures and oversized pairs are not cached. Cache misses use the unchanged parser/visitor/printer.
+
+Variables, operation names, authentication, database rows and responses are not cached here. Existing multi-operation normalization behavior, validation, response TTL, refresh requests and error handling remain unchanged.
+
+## Performance evidence
+
+Local Node 24.13.0, one process, four alternating parent/head pairs per case, 100 warmups and 1,000 measured requests per variant. The harness runs the actual compatibility function and Apollo execution with the existing response-cache plugin and validation rule. It asserts identical complete response data, no errors and one resolver call per server. HTTP, database I/O and profiler instrumentation are excluded.
+
+| Fields | Query text workload      | Parent median / 1,000 | Head median / 1,000 |
+| ------ | ------------------------ | --------------------: | ------------------: |
+| 50     | Eight repeated texts     |              80.93 ms |            14.02 ms |
+| 250    | Eight repeated texts     |             333.94 ms |            54.04 ms |
+| 50     | Fresh text every request |              79.37 ms |            81.67 ms |
+| 250    | Fresh text every request |             327.60 ms |           330.36 ms |
+
+Repeated-text cases take **82.7% and 83.8% less local processing elapsed time**. Fresh-text controls show **2.9% and 0.8% overhead**, not a speedup. The text variants differ in comments and normalize to the same document; repeated mode cycles through eight exact inputs, while fresh mode never reuses an input. Field counts include the root field and stay within existing validation limits.
+
+These are synthetic request traces, not measured production hit rates or end-to-end latency improvements. Existing service activity establishes that the middleware runs, but no live query-text repetition denominator was measured. Full samples are in `results.json`.
+
+## Reproduction
+
+From this checkout, with its locked dependencies and built dependencies available:
+
+```sh
+mkdir -p typescript/scraper-proxy/dist
+git show a4c4943e9781f1722f65f9e3818ac1dc0968d332:typescript/scraper-proxy/src/scraperdb/request-compatibility.ts > typescript/scraper-proxy/dist/request-compatibility.baseline.ts
+pnpm --filter @hyperlane-xyz/scraper-proxy exec tsx src/scripts/benchmark-query-normalization.ts dist/request-compatibility.baseline.ts
+```
+
+The baseline compatibility file has only a GraphQL dependency, so both variants use the identical installed parser and current Apollo/cache-plugin code. No network or database fixture is needed.
+
+## Validation
+
+All 70 scraper-proxy tests passed. Focused cache cases verify parser work reuse, LRU eviction, batch/non-string inputs, variable/operation independence, malformed inputs, oversized source text, and combined input/output size rejection. Build, lint and changed-file formatting passed. Independent source review found no blockers.

--- a/typescript/scraper-proxy/docs/performance/2026-09-05-query-normalization/results.json
+++ b/typescript/scraper-proxy/docs/performance/2026-09-05-query-normalization/results.json
@@ -1,0 +1,266 @@
+{
+  "node": "v24.13.0",
+  "parent": "a4c4943e9781f1722f65f9e3818ac1dc0968d332",
+  "warmupsPerVariant": 100,
+  "timedRequestsPerVariant": 1000,
+  "processes": 1,
+  "pairedRuns": 4,
+  "results": [
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 85.27224999999999
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 15.221042000000011
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 13.948333999999988
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 80.60225000000003
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 81.260625
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 13.672208999999953
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 14.081958999999983
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "repeated",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 79.20791700000007
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 77.13662499999998
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 79.11799999999994
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 77.94570800000008
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 80.56287499999985
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 78.18641700000012
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 84.2233749999998
+    },
+    {
+      "name": "current",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 84.40770799999996
+    },
+    {
+      "name": "baseline",
+      "fields": 50,
+      "workload": "fresh",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 81.64654100000007
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 325.33529099999987
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 51.98945800000001
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 54.30120799999986
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 334.160167
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 333.71670900000026
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 53.784917000000405
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 54.295624999999745
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "repeated",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 340.2998329999996
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 334.0277920000003
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 0,
+      "requests": 1000,
+      "elapsedMs": 331.88862500000005
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 339.64262499999995
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 1,
+      "requests": 1000,
+      "elapsedMs": 337.16349999999966
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 321.176375
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 2,
+      "requests": 1000,
+      "elapsedMs": 328.830833
+    },
+    {
+      "name": "current",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 325.5854169999993
+    },
+    {
+      "name": "baseline",
+      "fields": 250,
+      "workload": "fresh",
+      "run": 3,
+      "requests": 1000,
+      "elapsedMs": 314.62545800000044
+    }
+  ]
+}

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.test.ts
@@ -228,3 +228,48 @@ async function cachedValue(server: ApolloServer, key: number): Promise<void> {
     variables: { key },
   });
 }
+
+void it('keeps variables and refresh dynamic when reusing a parsed document', async () => {
+  let calls = 0;
+  const server = cacheServer(() => ++calls, 'Int!');
+  await server.start();
+  try {
+    const query =
+      'query($key: Int!, $ttl: Int!, $refresh: Boolean!) @cached(ttl: $ttl, refresh: $refresh) { value(key: $key) }';
+    const request = (key: number, ttl = 10, refresh = false) =>
+      server.executeOperation({
+        query,
+        variables: { key, ttl, refresh },
+      });
+    assert.equal(value(await request(1)), 1);
+    assert.equal(value(await request(2)), 2);
+    assert.equal(value(await request(1, 20)), 1);
+    assert.equal(value(await request(1, 20, true)), 3);
+    assert.equal(value(await request(1)), 3);
+    assert.equal(value(await request(2)), 2);
+    assert.equal(calls, 3);
+  } finally {
+    await server.stop();
+  }
+});
+
+void it('separates named operations in the same reusable document', async () => {
+  let calls = 0;
+  const server = cacheServer(() => ++calls, 'Int!');
+  await server.start();
+  try {
+    const query = `
+      query First($key: Int!) @cached(ttl: 10) { value(key: $key) }
+      query Second($key: Int!) @cached(ttl: 10) { value(key: $key) }
+    `;
+    const request = (operationName: string) =>
+      server.executeOperation({ query, operationName, variables: { key: 1 } });
+    assert.equal(value(await request('First')), 1);
+    assert.equal(value(await request('Second')), 2);
+    assert.equal(value(await request('First')), 1);
+    assert.equal(value(await request('Second')), 2);
+    assert.equal(calls, 2);
+  } finally {
+    await server.stop();
+  }
+});

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
@@ -18,9 +18,13 @@ const MAX_ENTRIES = 1_000;
 const MAX_ENTRY_BYTES = 1_000_000;
 const MAX_TOTAL_BYTES = 16_000_000;
 type Entry = { body: string; bytes: number; expires: number };
+type CacheDocument = { query: string; usedVariables: ReadonlySet<string> };
 
 export function scraperDbCachePlugin(): ApolloServerPlugin {
   const cache = new Map<string, Entry>();
+  // Apollo reuses parsed documents. Weak keys retain metadata only while the
+  // document is reachable, independently of response TTL and cache eviction.
+  const documents = new WeakMap<DocumentNode, CacheDocument>();
   let cacheBytes = 0;
   const remove = (key: string): void => {
     const entry = cache.get(key);
@@ -40,9 +44,14 @@ export function scraperDbCachePlugin(): ApolloServerPlugin {
             context.request.variables,
           );
           if (!directive) return null;
+          let document = documents.get(context.document);
+          if (!document) {
+            document = prepareCacheDocument(context.document);
+            documents.set(context.document, document);
+          }
           key = cacheKey(
             context.operationName,
-            context.document,
+            document,
             context.request.variables ?? {},
           );
           if (directive.refresh) {
@@ -98,11 +107,7 @@ export function scraperDbCachePlugin(): ApolloServerPlugin {
   };
 }
 
-function cacheKey(
-  operation: string | null,
-  document: DocumentNode,
-  variables: Record<string, unknown>,
-): string {
+function prepareCacheDocument(document: DocumentNode): CacheDocument {
   const query = stripUnusedVariableDefinitions(
     print(
       visit(document, {
@@ -116,6 +121,14 @@ function cacheKey(
       usedVariables.add(name.value);
     },
   });
+  return { query, usedVariables };
+}
+
+function cacheKey(
+  operation: string | null,
+  { query, usedVariables }: CacheDocument,
+  variables: Record<string, unknown>,
+): string {
   const dataVariables = Object.fromEntries(
     Object.entries(variables).filter(([name]) => usedVariables.has(name)),
   );

--- a/typescript/scraper-proxy/src/scraperdb/request-compatibility.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/request-compatibility.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
+
+import { Parser } from 'graphql/language/parser.js';
 
 import {
   normalizeGraphqlRequestBody,
@@ -29,5 +31,77 @@ void describe('GraphQL request compatibility', () => {
     `);
     assert.match(query, /\$used: String = "\)"/);
     assert.doesNotMatch(query, /unused/);
+  });
+});
+
+void describe('query normalization cache', () => {
+  void it('reuses normalization across variables and preserves batch/operation semantics', () => {
+    const parser = mock.method(Parser.prototype, 'parseDocument');
+    try {
+      const query = `# shared document
+        query First($used: Int!, $unused: String) { domain(limit: $used) { id } }
+        query Second($other: Int) { domain(limit: $other) { name } }`;
+      const first = { query, operationName: 'First', variables: { used: 1 } };
+      const second = {
+        query,
+        operationName: 'Second',
+        variables: { other: 7 },
+      };
+      normalizeGraphqlRequestBody([first, second, null, { query: 42 }]);
+      assert.equal(parser.mock.callCount(), 1);
+      assert.equal(first.query, second.query);
+      assert.doesNotMatch(first.query, /unused/);
+      assert.match(first.query, /\$used: Int!/);
+      assert.match(first.query, /\$other: Int/);
+      assert.equal(first.operationName, 'First');
+      assert.deepEqual(second.variables, { other: 7 });
+    } finally {
+      parser.mock.restore();
+    }
+  });
+
+  void it('does not cache malformed or oversized query text', () => {
+    const parser = mock.method(Parser.prototype, 'parseDocument');
+    try {
+      const malformed = 'query Broken(';
+      assert.equal(stripUnusedVariableDefinitions(malformed), malformed);
+      assert.equal(stripUnusedVariableDefinitions(malformed), malformed);
+      const oversized =
+        '# ' + 'x'.repeat(8192) + '\nquery Large { domain { id } }';
+      const normalized = stripUnusedVariableDefinitions(oversized);
+      assert.equal(stripUnusedVariableDefinitions(oversized), normalized);
+      const expanded = `query Expanded { domain { ${Array.from({ length: 500 }, (_, i) => `a${i}:id`).join(' ')} } }`;
+      assert(expanded.length < 8192);
+      const expandedNormalized = stripUnusedVariableDefinitions(expanded);
+      assert(expanded.length + expandedNormalized.length > 8192);
+      assert.equal(
+        stripUnusedVariableDefinitions(expanded),
+        expandedNormalized,
+      );
+      assert.equal(parser.mock.callCount(), 6);
+    } finally {
+      parser.mock.restore();
+    }
+  });
+
+  void it('bounds entries and retains recently used query text', () => {
+    const parser = mock.method(Parser.prototype, 'parseDocument');
+    try {
+      const queries = Array.from(
+        { length: 65 },
+        (_, i) => `query CacheBound${i} { domain { id } }`,
+      );
+      for (const query of queries.slice(0, 64))
+        stripUnusedVariableDefinitions(query);
+      assert.equal(parser.mock.callCount(), 64);
+      stripUnusedVariableDefinitions(queries[0]);
+      stripUnusedVariableDefinitions(queries[64]);
+      stripUnusedVariableDefinitions(queries[0]);
+      assert.equal(parser.mock.callCount(), 65);
+      stripUnusedVariableDefinitions(queries[1]);
+      assert.equal(parser.mock.callCount(), 66);
+    } finally {
+      parser.mock.restore();
+    }
   });
 });

--- a/typescript/scraper-proxy/src/scraperdb/request-compatibility.ts
+++ b/typescript/scraper-proxy/src/scraperdb/request-compatibility.ts
@@ -1,5 +1,11 @@
 import { type DocumentNode, Kind, parse, print, visit } from 'graphql';
 
+// Cache only pure query-text normalization, independently of response freshness.
+// At most 1 MiB of UTF-16 string content (excluding Map/object overhead).
+const MAX_NORMALIZED_QUERIES = 64;
+const MAX_QUERY_PAIR_LENGTH = 8_192;
+const normalizedQueries = new Map<string, string>();
+
 type Payload = {
   operationName?: unknown;
   query?: unknown;
@@ -15,6 +21,12 @@ export function normalizeGraphqlRequestBody(body: unknown): void {
 }
 
 export function stripUnusedVariableDefinitions(query: string): string {
+  const cached = normalizedQueries.get(query);
+  if (cached !== undefined) {
+    normalizedQueries.delete(query);
+    normalizedQueries.set(query, cached);
+    return cached;
+  }
   let document: DocumentNode;
   try {
     document = parse(query);
@@ -32,7 +44,7 @@ export function stripUnusedVariableDefinitions(query: string): string {
         used.add(name.value);
     },
   });
-  return print(
+  const normalized = print(
     visit(document, {
       OperationDefinition: (node) => ({
         ...node,
@@ -42,6 +54,14 @@ export function stripUnusedVariableDefinitions(query: string): string {
       }),
     }),
   );
+  if (query.length + normalized.length <= MAX_QUERY_PAIR_LENGTH) {
+    normalizedQueries.set(query, normalized);
+    if (normalizedQueries.size > MAX_NORMALIZED_QUERIES) {
+      const oldest = normalizedQueries.keys().next().value;
+      if (oldest !== undefined) normalizedQueries.delete(oldest);
+    }
+  }
+  return normalized;
 }
 
 function isPayload(value: unknown): value is Payload {

--- a/typescript/scraper-proxy/src/scripts/benchmark-cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scripts/benchmark-cache-plugin.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { ApolloServer, type ApolloServerPlugin } from '@apollo/server';
+import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl';
+
+import { scraperDbCachePlugin } from '../scraperdb/cache-plugin.js';
+import { normalizeGraphqlRequestBody } from '../scraperdb/request-compatibility.js';
+import { scraperProxyValidationRule } from '../scraperdb/validation.js';
+
+const variants: Array<{ name: string; plugin: () => ApolloServerPlugin }> = [];
+if (process.argv[2]) {
+  const baseline: typeof import('../scraperdb/cache-plugin.js') = await import(
+    pathToFileURL(resolve(process.argv[2])).href
+  );
+  variants.push({ name: 'baseline', plugin: baseline.scraperDbCachePlugin });
+}
+variants.push({ name: 'current', plugin: scraperDbCachePlugin });
+
+// Synthetic queries at two sizes within the production field/root/alias limits.
+// Includes request normalization and Apollo execution, excluding HTTP and DB IO.
+for (const fields of [50, 250]) {
+  const names = Array.from({ length: fields - 1 }, (_, i) => `f${i}`);
+  const payload = Object.fromEntries(names.map((name) => [name, 1]));
+  const expectedData = JSON.stringify({ value: payload });
+  const query = `query($key: Int!) @cached(ttl: 300) { value(key: $key) { ${names.join(' ')} } }`;
+  for (let run = 0; run < 3; run++) {
+    for (const { name, plugin } of variants) {
+      let calls = 0;
+      const server = new ApolloServer({
+        plugins: [
+          ApolloServerPluginCacheControl({ calculateHttpHeaders: false }),
+          plugin(),
+        ],
+        validationRules: [scraperProxyValidationRule],
+        typeDefs: `directive @cached(ttl: Int, refresh: Boolean) on QUERY
+          type Query { value(key: Int!): Value! }
+          type Value { ${names.map((field) => `${field}: Int!`).join(' ')} }`,
+        resolvers: {
+          Query: {
+            value: () => {
+              calls++;
+              return payload;
+            },
+          },
+        },
+      });
+      await server.start();
+      try {
+        const execute = async () => {
+          const request = { query, variables: { key: 1 } };
+          normalizeGraphqlRequestBody(request);
+          const response = await server.executeOperation(request);
+          assert(response.body.kind === 'single');
+          assert.equal(response.body.singleResult.errors, undefined);
+          assert.equal(
+            JSON.stringify(response.body.singleResult.data),
+            expectedData,
+          );
+        };
+        for (let i = 0; i < 100; i++) await execute();
+        const start = performance.now();
+        for (let i = 0; i < 1_000; i++) await execute();
+        console.log(
+          JSON.stringify({
+            name,
+            fields,
+            run,
+            requests: 1_000,
+            elapsedMs: performance.now() - start,
+          }),
+        );
+        assert.equal(calls, 1);
+      } finally {
+        await server.stop();
+      }
+    }
+  }
+}

--- a/typescript/scraper-proxy/src/scripts/benchmark-query-normalization.ts
+++ b/typescript/scraper-proxy/src/scripts/benchmark-query-normalization.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { ApolloServer } from '@apollo/server';
+import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl';
+
+import { scraperDbCachePlugin } from '../scraperdb/cache-plugin.js';
+import { normalizeGraphqlRequestBody } from '../scraperdb/request-compatibility.js';
+import { scraperProxyValidationRule } from '../scraperdb/validation.js';
+
+const variants: Array<{
+  name: string;
+  normalize: typeof normalizeGraphqlRequestBody;
+}> = [];
+if (process.argv[2]) {
+  const baseline: typeof import('../scraperdb/request-compatibility.js') =
+    await import(pathToFileURL(resolve(process.argv[2])).href);
+  variants.push({
+    name: 'baseline',
+    normalize: baseline.normalizeGraphqlRequestBody,
+  });
+}
+variants.push({ name: 'current', normalize: normalizeGraphqlRequestBody });
+
+// Synthetic queries at two sizes within the production field/root/alias limits.
+// Includes request normalization and Apollo execution, excluding HTTP and DB IO.
+for (const fields of [50, 250]) {
+  const names = Array.from({ length: fields - 1 }, (_, i) => `f${i}`);
+  const payload = Object.fromEntries(names.map((name) => [name, 1]));
+  const expectedData = JSON.stringify({ value: payload });
+  const query = `query($key: Int!) @cached(ttl: 300) { value(key: $key) { ${names.join(' ')} } }`;
+  for (const workload of ['repeated', 'fresh'] as const) {
+    for (let run = 0; run < 4; run++) {
+      for (const { name, normalize } of run % 2
+        ? [...variants].reverse()
+        : variants) {
+        let calls = 0;
+        const server = new ApolloServer({
+          plugins: [
+            ApolloServerPluginCacheControl({ calculateHttpHeaders: false }),
+            scraperDbCachePlugin(),
+          ],
+          validationRules: [scraperProxyValidationRule],
+          typeDefs: `directive @cached(ttl: Int, refresh: Boolean) on QUERY
+          type Query { value(key: Int!): Value! }
+          type Value { ${names.map((field) => `${field}: Int!`).join(' ')} }`,
+          resolvers: {
+            Query: {
+              value: () => {
+                calls++;
+                return payload;
+              },
+            },
+          },
+        });
+        await server.start();
+        try {
+          let sequence = 0;
+          const execute = async () => {
+            const suffix = workload === 'fresh' ? sequence++ : sequence++ % 8;
+            const request = {
+              query: query + ` # ${name}-${run}-${suffix}`,
+              variables: { key: 1 },
+            };
+            normalize(request);
+            const response = await server.executeOperation(request);
+            assert(response.body.kind === 'single');
+            assert.equal(response.body.singleResult.errors, undefined);
+            assert.equal(
+              JSON.stringify(response.body.singleResult.data),
+              expectedData,
+            );
+          };
+          for (let i = 0; i < 100; i++) await execute();
+          const start = performance.now();
+          for (let i = 0; i < 1_000; i++) await execute();
+          console.log(
+            JSON.stringify({
+              name,
+              fields,
+              workload,
+              run,
+              requests: 1_000,
+              elapsedMs: performance.now() - start,
+            }),
+          );
+          assert.equal(calls, 1);
+        } finally {
+          await server.stop();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Repeated GraphQL requests rebuilt both compatibility-normalized query text before Apollo processing and invariant document metadata while constructing response-cache keys.

## Solution

Cache pure query-text normalization in a bounded 64-entry LRU (combined original/normalized text capped at 8,192 code units per entry), and memoize invariant cache metadata by document identity. Preserve per-request variables and operation names, existing response-cache freshness and eviction, malformed-query behavior and batch semantics.

Consolidates #9467, #9512. Earlier PRs retain their original descriptions and detailed benchmark references.

## Performance evidence

| Component | Evidence and scope |
| --- | --- |
| reuse cache key document metadata | 61.7–63.0% reduction in synthetic cached-request processing time |
| reuse normalized query text | Synthetic repeated texts: 82.7–83.8% less local processing time; fresh-text controls add 0.8–2.9%. HTTP/DB excluded; production repetition rate unknown. |

These measurements describe separate workloads and scopes. Percentages must not be added; local or modeled results are not deployed speedups. The individual benchmark artifacts remain in this branch.

### Production observation

Exact stacked image `2b7731d-20260907-013323` became Ready at about 01:38 UTC on 2026-09-07 and remained Ready with zero restarts through the 09:35 snapshot. Matched six-hour pre/post windows showed:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| GraphQL requests | 895 | 1,767 | +97.5% |
| Mean duration | 16.94ms | 12.23ms | -27.8% |
| p50 | 11.51ms | 7.39ms | -35.8% |
| p95 | 47.65ms | 42.99ms | -9.8% |
| Whole-process CPU | 139.6 CPU-seconds | 140.1 CPU-seconds | +0.4% |
| Approximate CPU/request | 156.0ms | 79.3ms | -49.2% |
| DB queries/request | 1.490 | 1.607 | +7.8% |

End-to-end latency improved less than the synthetic local-processing targets, as expected with DB/network time included. Nearly doubled request volume used flat total CPU despite more DB queries per request. This is observational rather than causal proof because adjacent windows can differ in query mix.

## Validation

The unchanged cumulative source at 069f5eec10e006f473d405fb30cf6236940fc1bc has 70 passing tests plus build, lint and format checks. Regression coverage includes normalization reuse, fresh-text controls, bounded eviction, malformed/oversized queries, variables, operations, response data and resolver counts. The combined monorepo integration also passed the scraper build and all 70 tests. Consolidation only retargets the existing final head to main; source tree is unchanged.

No runtime behavior was added during consolidation. The PR is ready for review.

Reproduction: [normalization benchmark and samples](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/069f5eec10e006f473d405fb30cf6236940fc1bc/typescript/scraper-proxy/docs/performance/2026-09-05-query-normalization/README.md), [AST cache benchmark](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/069f5eec10e006f473d405fb30cf6236940fc1bc/typescript/scraper-proxy/src/scripts/benchmark-cache-plugin.ts).
