### PR TITLE
perf(storage): borrow UUID bytes for Lander database reads

### DIFF
--- a/rust/main/lander/src/dispatcher/db/json_decode_tests.rs
+++ b/rust/main/lander/src/dispatcher/db/json_decode_tests.rs
@@ -143,3 +143,118 @@ async fn slice_decoded_records_survive_database_reopen() {
         Some(transaction)
     );
 }
+
+#[tokio::test]
+async fn uuid_point_getters_preserve_encoded_keys_errors_and_reopen() {
+    use crate::transaction::Transaction;
+    use hyperlane_core::{identifiers::UniqueIdentifier, Encode};
+    for byte in 0..=255 {
+        let key = UniqueIdentifier::new(uuid::Uuid::from_bytes([byte; 16]));
+        assert_eq!(Encode::to_vec(&key), key.as_bytes());
+    }
+    let directory = tempfile::tempdir().unwrap();
+    let domain = KnownHyperlaneDomain::Arbitrum.into();
+    let key = UniqueIdentifier::new(uuid::Uuid::from_bytes([0x81; 16]));
+    let mut payload = FullPayload::default();
+    payload.details.uuid = key.clone();
+    payload.data = vec![17; 4096];
+    let mut transaction = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
+    transaction.uuid = key.clone();
+    let raw = DB::from_path(directory.path()).unwrap();
+    let db = HyperlaneRocksDB::new(&domain, raw.clone());
+    assert!(db.retrieve_payload_by_uuid(&key).await.unwrap().is_none());
+    assert!(db
+        .retrieve_payload_index_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_transaction_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_transaction_index_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+
+    // Seed keys through the unchanged canonical Encode API, as existing databases do.
+    db.store_value_by_key("payload_by_uuid_", &key, &payload)
+        .unwrap();
+    db.store_value_by_key("transaction_by_uuid_", &key, &transaction)
+        .unwrap();
+    db.store_value_by_key("payload_index_by_uuid_", &key, &42u32)
+        .unwrap();
+    db.store_value_by_key("tx_index_by_uuid_", &key, &84u32)
+        .unwrap();
+    let other = HyperlaneRocksDB::new(&KnownHyperlaneDomain::Ethereum.into(), raw.clone());
+    assert!(other
+        .retrieve_payload_by_uuid(&key)
+        .await
+        .unwrap()
+        .is_none());
+    drop(other);
+    macro_rules! compare {
+        ($method:ident, $prefix:literal, $value:expr, $ty:ty) => {
+            assert_eq!(db.$method(&key).await.unwrap(), Some($value.clone()));
+            let encoded_key = [
+                b"arbitrum_".as_slice(),
+                $prefix.as_bytes(),
+                &Encode::to_vec(&key),
+            ]
+            .concat();
+            raw.store(&encoded_key, &[255]).unwrap();
+            let old_error = db
+                .retrieve_value_by_key::<_, $ty>($prefix, &key)
+                .unwrap_err();
+            let new_error = db.$method(&key).await.unwrap_err();
+            assert_eq!(new_error.to_string(), old_error.to_string());
+            db.store_value_by_key($prefix, &key, &$value).unwrap();
+            assert_eq!(db.$method(&key).await.unwrap(), Some($value.clone()));
+        };
+    }
+    compare!(
+        retrieve_payload_by_uuid,
+        "payload_by_uuid_",
+        payload,
+        FullPayload
+    );
+    compare!(
+        retrieve_transaction_by_uuid,
+        "transaction_by_uuid_",
+        transaction,
+        Transaction
+    );
+    compare!(
+        retrieve_payload_index_by_uuid,
+        "payload_index_by_uuid_",
+        42u32,
+        u32
+    );
+    compare!(
+        retrieve_transaction_index_by_uuid,
+        "tx_index_by_uuid_",
+        84u32,
+        u32
+    );
+    drop(db);
+    drop(raw);
+    let db = HyperlaneRocksDB::new(&domain, DB::from_path(directory.path()).unwrap());
+    assert_eq!(
+        db.retrieve_payload_by_uuid(&key).await.unwrap(),
+        Some(payload)
+    );
+    assert_eq!(
+        db.retrieve_transaction_by_uuid(&key).await.unwrap(),
+        Some(transaction)
+    );
+    assert_eq!(
+        db.retrieve_payload_index_by_uuid(&key).await.unwrap(),
+        Some(42)
+    );
+    assert_eq!(
+        db.retrieve_transaction_index_by_uuid(&key).await.unwrap(),
+        Some(84)
+    );
+}

--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -151,7 +151,7 @@ impl PayloadDb for HyperlaneRocksDB {
         &self,
         payload_uuid: &PayloadUuid,
     ) -> DbResult<Option<FullPayload>> {
-        self.retrieve_value_by_key(PAYLOAD_BY_UUID_STORAGE_PREFIX, payload_uuid)
+        self.retrieve_decodable(PAYLOAD_BY_UUID_STORAGE_PREFIX, payload_uuid.as_bytes())
     }
 
     async fn store_payload_by_uuid(&self, payload: &FullPayload) -> DbResult<()> {
@@ -231,7 +231,10 @@ impl PayloadDb for HyperlaneRocksDB {
         &self,
         payload_uuid: &PayloadUuid,
     ) -> DbResult<Option<u32>> {
-        self.retrieve_value_by_key(PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX, payload_uuid)
+        self.retrieve_decodable(
+            PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX,
+            payload_uuid.as_bytes(),
+        )
     }
 
     async fn store_payload_index_by_uuid(

--- a/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
+++ b/rust/main/lander/src/dispatcher/db/transaction/transaction_db.rs
@@ -75,7 +75,7 @@ impl TransactionDb for HyperlaneRocksDB {
         &self,
         tx_uuid: &TransactionUuid,
     ) -> DbResult<Option<Transaction>> {
-        self.retrieve_value_by_key(TRANSACTION_BY_UUID_STORAGE_PREFIX, tx_uuid)
+        self.retrieve_decodable(TRANSACTION_BY_UUID_STORAGE_PREFIX, tx_uuid.as_bytes())
     }
 
     async fn store_transaction_by_uuid(&self, tx: &Transaction) -> DbResult<()> {
@@ -99,7 +99,7 @@ impl TransactionDb for HyperlaneRocksDB {
         &self,
         tx_uuid: &TransactionUuid,
     ) -> DbResult<Option<u32>> {
-        self.retrieve_value_by_key(TRANSACTION_INDEX_BY_UUID_STORAGE_PREFIX, tx_uuid)
+        self.retrieve_decodable(TRANSACTION_INDEX_BY_UUID_STORAGE_PREFIX, tx_uuid.as_bytes())
     }
 
     async fn store_transaction_index_by_uuid(


### PR DESCRIPTION
Consolidated into #9489 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stack: follows #9511 on the validator/shared-storage stack.

## Problem

The four Lander payload/transaction UUID getters allocate a 16-byte vector to encode each UUID, then copy those same bytes into the domain-prefixed database key. UUIDs already expose the identical canonical bytes.

## Solution

Pass `uuid.as_bytes()` to the existing `retrieve_decodable` API at those four call sites. Composite-key construction, database options, pinned value lifetime, decoders, writes and public APIs remain unchanged. No new key encoder or stack-buffer abstraction.

## Numerical evidence

A warmed actual RocksDB point-read probe compares the existing encoded-key wrapper with the byte-slice call using real Lander payload/transaction types and exact production prefixes. Six fixtures return equal values and remove **one Rust allocation and 16 requested bytes per lookup**:

| Lookup | Rust allocation calls, before → after | Requested bytes, before → after |
| --- | --- | --- |
| Payload index | 2 → 1 | 63 → 47 |
| Transaction index | 2 → 1 | 58 → 42 |
| Payload with 4KiB data | 12 → 11 | 8,241 → 8,225 |
| Transaction with 4KiB retained criteria | 14 → 13 | 8,513 → 8,497 |

The probe measures synchronous key construction, actual pinned DB retrieval and decoding after warm-up. Fixture creation and async trait wrappers are excluded; Rust allocator counters do not observe RocksDB's native allocations. This is a small per-read allocation reduction, not a claim about fleet CPU or latency. The final composite-key allocation remains.

## Validation

- Three DB decoder tests passed, including a new test checking 256 UUID byte encodings and all four getters against canonically written keys, missing rows, malformed-value errors, repair and database reopen; domain isolation is also checked.
- Qualified strict production Lander Clippy passed with only the existing `cloned_ref_to_slice_refs` baseline allowance. That unrelated finality cleanup already exists on the relayer stack; it is not duplicated here.
- Self-review and independent relayer review found no blocker. Normal commit hooks passed.

This shared-storage change follows the validator stack's pinned/slice decoding work and benefits Lander. It composes with the relayer stack's separate Encode overrides and does not duplicate the excluded pending-index/recovery work; those paths and all writes remain unchanged.
