### PR TITLE
perf(validator): reuse final root within checkpoint ingestion

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -95,17 +95,17 @@ impl ValidatorSubmitter {
         }
     }
 
-    pub(crate) fn checkpoint(&self, tree: &IncrementalMerkle) -> Checkpoint {
+    fn checkpoint(&self, root: H256, index: u32) -> Checkpoint {
         Checkpoint {
             merkle_tree_hook_address: self.merkle_tree_hook.address(),
             mailbox_domain: self.merkle_tree_hook.domain().id(),
-            root: tree.root(),
-            index: tree.index(),
+            root,
+            index,
         }
     }
 
     pub(crate) fn checkpoint_at_block(&self, tree: &IncrementalMerkleAtBlock) -> CheckpointAtBlock {
-        let checkpoint = self.checkpoint(&tree.tree);
+        let checkpoint = self.checkpoint(tree.tree.root(), tree.tree.index());
 
         CheckpointAtBlock {
             checkpoint,
@@ -349,8 +349,12 @@ impl ValidatorSubmitter {
             });
         }
 
+        let root = checkpoint_queue
+            .last()
+            .map(|checkpoint| checkpoint.root)
+            .unwrap_or_else(|| tree.root());
         info!(
-            root = ?tree.root(),
+            ?root,
             queue_length = checkpoint_queue.len(),
             "Ingested leaves into in-memory merkle tree"
         );
@@ -364,13 +368,13 @@ impl ValidatorSubmitter {
             tree.index(),
         );
 
-        let checkpoint = self.checkpoint(tree);
+        let checkpoint = self.checkpoint(root, tree.index());
 
         // If the tree's checkpoint doesn't match the correctness checkpoint, something went wrong
         // and we bail loudly.
         if checkpoint != correctness_checkpoint.checkpoint {
             let reorg_event = ReorgEvent::new(
-                tree.root(),
+                root,
                 correctness_checkpoint.root,
                 checkpoint.index,
                 chrono::Utc::now().timestamp() as u64,

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -1522,3 +1522,53 @@ async fn sign_and_submit_checkpoint_different_signature() {
 
     logs_contain("Checkpoint already submitted, but with different signature, overwriting");
 }
+
+#[tokio::test]
+async fn unchanged_tree_checkpoint_preserves_root_index_namespace_and_block() {
+    for leaf_count in [1, 5] {
+        let mut tree = IncrementalMerkle::default();
+        for index in 0..leaf_count {
+            tree.ingest(H256::from_low_u64_be(index + 1));
+        }
+        let expected = Checkpoint {
+            root: tree.root(),
+            index: tree.index(),
+            merkle_tree_hook_address: H256::from_low_u64_be(123),
+            mailbox_domain: 17,
+        };
+        let mut hook = MockMerkleTreeHook::new();
+        hook.expect_address()
+            .return_const(expected.merkle_tree_hook_address);
+        hook.expect_domain()
+            .return_const(dummy_domain(17, "root_reuse_domain"));
+        let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+        let submitter = ValidatorSubmitter::new(
+            Duration::from_secs(1),
+            ReorgPeriod::from_blocks(1),
+            Arc::new(hook),
+            Arc::new(MockMerkleTreeHook::new()),
+            dummy_singleton_handle(),
+            signer,
+            Arc::new(MockCheckpointSyncer::new()),
+            Arc::new(MockDb::new()),
+            dummy_metrics(),
+            2,
+            Arc::new(MockReorgReporter::new()),
+            dummy_readiness(),
+        );
+        let at_block = IncrementalMerkleAtBlock {
+            tree: tree.clone(),
+            block_height: Some(42),
+        };
+        let checkpoint = submitter.checkpoint_at_block(&at_block);
+        assert_eq!(checkpoint.checkpoint, expected);
+        assert_eq!(checkpoint.block_height, Some(42));
+        // No DB reads, signing/storage calls, or reorg reports are expected when
+        // the complete checkpoint already matches and no leaves are ingested.
+        submitter
+            .submit_checkpoints_until_correctness_checkpoint(&mut tree, &checkpoint)
+            .await;
+        assert_eq!(tree.root(), expected.root);
+        assert_eq!(tree.index(), expected.index);
+    }
+}


### PR DESCRIPTION
Consolidated into #9471 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stack: follows #9513 on the validator/shared-storage stack.

## Problem

After ingesting a batch, the validator already holds the final Merkle root in its last queued checkpoint. It recomputes that unchanged root for the INFO event and the final checkpoint comparison, and once more when reporting a mismatch. Each root calculation performs 32 hash concatenations.

## Solution

Reuse the final queued root within the same ingestion call. If no leaves were ingested, calculate the root once. Pass that root and the same tree index to the private checkpoint constructor and reuse it in logs and reorg reporting. Preserve the index assertion, full checkpoint equality gate, namespace, signed values and reporting behavior. No root is cached across calls or acquisition waits.

## Numerical evidence

For a successful nonempty batch, removes **two root calculations / 64 hash concatenations with INFO enabled**, or **one root calculation / 32 hashes when INFO is disabled**. For one ingested leaf with INFO enabled, root-computation work drops 96→32 hashes; the necessary per-leaf roots and ingestion hashes remain unchanged. A zero-ingestion call removes one root calculation only when INFO is enabled. The reorg path removes one additional calculation.

An isolated optimized probe of the actual `IncrementalMerkle::root()` on an Apple M3 Pro measured medians 7.348µs (one-leaf tree) and 7.273µs (1,024-leaf tree), each 15 batches×1,000 calls. Multiplying by the two removed calculations models approximately 14–15µs saved per nonempty batch with INFO enabled. This is a small local CPU saving, not a measured whole-routine, throughput, latency or fleet gain; backfill still needs one root for every leaf.

## Validation

- 19 submit tests passed, including exact five-leaf checkpoints/recovered signatures and reorg persistence/same-index mismatch checks.
- Added unchanged-tree 1/5-leaf checks for root/index/namespace/block-height parity and absence of DB, storage or reorg calls.
- Independent source/test review clear; strict validator production Clippy and normal commit hooks passed.
