### PR TITLE
perf(scraper): skip payment baselines for no-write replays

### DIFF
--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -144,16 +144,6 @@ impl ScraperDb {
         ))
         .await?;
 
-        let latest_id_before = gas_payment::Entity::find()
-            .select_only()
-            .column_as(gas_payment::Column::Id.max(), "max_id")
-            .filter(gas_payment::Column::Domain.eq(domain))
-            .into_tuple::<Option<i64>>()
-            .one(&txn)
-            .await?
-            .flatten()
-            .unwrap_or(0);
-
         let payment_msg_ids = payments
             .iter()
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
@@ -217,38 +207,48 @@ impl ScraperDb {
             ));
         }
 
-        let mut fallback_replacements = fallback_replacements.into_iter();
-        while !fallback_replacements.as_slice().is_empty() {
-            // Two parameters per identity plus domain/IGP scope. Keep deletion
-            // inside the same transaction as the replacement inserts.
-            let identities: Vec<_> = fallback_replacements
-                .by_ref()
-                .take(Self::PAYMENT_STORE_CHUNK_SIZE)
-                .collect();
-            gas_payment::Entity::delete_many()
-                .filter(gas_payment::Column::Domain.eq(domain))
-                .filter(
-                    gas_payment::Column::InterchainGasPaymaster
-                        .eq(interchain_gas_paymaster.clone()),
-                )
-                .filter(gas_payment::Column::TxId.is_null())
-                .filter(
-                    Expr::tuple([
-                        Expr::col(gas_payment::Column::MsgId).into(),
-                        Expr::col(gas_payment::Column::LogIndex).into(),
-                    ])
-                    .in_tuples(identities),
-                )
-                .exec(&txn)
-                .await?;
-        }
-
         debug!(?models, "Writing gas payments to database");
 
         let new_payments_count = if models.is_empty() {
             debug!("Wrote zero new gas payments to database");
             0
         } else {
+            let latest_id_before = gas_payment::Entity::find()
+                .select_only()
+                .column_as(gas_payment::Column::Id.max(), "max_id")
+                .filter(gas_payment::Column::Domain.eq(domain))
+                .into_tuple::<Option<i64>>()
+                .one(&txn)
+                .await?
+                .flatten()
+                .unwrap_or(0);
+
+            let mut fallback_replacements = fallback_replacements.into_iter();
+            while !fallback_replacements.as_slice().is_empty() {
+                // Two parameters per identity plus domain/IGP scope. Keep deletion
+                // inside the same transaction as the replacement inserts.
+                let identities: Vec<_> = fallback_replacements
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect();
+                gas_payment::Entity::delete_many()
+                    .filter(gas_payment::Column::Domain.eq(domain))
+                    .filter(
+                        gas_payment::Column::InterchainGasPaymaster
+                            .eq(interchain_gas_paymaster.clone()),
+                    )
+                    .filter(gas_payment::Column::TxId.is_null())
+                    .filter(
+                        Expr::tuple([
+                            Expr::col(gas_payment::Column::MsgId).into(),
+                            Expr::col(gas_payment::Column::LogIndex).into(),
+                        ])
+                        .in_tuples(identities),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+
             let mut models = models.into_iter();
             while !models.as_slice().is_empty() {
                 let chunk = models

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -137,8 +137,8 @@ async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
     // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERT statements.
     for count in [5_000_u32, 66_000] {
         let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
-        let mut results = vec![result("max_id", 0)];
-        results.extend((0..chunks).map(|_| Vec::new()));
+        let mut results = (0..chunks).map(|_| Vec::new()).collect::<Vec<_>>();
+        results.push(result("max_id", 0));
         results.extend((0..chunks).map(|_| result("id", 1)));
         results.push(result("num_items", i64::from(count)));
         let db = ScraperDb::with_connection(
@@ -197,6 +197,80 @@ async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
             .values
             .as_ref()
             .map_or(true, |values| values.0.len() <= usize::from(u16::MAX))));
+    }
+}
+
+#[tokio::test]
+async fn payment_fallback_replays_skip_count_baseline() {
+    for existing_tx_id in [None, Some(7)] {
+        let payments = payments(1);
+        let meta = LogMeta::default();
+        let existing = vec![BTreeMap::from([
+            (
+                "0".to_owned(),
+                Value::Bytes(Some(Box::new(hyperlane_core::h256_to_bytes(
+                    &payments[0].message_id,
+                )))),
+            ),
+            ("1".to_owned(), Value::BigInt(Some(0))),
+            ("2".to_owned(), Value::BigInt(existing_tx_id)),
+        ])];
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results([existing])
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &payment_rows(&payments, &meta, None))
+                .await
+                .unwrap(),
+            0
+        );
+        let log = db.0.into_transaction_log();
+        let statements = log[0].statements();
+        assert_eq!(statements.len(), 4);
+        assert_eq!(statements[0].sql, "BEGIN");
+        assert!(statements[1].sql.contains("pg_advisory_xact_lock"));
+        assert!(statements[2].sql.contains(" IN ("));
+        assert_eq!(statements[3].sql, "COMMIT");
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_baseline_errors_precede_writes() {
+    for fail_prefetch in [true, false] {
+        let mock =
+            MockDatabase::new(DatabaseBackend::Postgres).append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }]);
+        let mock = if fail_prefetch {
+            mock
+        } else {
+            mock.append_query_results([Vec::<BTreeMap<String, Value>>::new()])
+        };
+        let db = ScraperDb::with_connection(
+            mock.append_query_errors([sea_orm::DbErr::Custom("read failed".to_owned())])
+                .into_connection(),
+        );
+        let payments = payments(1);
+        let meta = LogMeta::default();
+        assert!(db
+            .store_payments(DOMAIN, &H256::zero(), &payment_rows(&payments, &meta, None))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("read failed"));
+        let log = db.0.into_transaction_log();
+        let statements = log[0].statements();
+        assert_eq!(statements.last().unwrap().sql, "ROLLBACK");
+        assert!(!statements
+            .iter()
+            .any(|s| s.sql.starts_with("INSERT") || s.sql.starts_with("DELETE")));
     }
 }
 
