### PR TITLE
perf(validator): consume checkpoint chunks without temporary vectors

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -581,18 +581,9 @@ impl ValidatorSubmitter {
             // A side effect is that new checkpoints will also be submitted in reverse order.
 
             // Keep bounded chunks so a storage/signing burst is paced before the next chunk.
-            let mut chunk = Vec::with_capacity(self.max_sign_concurrency);
-            for _ in 0..self.max_sign_concurrency {
-                if let Some(cp) = checkpoints.next() {
-                    chunk.push(cp);
-                } else {
-                    break;
-                }
-            }
-
-            let chunk_len = chunk.len();
-
-            let futures = chunk.into_iter().map(|checkpoint| {
+            let chunk_len = checkpoints.len().min(self.max_sign_concurrency);
+            let chunk = checkpoints.by_ref().take(self.max_sign_concurrency);
+            let futures = chunk.map(|checkpoint| {
                 let self_clone = arc_self.clone();
                 // The first popped checkpoint alone owns publication, even if a caller
                 // supplied the same maximum index more than once.

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -286,6 +286,51 @@ async fn compact_queue_materializes_only_the_active_chunk() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn checkpoint_chunks_preserve_boundaries_and_publication_across_join_all_threshold() {
+    for chunk_size in [1, 6, 30, 31, 50] {
+        let count = chunk_size * 2 + 1;
+        let writes = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_fetch_checkpoint()
+            .times(count)
+            .returning(|_| Ok(None));
+        syncer.expect_write_checkpoint().times(count).returning({
+            let writes = Arc::clone(&writes);
+            move |checkpoint| {
+                writes.lock().unwrap().push(checkpoint.value.index);
+                Ok(())
+            }
+        });
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq((count - 1) as u32))
+            .once()
+            .returning(|_| Ok(()));
+        let mut submitter = submission_test_submitter(syncer, dummy_readiness());
+        submitter.max_sign_concurrency = chunk_size;
+        let start = tokio::time::Instant::now();
+        submitter
+            .sign_and_submit_checkpoints((0..count as u32).map(submission_checkpoint))
+            .await;
+        assert_eq!(start.elapsed(), Duration::from_millis(200));
+        let writes = writes.lock().unwrap();
+        for (chunk, expected) in writes.chunks(chunk_size).zip(
+            (0..count as u32)
+                .rev()
+                .collect::<Vec<_>>()
+                .chunks(chunk_size),
+        ) {
+            let mut actual = chunk.to_vec();
+            actual.sort_unstable();
+            let mut expected = expected.to_vec();
+            expected.sort_unstable();
+            assert_eq!(actual, expected);
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
 async fn latest_index_waits_for_newest_checkpoint_but_not_older_siblings() {
     for failing_index in [7, 8] {
         let attempts = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Consolidated into #9471 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stack: follows #9516.

## Problem

Validator checkpoint submission creates an intermediate checkpoint vector for every signing chunk, then immediately consumes it to build `join_all`. The vector reserves the configured maximum even when the chunk contains only a few checkpoints.

## Solution

Pass the existing reversed iterator directly through bounded `take` and `map` into `join_all`. Keep chunk length reporting, newest-first groups, one latest-index publisher, retries, concurrency and inter-chunk pacing unchanged.

## Numerical evidence

Source-derived: each checkpoint occupies 104 bytes on this 64-bit build. At the default maximum concurrency 50, remove one allocation requesting 5,200 bytes per nonempty chunk. This includes short tail chunks. This is not an RSS or fleet CPU estimate.

Synthetic allocation probe using actual checkpoint and `join_all` types: 135 combinations of input lengths, concurrency limits and ready/suspended worker sizes produced matching ordered-output checksums with no allocation regression. Six checkpoints with 352-byte synthetic worker futures: 3→2 allocation calls and 7,384→2,184 requested bytes. 31 checkpoints across `join_all`'s threshold: 38→37 calls and 19,328→14,128 requested bytes. Initial inputs and real signing/storage work are excluded; actual signing-future layout is not claimed.

## Validation

New local-signer/mock-storage regression covers concurrency 1/6/30/31/50 with full and tail chunks, exact checkpoint groups, one maximum-index publication and exactly 200 ms total pacing across three written chunks. Existing tests cover retry/cancellation, lazy active-chunk materialization and all-existing/no-tail pacing. Full validator suite: 84 passed, zero failures. Strict production validator Clippy passed (`--no-deps -- -D warnings`); existing dependency warnings remain outside that package check.

Independent review found no signing/order/publication changes. This composes with earlier compact-queue and paced-submission work; neither exclusion gist covers this temporary allocation. No snapshot or RPC saving is claimed.

Normal commit hooks passed.
