### PR TITLE
perf(scraper): reuse inserted block and transaction IDs

### DIFF
--- a/rust/main/agents/scraper/src/db/block.rs
+++ b/rust/main/agents/scraper/src/db/block.rs
@@ -2,8 +2,11 @@ use eyre::{Context, Result};
 use itertools::Itertools;
 use migration::OnConflict;
 use sea_orm::{
-    prelude::*, sea_query::SelectStatement, ActiveValue::*, DbErr, EntityTrait, FromQueryResult,
-    Insert, QueryResult, QuerySelect,
+    prelude::*,
+    sea_query::{Query, SelectStatement},
+    ActiveValue::*,
+    ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Insert, QueryResult, QuerySelect,
+    QueryTrait,
 };
 use tracing::{debug, trace};
 
@@ -81,12 +84,12 @@ impl ScraperDb {
         Ok(blocks)
     }
 
-    /// Store a new block (or update an existing one)
+    /// Store blocks and return the IDs/hashes of inserted rows. Conflicts are omitted.
     pub async fn store_blocks(
         &self,
         domain: u32,
         blocks: impl Iterator<Item = BlockInfo>,
-    ) -> Result<()> {
+    ) -> Result<Vec<BasicBlock>> {
         let models = blocks
             .map(|info| block::ActiveModel {
                 id: NotSet,
@@ -98,18 +101,22 @@ impl ScraperDb {
             })
             .collect::<Vec<_>>();
 
-        debug_assert!(!models.is_empty());
+        if models.is_empty() {
+            return Ok(Vec::new());
+        }
         debug!(blocks = models.len(), "Writing blocks to database");
         trace!(?models, "Writing blocks to database");
-        match Insert::many(models)
+        let mut query = Insert::many(models)
             .on_conflict(OnConflict::new().do_nothing().to_owned())
-            .exec(&self.0)
+            .into_query();
+        query.returning(Query::returning().columns([block::Column::Id, block::Column::Hash]));
+        self.0
+            .query_all(self.0.get_database_backend().build(&query))
             .await
-        {
-            Ok(_) => Ok(()),
-            Err(DbErr::RecordNotInserted) => Ok(()),
-            Err(e) => Err(e).context("When inserting blocks"),
-        }
+            .context("When inserting blocks")?
+            .iter()
+            .map(|row| BasicBlock::from_query_result(row, "").map_err(Into::into))
+            .collect()
     }
 }
 

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -4,8 +4,10 @@ use derive_more::Deref;
 use eyre::{eyre, Context, Result};
 use itertools::Itertools;
 use sea_orm::{
-    prelude::*, sea_query::OnConflict, ActiveValue::*, DeriveColumn, EnumIter, Insert, NotSet,
-    QuerySelect,
+    prelude::*,
+    sea_query::{OnConflict, Query},
+    ActiveValue::*,
+    ConnectionTrait, DeriveColumn, EnumIter, Insert, NotSet, QuerySelect, QueryTrait,
 };
 use tracing::{debug, instrument, trace};
 
@@ -59,9 +61,12 @@ impl ScraperDb {
         Ok(txns)
     }
 
-    /// Store a new transaction into the database (or update an existing one).
+    /// Store transactions and return IDs by hash for inserted rows. Conflicts are omitted.
     #[instrument(skip_all)]