@@ -596,7 +670,7 @@ async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Re
 async fn payment_fallback_deletes_use_bounded_tuple_keys() {
     let payments = payments(6_000);
     let meta = LogMeta::default();
-    let mut results = vec![result("max_id", 0)];
+    let mut results = Vec::new();
     for chunk in payments.chunks(5_000) {
         // MockDatabase reads tuples by sorted-key position, not SQL column name.
         results.push(
@@ -617,6 +691,7 @@ async fn payment_fallback_deletes_use_bounded_tuple_keys() {
                 .collect(),
         );
     }
+    results.push(result("max_id", 0));
     results.extend([result("id", 1), result("id", 2), result("num_items", 6_000)]);
     let db = ScraperDb::with_connection(
         MockDatabase::new(DatabaseBackend::Postgres)


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Payment reconciliation reads the domain's maximum payment ID even when every incoming fallback payment is already represented and no rows will be written. The baseline is only used to count rows after writes.

## Solution

Read the baseline only in the existing nonempty-model branch, before replacement deletes and inserts. Keep prefetch, deduplication, reconciliation, counting, and commit under the same domain advisory lock and transaction. No-write replays still commit and return zero. Prefetch now precedes the baseline query, so its error can surface first; both read failures still abort before writes. Existing debug messages remain, with the writing message now preceding the baseline/deletion phase.

Stacked on #9515.

## Numerical impact

Source-derived SQL command counts, including transaction commands: a successful no-write fallback replay with one prefetch chunk goes from 5 to 4 commands (20% fewer): BEGIN, advisory lock, prefetch, COMMIT. With k prefetch chunks, k+4 becomes k+3. Batches that write rows retain the same command count; empty inputs remain zero. No measured latency, database CPU, or fleet-wide savings claim; replay frequency is unknown.

## Verification

Full scraper suite: 62 passed, 0 failed, 1 ignored (38.79s). Strict scraper production Clippy passed. New SQL regressions cover replay against existing NULL and resolved payment identities, and prefetch/baseline failures before writes. Existing real PostgreSQL tests cover fallback replay, replacement, unrelated identities, and rollback of deletes/inserts on a failed tail.

Normal commit hooks passed at `01818244cafd156f2b25029145938a18885551f7`. Root, validator, and relayer independent reviews found no blockers.
