### PR TITLE
perf(core): skip precomputed zero subtrees in Merkle roots

### DIFF
--- a/rust/main/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/main/hyperlane-core/src/accumulator/incremental.rs
@@ -64,17 +64,27 @@ impl IncrementalMerkle {
 
     /// Calculate the current tree root
     pub fn root(&self) -> H256 {
-        let mut node: H256 = Default::default();
-        let mut size = self.count;
+        // Each low zero count bit hashes the empty subtree with itself. Those
+        // nodes are already precomputed, independently of the stored branch.
+        let skip = self.count.trailing_zeros() as usize;
+        if skip >= TREE_DEPTH {
+            return ZERO_HASHES[TREE_DEPTH];
+        }
+        let mut node = ZERO_HASHES[skip];
+        let mut size = self.count >> skip;
 
-        self.branch.iter().enumerate().for_each(|(i, elem)| {
-            node = if (size & 1) == 1 {
-                hash_concat(elem, node)
-            } else {
-                hash_concat(node, ZERO_HASHES[i])
-            };
-            size /= 2;
-        });
+        self.branch
+            .iter()
+            .enumerate()
+            .skip(skip)
+            .for_each(|(i, elem)| {
+                node = if (size & 1) == 1 {
+                    hash_concat(elem, node)
+                } else {
+                    hash_concat(node, ZERO_HASHES[i])
+                };
+                size /= 2;
+            });
 
         node
     }
@@ -110,6 +120,58 @@ impl IncrementalMerkle {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn legacy_root(tree: &IncrementalMerkle) -> H256 {
+        let mut node: H256 = Default::default();
+        let mut size = tree.count;
+        for (i, elem) in tree.branch.iter().enumerate() {
+            node = if (size & 1) == 1 {
+                hash_concat(elem, node)
+            } else {
+                hash_concat(node, ZERO_HASHES[i])
+            };
+            size /= 2;
+        }
+        node
+    }
+
+    #[test]
+    fn root_zero_prefix_matches_legacy_for_arbitrary_branches_and_counts() {
+        let mut seed = 0x0123_4567_89ab_cdefu64;
+        let mut random = || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        let counts = (0..2048)
+            .chain((0..usize::BITS).flat_map(|bit| {
+                let count = 1usize << bit;
+                [count, count.saturating_sub(1), count.saturating_add(1)]
+            }))
+            .chain([usize::MAX, usize::MAX - 1]);
+        for count in counts {
+            let branch = std::array::from_fn(|_| {
+                let mut bytes = [0; 32];
+                for chunk in bytes.chunks_mut(8) {
+                    chunk.copy_from_slice(&random().to_be_bytes());
+                }
+                H256::from(bytes)
+            });
+            let tree = IncrementalMerkle { branch, count };
+            assert_eq!(tree.root(), legacy_root(&tree), "count={count}");
+        }
+    }
+
+    #[test]
+    fn root_zero_prefix_matches_legacy_through_sequential_ingestion() {
+        let mut tree = IncrementalMerkle::default();
+        for leaf in 0..8192 {
+            assert_eq!(tree.root(), legacy_root(&tree), "leaf count={leaf}");
+            tree.ingest(H256::from_low_u64_be(leaf));
+        }
+        assert_eq!(tree.root(), legacy_root(&tree));
+    }
 
     #[test]
     fn borsh_roundtrip() {


### PR DESCRIPTION
Consolidated into #9471 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

`IncrementalMerkle::root()` recomputes all 32 levels, including low levels where the count bit is zero and the accumulator is still a known empty subtree. Those hashes are already available in `ZERO_HASHES`.

## Solution

Start at `ZERO_HASHES[count.trailing_zeros()]` and retain the identical remaining branch loop. A guard handles counts whose low 32 bits are all zero, including empty trees and publicly constructible high-bit counts. No mutable cache, public API, hash implementation, ingestion order or signing gate changes.

## Numerical evidence

The number of hashes per remaining root call changes from 32 to `32 - min(count.trailing_zeros(), 32)`:

| Count | Hash calls before → after |
| --- | --- |
| Odd | 32 → 32 |
| 2 or 6 | 32 → 31 |
| 1,024 | 32 → 22 |
| 0 | 32 → 0 |

A sequential 1..4,096 fixture skips an average 0.999756 hashes/root; a uniform u32 count skips almost one hash on average, approximately 3.125% of root hashing work.

An optimized local exact-source probe, using the same core types/zero hashes/Keccak implementation, measured **2.90% median paired root-time reduction** across 4,096 valid sequential trees and **3.12%** across a synthetic uniform u32 fixture. It interleaved 31 paired batches of 20,000 calls with alternating order. Odd-count cases, which skip no hashing, were near parity: median paired slowdowns of 0.09–0.28%. Fixture creation was excluded. Paired percentages are not ratios of separately aggregated timing medians.

These are local root-computation measurements, not whole-validator CPU, on-chain/BPF cost or delivery latency. They apply only to root calls remaining after parent #9514's reuse; the two percentages must not be added as whole-workload savings.

## Validation

- 19 accumulator tests and 19 validator submit tests passed. Two new accumulator tests compare arbitrary branches/counts (zero, powers and neighbors, high usize bits, maxima) and 8,193 valid sequential states against the legacy algorithm.
- The standalone oracle checked 11,458 cases per run, including an additional uniform-count fixture; all matched. Additional runs also compare against the frozen linked original public `root()` implementation.
- Qualified strict core Clippy passed for `agent,matching-list`, with existing `cfg(feature="dev")` declarations and the existing manual `Filter::Default` allowance. No source suppressions added.
- Self-review and independent relayer review found no blocker. Normal commit hooks passed.

The skipped levels ignore arbitrary branch values in the legacy algorithm: until the first set count bit, each accumulator equals `ZERO_HASHES[level]`. The guard preserves the legacy behavior of ignoring count bits above the 32-level tree. This is separate from excluded ingestion batching and snapshot/history reduction.