-    pub async fn store_txns(&self, txns: impl Iterator<Item = StorableTxn>) -> Result<()> {
+    pub async fn store_txns(
+        &self,
+        txns: impl Iterator<Item = StorableTxn>,
+    ) -> Result<HashMap<H512, i64>> {
         let models = txns
             .map(|txn| {
                 let receipt = txn
@@ -91,22 +96,32 @@ impl ScraperDb {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        debug_assert!(!models.is_empty());
+        if models.is_empty() {
+            return Ok(HashMap::new());
+        }
         debug!(txns = models.len(), "Writing txns to database");
         trace!(?models, "Writing txns to database");
-
-        match Insert::many(models)
+        let mut query = Insert::many(models)
             .on_conflict(
                 OnConflict::column(transaction::Column::Hash)
                     .do_nothing()
                     .to_owned(),
             )
-            .exec(&self.0)
+            .into_query();
+        query.returning(
+            Query::returning().columns([transaction::Column::Id, transaction::Column::Hash]),
+        );
+        self.0
+            .query_all(self.0.get_database_backend().build(&query))
             .await
-        {
-            Ok(_) => Ok(()),
-            Err(DbErr::RecordNotInserted) => Ok(()),
-            Err(e) => Err(e).context("When inserting transactions"),
-        }
+            .context("When inserting transactions")?
+            .iter()
+            .map(|row| {
+                Ok((
+                    bytes_to_h512(&row.try_get::<Vec<u8>>("", "hash")?),
+                    row.try_get("", "id")?,
+                ))
+            })
+            .collect()
     }
 }

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -173,8 +173,18 @@ impl HyperlaneDbStore {
                 continue;
             }
 
-            self.db.store_txns(txns_to_insert.drain(..)).await?;
-            let ids = self.db.get_txn_ids(hashes_to_insert.drain(..)).await?;
+            let mut ids = self.db.store_txns(txns_to_insert.drain(..)).await?;
+            // DO NOTHING can omit concurrent winners. Read those in a fresh statement
+            // after the INSERT, rather than the INSERT's earlier snapshot.
+            let existing = self
+                .db
+                .get_txn_ids(
+                    hashes_to_insert
+                        .drain(..)
+                        .filter(|hash| !ids.contains_key(*hash)),
+                )
+                .await?;
+            ids.extend(existing);
 
             for (hash, (txn_id, _block_id)) in chunk.iter_mut() {
                 *txn_id = ids.get(hash).copied();
@@ -255,17 +265,25 @@ impl HyperlaneDbStore {
                 continue;
             }
 
-            self.db
-                .store_blocks(self.domain.id(), block_infos.into_iter())
-                .await?;
-
-            let hashes = self
+            let mut hashes: HashMap<_, _> = self
                 .db
-                .get_block_basic(blocks_to_insert.iter().map(|(hash, _)| *hash))
+                .store_blocks(self.domain.id(), block_infos.into_iter())
                 .await?
                 .into_iter()
-                .map(|b| (b.hash, b.id))
-                .collect::<HashMap<_, _>>();
+                .map(|block| (block.hash, block.id))
+                .collect();
+            // Query only requested hashes omitted by RETURNING, including conflicts
+            // and provider responses carrying a different hash than requested.
+            let existing = self
+                .db
+                .get_block_basic(
+                    blocks_to_insert
+                        .iter()
+                        .map(|(hash, _)| *hash)
+                        .filter(|hash| !hashes.contains_key(*hash)),
+                )
+                .await?;
+            hashes.extend(existing.into_iter().map(|block| (block.hash, block.id)));
 
             for (hash, block_id) in blocks_to_insert {
                 if let Some(id) = hashes.get(hash) {
@@ -381,3 +399,6 @@ mod tests {
 
 #[cfg(test)]
 mod block_tests;
+
+#[cfg(test)]
+mod returning_tests;

--- a/rust/main/agents/scraper/src/store/storage/returning_tests.rs
+++ b/rust/main/agents/scraper/src/store/storage/returning_tests.rs
@@ -1,0 +1,258 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use migration::MigratorTrait;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseBackend, DbErr, MockDatabase, Statement, TransactionTrait,
+    Value,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+use hyperlane_core::{
+    ChainInfo, ChainResult, HyperlaneChain, KnownHyperlaneDomain, TxnInfo, TxnReceiptInfo, U256,
+};
+
+#[derive(Clone, Debug)]
+struct Provider(HyperlaneDomain);
+impl HyperlaneChain for Provider {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.0
+    }
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.clone())
+    }
+}
+fn txn_info(hash: H512) -> TxnInfo {
+    TxnInfo {
+        hash,
+        gas_limit: U256::one(),
+        max_priority_fee_per_gas: None,
+        max_fee_per_gas: None,
+        gas_price: None,
+        nonce: 0,
+        sender: H256::zero(),
+        recipient: None,
+        receipt: Some(TxnReceiptInfo {
+            gas_used: U256::one(),
+            cumulative_gas_used: U256::one(),
+            effective_gas_price: None,
+        }),
+        raw_input_data: None,
+    }
+}
+#[async_trait]
+impl HyperlaneProvider for Provider {
+    async fn get_block_by_height(&self, height: u64) -> ChainResult<BlockInfo> {
+        Ok(BlockInfo {
+            hash: H256::from_low_u64_be(height),
+            number: height,
+            timestamp: 1_700_000_000,
+        })
+    }
+    async fn get_txn_by_hash(&self, hash: &H512) -> ChainResult<TxnInfo> {
+        Ok(txn_info(*hash))
+    }
+    async fn is_contract(&self, _: &H256) -> ChainResult<bool> {
+        panic!("unexpected RPC")
+    }
+    async fn get_balance(&self, _: String) -> ChainResult<U256> {
+        panic!("unexpected RPC")
+    }
+    async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
+        panic!("unexpected RPC")
+    }
+}
+async fn store(db: ScraperDb) -> eyre::Result<HyperlaneDbStore> {
+    let domain: HyperlaneDomain = KnownHyperlaneDomain::Ethereum.into();
+    HyperlaneDbStore::new(
+        db,
+        domain.clone(),
+        CoreContractAddresses::default(),
+        Arc::new(Provider(domain)),
+        &IndexSettings::default(),
+        None,
+    )
+    .await
+}
+fn row(id: i64, hash: Vec<u8>) -> BTreeMap<String, Value> {
+    BTreeMap::from([("id".into(), id.into()), ("hash".into(), hash.into())])
+}
+async fn ensure(
+    store: &HyperlaneDbStore,
+    txn: bool,
+    count: u64,
+) -> eyre::Result<HashMap<H512, i64>> {
+    if txn {
+        Ok(store
+            .ensure_txns((1..=count).map(|n| TxnWithBlockId {
+                txn_hash: H512::from_low_u64_be(n),
+                block_id: 1,
+            }))
+            .await?
+            .collect())
+    } else {
+        Ok(store
+            .ensure_blocks((1..=count).map(|n| BlockId::new(H256::from_low_u64_be(n), n)))
+            .await?
+            .map(|b| (H512::from_low_u64_be(b.hash.to_low_u64_be()), b.id))
+            .collect())
+    }
+}
+#[tokio::test]
+async fn enrichment_returning_only_queries_missing_hashes() -> eyre::Result<()> {
+    for txn in [false, true] {
+        for returned in [0, 1, 2] {
+            let hash = |n| {
+                if txn {
+                    hyperlane_core::h512_to_bytes(&H512::from_low_u64_be(n))
+                } else {
+                    hyperlane_core::h256_to_bytes(&H256::from_low_u64_be(n))
+                }
+            };
+            let mut results = vec![
+                vec![],
+                vec![],
+                (1..=returned).map(|n| row(n as i64, hash(n))).collect(),
+            ];
+            if returned < 2 {
+                results.push(
+                    ((returned + 1)..=2)
+                        .map(|n| row(n as i64, hash(n)))
+                        .collect(),
+                );
+            }
+            let db = ScraperDb::with_connection(
+                MockDatabase::new(DatabaseBackend::Postgres)
+                    .append_query_results(results)
+                    .into_connection(),
+            );
+            let store = store(db).await?;
+            assert_eq!(
+                ensure(&store, txn, 2).await?,
+                HashMap::from([(H512::from_low_u64_be(1), 1), (H512::from_low_u64_be(2), 2)])
+            );
+            let log = store.db.clone_connection().into_transaction_log();
+            // Exclude the cursor initialization SELECT.
+            assert_eq!(log.len() - 1, if returned == 2 { 2 } else { 3 });
+            let insert = &log[2].statements()[0];
+            assert!(
+                insert.sql.ends_with("RETURNING \"id\", \"hash\""),
+                "{}",
+                insert.sql
+            );
+            assert!(insert.sql.contains("DO NOTHING"));
+            if returned < 2 {
+                let lookup = &log[3].statements()[0];
+                assert_eq!(
+                    lookup.values.as_ref().unwrap().0.len(),
+                    (2 - returned) as usize
+                );
+                for n in (returned + 1)..=2 {
+                    assert!(lookup.values.as_ref().unwrap().0.contains(&hash(n).into()));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+#[tokio::test]
+async fn enrichment_returning_errors_and_empty_inputs_preserve_boundaries() -> eyre::Result<()> {
+    for txn in [false, true] {
+        for insertion_fails in [false, true] {
+            let mut db = MockDatabase::new(DatabaseBackend::Postgres).append_query_results(vec![
+                    Vec::<
+                        BTreeMap<String, Value>,
+                    >::new(
+                    );
+                    if insertion_fails {
+                        2
+                    } else {
+                        3
+                    }
+                ]);
+            db = db.append_query_errors([DbErr::Custom("enrichment read/write failed".into())]);
+            let store = store(ScraperDb::with_connection(db.into_connection())).await?;
+            assert!(ensure(&store, txn, 0).await?.is_empty());
+            assert!(store
+                .db
+                .store_blocks(1, std::iter::empty())
+                .await?
+                .is_empty());
+            assert!(store.db.store_txns(std::iter::empty()).await?.is_empty());
+            let error = ensure(&store, txn, 1).await.unwrap_err();
+            assert!(format!("{error:#}").contains("enrichment read/write failed"));
+            assert_eq!(
+                store.db.clone_connection().into_transaction_log().len(),
+                if insertion_fails { 3 } else { 4 }
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn enrichment_returning_observes_concurrent_conflict_winner_in_postgres() -> eyre::Result<()>
+{
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let store = store(ScraperDb::with_connection(connection)).await?;
+    let connection = store.db.clone_connection();
+    for txn in [false, true] {
+        let winner = connection.begin().await?;
+        let (table, sql) = if txn {
+            ("transaction", "INSERT INTO \"transaction\" (time_created,hash,block_id,gas_limit,nonce,sender,gas_used,cumulative_gas_used) VALUES (now(),$1,$2,1,0,$3,1,1) RETURNING id")
+        } else {
+            ("block", "INSERT INTO \"block\" (time_created,hash,domain,height,timestamp) VALUES (now(),$1,1,1,now()) RETURNING id")
+        };
+        let mut params: Vec<Value> =
+            vec![hyperlane_core::h256_to_bytes(&H256::from_low_u64_be(1)).into()];
+        if txn {
+            let block_id = store
+                .db
+                .get_block_basic([&H256::from_low_u64_be(1)].into_iter())
+                .await?[0]
+                .id;
+            params.extend([
+                block_id.into(),
+                hyperlane_core::address_to_bytes(&H256::zero()).into(),
+            ]);
+        }
+        let winner_id: i64 = winner
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                sql,
+                params,
+            ))
+            .await?
+            .unwrap()
+            .try_get("", "id")?;
+        let waiting_insert = format!("INSERT INTO \"{table}\"%");
+        let commit_when_blocked = async {
+            tokio::time::timeout(Duration::from_secs(10), async {
+                loop {
+                    let row = connection.query_one(Statement::from_sql_and_values(DatabaseBackend::Postgres,
+                        "SELECT COUNT(*) AS waiting FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND query LIKE $1", [waiting_insert.clone().into()])).await?.unwrap();
+                    if row.try_get::<i64>("", "waiting")? > 0 { break; }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Ok::<_, eyre::Report>(())
+            }).await??;
+            winner.commit().await?;
+            Ok::<_, eyre::Report>(())
+        };
+        let (found, ()) = tokio::try_join!(ensure(&store, txn, 1), commit_when_blocked)?;
+        assert_eq!(found[&H512::from_low_u64_be(1)], winner_id);
+        assert_eq!(
+            ensure(&store, txn, 1).await?,
+            found,
+            "replay keeps the winner ID"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Consolidated into #9468 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stacked on #9510; review the child diff.

## Problem

After inserting missing blocks or transactions, scraper enrichment immediately selects their IDs again. For the usual new-row case, PostgreSQL can return these IDs and hashes directly from the INSERT, avoiding a separate database lookup.

## Solution

Add narrow `RETURNING id, hash` to the existing block and transaction INSERTs and return those mappings to enrichment. Query only requested hashes omitted from RETURNING. Keep the separate post-INSERT SELECT for conflicts: a concurrent insert can win without being visible to the earlier statement snapshot, so combining insertion and fallback into one SQL statement would be incorrect.

Keep `ON CONFLICT DO NOTHING`, 50-entry enrichment chunks, block identity constraints, requested-hash matching and missing-provider behavior. Wrong provider hashes still require the requested hash to resolve before returning an ID. Empty writes return without accessing the database. The changed return types are internal to the scraper binary; no new wrapper or public library API is introduced.

## Numerical impact

Source-derived query counts, verified by emitted SQL tests, for one entity batch of up to 50 missing rows:

| Case | Before | After |
| --- | --- | --- |
| All inserted rows new | Initial lookup + INSERT + ID lookup = 3 | Initial lookup + INSERT RETURNING = 2 |
| All conflict or mixed new/conflicting rows | 3 | 3; final lookup includes only omitted requested hashes |
| Already known rows | 1 initial lookup | 1 initial lookup |
| Empty input | 0 | 0 |

For all-new blocks and transactions each fitting one chunk, combined enrichment uses **6 → 4 database queries (33.3% fewer)**. This is a conditional query-count model, not measured latency or fleet-wide savings. RETURNING transfers only ID/hash, not full block or transaction models. Conflict-heavy workloads retain their follow-up query, and upstream maps/provider calls remain unchanged.

## Verification

- Full scraper suite: **60 passed, 0 failed, 1 existing ignored**.
- New SQL tests cover all-new, all-conflict and mixed RETURNING results for both entities; assert exact omitted hash parameters and only two returned columns.
- Real PostgreSQL race tests hold a competing insert uncommitted until the scraper INSERT is observed waiting on its unique-key lock, then commit the winner. Both block and transaction enrichment recover the correct winner ID through the later lookup and preserve it on replay.
- Empty store/enrichment inputs skip queries; insert and fallback-read errors propagate without partial success.
- Existing block duplicate-hash, same-height/different-hash and wrong-provider-hash regressions pass, alongside nullable metadata and event replay tests.
- Self-review and independent source/test review found no blockers. Strict production scraper Clippy, formatting and normal commit hooks passed (exit 0).
- No production database writes.
