### PR TITLE
perf(lander): retain owned transactions through submission retries

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -501,7 +501,7 @@ impl InclusionStage {
         tx = Self::estimate_tx(&tx, state).await?;
 
         // Submitting transaction to the node
-        tx = Self::submit_tx(&tx, state).await?;
+        tx = Self::submit_tx(tx, state).await?;
         info!(?tx, "Transaction submitted to node");
 
         state
@@ -521,37 +521,35 @@ impl InclusionStage {
     }
 
     async fn submit_tx(
-        tx: &Transaction,
+        tx: Transaction,
         state: &DispatcherState,
     ) -> Result<Transaction, LanderError> {
-        // create a temporary arcmutex so that submission retries are aware of tx fields (e.g. gas price)
-        // set by previous retries when calling `adapter.submit`
-        let tx_shared = Arc::new(Mutex::new(tx.clone()));
+        // Submission retries retain tx fields (e.g. gas price) set by previous
+        // attempts. The retry future borrows this local mutex until it completes.
+        let tx_shared = Mutex::new(tx);
         // successively calling `submit` will result in escalating gas price until the tx is accepted
         // by the node.
         // at this point, not all VMs return information about whether the tx was reverted.
         // so dropping reverted payloads has to happen in the finality step
-        let submitted_tx = call_until_success_or_nonretryable_error(
-            || {
-                let tx_shared_clone = tx_shared.clone();
-                async move {
-                    let mut tx_guard = tx_shared_clone.lock().await;
-                    let submit_result = state.adapter.submit(&mut tx_guard).await;
+        call_until_success_or_nonretryable_error(
+            || async {
+                let mut tx_guard = tx_shared.lock().await;
+                let submit_result = state.adapter.submit(&mut tx_guard).await;
 
-                    match submit_result {
-                        Ok(()) => Ok(tx_guard.clone()),
-                        Err(err) if matches!(err, LanderError::TxAlreadyExists) => {
-                            warn!(tx=?tx_guard, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
-                            Ok(tx_guard.clone())
-                        }
-                        Err(err) => Err(err),
+                match submit_result {
+                    Ok(()) => Ok(()),
+                    Err(err) if matches!(err, LanderError::TxAlreadyExists) => {
+                        warn!(tx=?tx_guard, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
+                        Ok(())
                     }
+                    Err(err) => Err(err),
                 }
             },
             "Submitting transaction",
             state,
         )
         .await?;
+        let submitted_tx = tx_shared.into_inner();
         state.notify_reprocess_txs_activity();
         Ok(submitted_tx)
     }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -223,7 +223,7 @@ async fn test_successful_submission_notifies_reprocess_poller() {
     let (state, _) = reprocess_test_state(mock_adapter);
     let tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
 
-    InclusionStage::submit_tx(&tx, &state).await.unwrap();
+    InclusionStage::submit_tx(tx, &state).await.unwrap();
 
     tokio::time::timeout(
         Duration::from_millis(10),
@@ -1360,5 +1360,109 @@ async fn retry_attempt_terminal_errors_return_without_retrying() {
         };
         assert_eq!(actual, expected);
         assert_eq!(tx, original);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn owned_submission_preserves_retry_mutations_and_notifies_only_on_success() {
+    for already_exists in [false, true] {
+        let tx = retry_clone_fixture();
+        let pointer = tx.payload_details[0]
+            .success_criteria
+            .as_ref()
+            .unwrap()
+            .as_ptr() as usize;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let attempt_calls = calls.clone();
+        let mut adapter = MockAdapter::new();
+        adapter.expect_submit().times(2).returning(move |tx| {
+            let attempt = attempt_calls.fetch_add(1, Ordering::SeqCst);
+            let bytes = tx.payload_details[0].success_criteria.as_mut().unwrap();
+            assert_eq!(bytes.as_ptr() as usize, pointer);
+            assert_eq!(bytes[0], if attempt == 0 { 7 } else { 9 });
+            bytes[0] = if attempt == 0 { 9 } else { 11 };
+            if attempt == 0 {
+                Err(LanderError::TxSubmissionError("retry fixture".to_owned()))
+            } else if already_exists {
+                Err(LanderError::TxAlreadyExists)
+            } else {
+                Ok(())
+            }
+        });
+        let (state, _) = reprocess_test_state(adapter);
+        let task_state = state.clone();
+        let task = tokio::spawn(async move { InclusionStage::submit_tx(tx, &task_state).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first submission attempt must start");
+        assert!(tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity()
+        )
+        .await
+        .is_err());
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let bytes = result.payload_details[0].success_criteria.as_ref().unwrap();
+        assert_eq!(bytes.as_ptr() as usize, pointer);
+        assert_eq!(bytes[0], 11);
+        tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity(),
+        )
+        .await
+        .expect("success must notify");
+        assert!(tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity()
+        )
+        .await
+        .is_err());
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn owned_submission_errors_and_cancellation_do_not_notify() {
+    for cancel in [false, true] {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let attempt_calls = calls.clone();
+        let mut adapter = MockAdapter::new();
+        adapter.expect_submit().times(1).returning(move |tx| {
+            attempt_calls.fetch_add(1, Ordering::SeqCst);
+            tx.payload_details[0].success_criteria.as_mut().unwrap()[0] = 9;
+            if cancel {
+                Err(LanderError::TxSubmissionError("retry fixture".to_owned()))
+            } else {
+                Err(LanderError::EstimationFailed)
+            }
+        });
+        let (state, _) = reprocess_test_state(adapter);
+        let tx = retry_clone_fixture();
+        if cancel {
+            assert!(tokio::time::timeout(
+                Duration::from_millis(10),
+                InclusionStage::submit_tx(tx, &state)
+            )
+            .await
+            .is_err());
+        } else {
+            let error = InclusionStage::submit_tx(tx, &state).await.unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                LanderError::NonRetryableError(LanderError::EstimationFailed.to_string())
+                    .to_string()
+            );
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(tokio::time::timeout(
+            Duration::from_millis(10),
+            state.wait_for_reprocess_txs_activity()
+        )
+        .await
+        .is_err());
     }
 }


### PR DESCRIPTION
Consolidated into #9496 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stack: follows #9509 on the relayer stack.

## Problem

Lander owns the transaction before submission but borrows it into the retry wrapper, which clones it into an Arc-backed mutex and clones it again on success or TxAlreadyExists. The caller immediately replaces its original with the result. These copies are unnecessary; submission retries only need one mutable transaction whose changes survive between attempts.

## Solution

Move the transaction into a local mutex borrowed by each sequential retry future. Return the owned mutated transaction after success. Preserve gas/state mutations across retries, exact terminal error wrapping, cancellation, and the single activity notification after successful completion. Estimation/simulation retries retain their separate fresh-snapshot behavior.

## Numerical evidence and tradeoff

Measured allocation costs of the changed ownership portion of one successful wrapper, using actual Transaction fixtures with 4 KiB retained success criteria:

| Fixture | Allocation calls before → after | Total requested bytes before → after |
| --- | ---: | ---: |
| CosmWasm | 7 → 0 | 8,624 → 0 |
| EVM | 11 → 0 | 9,450 → 0 |

Removes two Transaction clones and one Arc allocation. All six sampled cases (two variants ×32 B/4 KiB/64 KiB) remove these allocations. Initial fixture cloning, adapter/RPC work, retry bookkeeping and caller allocations are excluded; EVM calldata uses its existing shared-buffer clone behavior.

The actual submission future grows **728 → 1,032 bytes (+304 bytes)** in the Rust1.93 dev/test build because state moves inline. This fixed future-size tradeoff is separate from allocator traffic; no smaller-future, total-memory, RSS, latency or fleet claim.

## Validation

- New tests check original metadata buffer identity across retries/return, failed-attempt mutations surviving into the next attempt, success and TxAlreadyExists, exact terminal errors, cancellation during retry delay, and notification only once after success.
- 29 inclusion-stage tests, strict Lander production Clippy and normal commit hooks passed; independent review clear.
- Benchmark-only legacy helper/future-size module is an external artifact, not included in the PR.
