### PR TITLE
perf(scraper): streamline CCR replay and cursor persistence

### DIFF
--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -1254,9 +1254,10 @@ impl Scraper {
                         }
                     }
 
-                    ccr_cursor.update(to_block.into()).await;
-                    if let Err(e) = ccr_cursor.flush().await {
-                        warn!(?e, from_block, to_block, "Failed to flush CCR cursor; advancing anyway, next flush will catch up");
+                    if !ccr_cursor.update(to_block.into()).await {
+                        if let Err(e) = ccr_cursor.flush().await {
+                            warn!(?e, from_block, to_block, "Failed to flush CCR cursor; advancing anyway, next flush will catch up");
+                        }
                     }
                     from_block = to_block.saturating_add(1);
                 }

--- a/rust/main/agents/scraper/src/db/block_cursor.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor.rs
@@ -76,8 +76,9 @@ impl BlockCursor {
         self.inner.read().await.height
     }
 
+    /// Update the in-memory height and report whether a throttled flush succeeded.
     #[instrument(skip(self), fields(cursor = ?self.inner))]
-    pub async fn update(&self, height: u64) {
+    pub async fn update(&self, height: u64) -> bool {
         let mut inner = self.inner.write().await;
 
         let old_height = inner.height;
@@ -89,10 +90,14 @@ impl BlockCursor {
         drop(inner);
 
         if should_flush {
-            if let Err(e) = self.flush().await {
-                warn!(error = ?e, "Failed to update database with new cursor. When you just started this, ensure that the migrations included this domain.")
+            match self.flush().await {
+                Ok(()) => return true,
+                Err(e) => {
+                    warn!(error = ?e, "Failed to update database with new cursor. When you just started this, ensure that the migrations included this domain.")
+                }
             }
         }
+        false
     }
 
     /// Persist the current height to the database unconditionally, bypassing the
@@ -152,3 +157,6 @@ impl ScraperDb {
         BlockCursor::new(self.clone_connection(), domain, event_type, default_height).await
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/agents/scraper/src/db/block_cursor/tests.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor/tests.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{Database, DatabaseBackend, DbErr, MockDatabase, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+
+// The CCR caller forces persistence only if update did not already succeed.
+async fn update_and_persist(cursor: &BlockCursor, height: u64) -> Result<()> {
+    if !cursor.update(height).await {
+        cursor.flush().await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn cursor_updates_report_success_without_losing_retry_or_throttle_behavior() {
+    // expired, requested height, failed writes, expected attempts
+    for (expired, height, failures, attempts) in [
+        (true, 100, 0, 1),
+        (false, 100, 0, 1),
+        (true, 50, 0, 1),
+        (true, 40, 0, 1),
+        (true, 100, 1, 2),
+        (true, 100, 2, 2),
+    ] {
+        let mock = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_errors((0..failures).map(|_| DbErr::Custom("write failed".to_owned())))
+            .append_query_results([vec![BTreeMap::from([(
+                "id".to_owned(),
+                Value::BigInt(Some(1)),
+            )])]]);
+        let last_saved_at = Instant::now()
+            - if expired {
+                Duration::from_secs(11)
+            } else {
+                Duration::ZERO
+            };
+        let cursor = BlockCursor {
+            db: mock.into_connection(),
+            domain: 1,
+            event_type: "ccr_swap".to_owned(),
+            inner: RwLock::new(BlockCursorInner {
+                height: 50,
+                last_saved_at,
+            }),
+        };
+        let result = update_and_persist(&cursor, height).await;
+        assert_eq!(result.is_err(), failures == 2);
+        assert_eq!(cursor.height().await, height.max(50));
+        let saved = cursor.inner.read().await.last_saved_at;
+        if failures == 2 {
+            assert_eq!(saved, last_saved_at);
+        } else {
+            assert!(saved > last_saved_at);
+        }
+        let log = cursor.db.into_transaction_log();
+        assert_eq!(log.len(), attempts);
+        for entry in log {
+            let query = &entry.statements()[0];
+            assert!(query.sql.starts_with("INSERT INTO \"cursor\""));
+            assert!(query.sql.contains("GREATEST"));
+            let values = &query.values.as_ref().unwrap().0;
+            assert!(values.contains(&Value::BigInt(Some(height.max(50) as i64))));
+            assert!(values.contains(&Value::String(Some(Box::new("ccr_swap".to_owned())))));
+        }
+    }
+}
+
+#[tokio::test]
+async fn cursor_throttled_update_alone_does_not_write() {
+    let cursor = BlockCursor {
+        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        domain: 1,
+        event_type: String::new(),
+        inner: RwLock::new(BlockCursorInner {
+            height: 50,
+            last_saved_at: Instant::now(),
+        }),
+    };
+    assert!(!cursor.update(100).await);
+    assert_eq!(cursor.height().await, 100);
+    assert!(cursor.db.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn cursor_persistence_is_monotonic_scoped_and_survives_reopen_in_postgres() -> Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let connection = Database::connect(&url).await?;
+    migration::Migrator::up(&connection, None).await?;
+    let connection = ScraperDb::with_connection(connection);
+    let first = BlockCursor::new(connection.clone_connection(), 1, "ccr_swap", 50).await?;
+    let second = BlockCursor::new(Database::connect(&url).await?, 1, "ccr_swap", 50).await?;
+    let messages = BlockCursor::new(connection.clone_connection(), 1, "", 10).await?;
+    let other_domain = BlockCursor::new(connection.clone_connection(), 137, "ccr_swap", 20).await?;
+    update_and_persist(&messages, 11).await?;
+    update_and_persist(&other_domain, 21).await?;
+    first.inner.write().await.last_saved_at = Instant::now() - Duration::from_secs(11);
+    let (a, b) = tokio::join!(
+        update_and_persist(&first, 100),
+        update_and_persist(&second, 80)
+    );
+    a?;
+    b?;
+    update_and_persist(&second, 60).await?; // Stale writer must not lower SQL height.
+    drop(first);
+    drop(second);
+    drop(messages);
+    drop(other_domain);
+    drop(connection);
+    let reopened = ScraperDb::with_connection(Database::connect(&url).await?);
+    assert_eq!(
+        BlockCursor::new(reopened.clone_connection(), 1, "ccr_swap", 0)
+            .await?
+            .height()
+            .await,
+        100
+    );
+    assert_eq!(
+        BlockCursor::new(reopened.clone_connection(), 1, "", 0)
+            .await?
+            .height()
+            .await,
+        11
+    );
+    assert_eq!(
+        BlockCursor::new(reopened.clone_connection(), 137, "ccr_swap", 0)
+            .await?
+            .height()
+            .await,
+        21
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/same_chain_ccr_swap.rs
+++ b/rust/main/agents/scraper/src/db/same_chain_ccr_swap.rs
@@ -1,6 +1,6 @@
 use ethers::utils::keccak256;
 use eyre::Result;
-use sea_orm::{prelude::*, QueryOrder, QuerySelect};
+use sea_orm::{prelude::*, QueryOrder, QuerySelect, QueryTrait};
 use tracing::instrument;
 
 use hyperlane_core::{
@@ -61,7 +61,7 @@ impl ScraperDb {
     ///   - Full re-index (DB wiped): blocks are always replayed in ascending
     ///     order, so swaps are seen in the same sequence and receive identical
     ///     nonces. Safe.
-    ///   - Partial re-index (rows already present): the `ccr_msg_already_stored`
+    ///   - Partial re-index (rows already present): the `ccr_pair_presence`
     ///     pre-check in `store_ccr_swaps_as_messages` skips already-stored swaps,
     ///     so existing nonces are never disturbed. Safe.
     ///   - Partial DB corruption (some rows deleted then re-indexed): deleted
@@ -90,23 +90,22 @@ impl ScraperDb {
         Ok(next)
     }
 
-    /// Returns true if a message with this `msg_id` is already stored.
-    /// Used to skip re-insertion when re-indexing a block range.
-    async fn ccr_msg_already_stored(&self, msg_id: H256) -> Result<bool> {
-        let count = message::Entity::find()
-            .filter(message::Column::MsgId.eq(h256_to_bytes(&msg_id)))
-            .count(&self.0)
-            .await?;
-        Ok(count > 0)
-    }
-
-    /// Returns true if a delivery row for this `msg_id` is already stored.
-    async fn ccr_delivery_already_stored(&self, msg_id: H256) -> Result<bool> {
-        let count = delivered_message::Entity::find()
+    /// None means no message; Some reports whether its delivery is also stored.
+    /// Both presence checks use one snapshot. Nonce allocation still assumes
+    /// the existing single writer per domain; this is not a cross-process lock.
+    async fn ccr_pair_presence(&self, msg_id: H256) -> Result<Option<bool>> {
+        let delivery = delivered_message::Entity::find()
+            .select_only()
+            .column(delivered_message::Column::Id)
             .filter(delivered_message::Column::MsgId.eq(h256_to_bytes(&msg_id)))
-            .count(&self.0)
-            .await?;
-        Ok(count > 0)
+            .into_query();
+        Ok(message::Entity::find()
+            .select_only()
+            .expr_as(Expr::exists(delivery), "delivery_stored")
+            .filter(message::Column::MsgId.eq(h256_to_bytes(&msg_id)))
+            .into_tuple::<bool>()
+            .one(&self.0)
+            .await?)
     }
 
     /// Store same-chain CCR swaps as synthetic Hyperlane messages so the
@@ -133,15 +132,15 @@ impl ScraperDb {
             let swap = storable.swap;
             let msg_id = synthetic_ccr_msg_id(storable.meta);
 
-            let msg_stored = self.ccr_msg_already_stored(msg_id).await?;
+            let presence = self.ccr_pair_presence(msg_id).await?;
             // Skip only when both rows are present. If the message was written
             // but the delivery was not (partial-commit on a prior retry), fall
             // through so the delivery upsert can complete the pair.
-            if msg_stored && self.ccr_delivery_already_stored(msg_id).await? {
+            if presence == Some(true) {
                 continue;
             }
 
-            if !msg_stored {
+            if presence.is_none() {
                 // Sequential nonce is non-deterministic across re-index runs, so
                 // guard insertion on msg_id rather than relying on ON CONFLICT.
                 let nonce = self.ccr_next_nonce(domain, &swap.source_router).await?;
@@ -260,3 +259,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "same_chain_ccr_swap/presence_tests.rs"]
+mod presence_tests;

--- a/rust/main/agents/scraper/src/db/same_chain_ccr_swap/presence_tests.rs
+++ b/rust/main/agents/scraper/src/db/same_chain_ccr_swap/presence_tests.rs
@@ -1,0 +1,248 @@
+use std::collections::BTreeMap;
+
+use hyperlane_core::{BlockInfo, TxnInfo, TxnReceiptInfo, H512, U256};
+use migration::MigratorTrait;
+use sea_orm::{Database, DatabaseBackend, DbErr, MockDatabase, MockExecResult, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+use crate::db::StorableTxn;
+
+fn swap() -> SameChainCcrSwap {
+    SameChainCcrSwap {
+        domain: 1,
+        source_router: H256::from_low_u64_be(11),
+        destination_router: H256::from_low_u64_be(12),
+        amount_received: U256::from(1234),
+        recipient: H256::from_low_u64_be(13),
+    }
+}
+
+fn result(key: &str, value: Value) -> Vec<BTreeMap<String, Value>> {
+    vec![BTreeMap::from([(key.to_owned(), value)])]
+}
+
+#[tokio::test]
+async fn ccr_presence_preserves_states_and_command_counts() {
+    for (presence, expected_count, commands) in
+        [(Some(true), 0, 1), (Some(false), 1, 4), (None, 1, 6)]
+    {
+        let mut query_results = vec![presence
+            .map(|b| result("delivery_stored", Value::Bool(Some(b))))
+            .unwrap_or_default()];
+        let mut exec_results = vec![];
+        // The fresh-pair path also reaches the dispatch store, which inserts
+        // inside an explicit transaction and counts affected rows: it consumes
+        // an execution result, not the removed MAX/INSERT/COUNT sequence.
+        if presence.is_none() {
+            query_results.push(Vec::new()); // No prior nonce.
+            exec_results.push(MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            });
+        }
+        if presence != Some(true) {
+            // Delivery upsert still uses scoped MAX(id) lookup, INSERT, and
+            // COUNT accounting.
+            query_results.extend([
+                result("max_id", Value::BigInt(Some(0))),
+                result("id", Value::BigInt(Some(1))),
+                result("num_items", Value::BigInt(Some(1))),
+            ]);
+        }
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(query_results)
+                .append_exec_results(exec_results)
+                .into_connection(),
+        );
+        let swap = swap();
+        let meta = LogMeta::default();
+        assert_eq!(
+            db.store_ccr_swaps_as_messages(
+                1,
+                &[StorableCcrSwap {
+                    swap: &swap,
+                    meta: &meta,
+                    txn_id: 1
+                }]
+            )
+            .await
+            .unwrap(),
+            expected_count
+        );
+        let log = db.0.into_transaction_log();
+        assert_eq!(log.len(), commands);
+        let query = &log[0].statements()[0];
+        assert!(query.sql.starts_with("SELECT EXISTS(SELECT"));
+        assert!(query.sql.contains("\"delivered_message\".\"msg_id\" ="));
+        assert!(query.sql.contains("\"message\".\"msg_id\" ="));
+        assert!(query.sql.contains("LIMIT"));
+        let expected_id = Value::Bytes(Some(Box::new(h256_to_bytes(&synthetic_ccr_msg_id(&meta)))));
+        assert_eq!(
+            query
+                .values
+                .as_ref()
+                .unwrap()
+                .0
+                .iter()
+                .filter(|value| **value == expected_id)
+                .count(),
+            2
+        );
+    }
+}
+
+#[tokio::test]
+async fn ccr_presence_errors_prevent_writes_and_empty_input_skips_queries() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_errors([DbErr::Custom("presence failed".to_owned())])
+            .into_connection(),
+    );
+    assert_eq!(db.store_ccr_swaps_as_messages(1, &[]).await.unwrap(), 0);
+    let swap = swap();
+    let meta = LogMeta::default();
+    assert!(db
+        .store_ccr_swaps_as_messages(
+            1,
+            &[StorableCcrSwap {
+                swap: &swap,
+                meta: &meta,
+                txn_id: 1
+            }]
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("presence failed"));
+    assert_eq!(db.0.into_transaction_log().len(), 1);
+}
+
+#[tokio::test]
+async fn ccr_presence_repairs_partial_and_orphan_pairs_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let block_hash = H256::from_low_u64_be(100);
+    let block_id = db
+        .store_blocks(
+            1,
+            [BlockInfo {
+                hash: block_hash,
+                timestamp: 1_700_000_000,
+                number: 50,
+            }]
+            .into_iter(),
+        )
+        .await?[0]
+        .id;
+    let tx_hash = H512::from_low_u64_be(101);
+    let txn_id = db
+        .store_txns(
+            [StorableTxn {
+                block_id,
+                info: TxnInfo {
+                    hash: tx_hash,
+                    gas_limit: U256::one(),
+                    max_priority_fee_per_gas: None,
+                    max_fee_per_gas: None,
+                    gas_price: None,
+                    nonce: 0,
+                    sender: H256::zero(),
+                    recipient: None,
+                    receipt: Some(TxnReceiptInfo {
+                        gas_used: U256::one(),
+                        cumulative_gas_used: U256::one(),
+                        effective_gas_price: None,
+                    }),
+                    raw_input_data: None,
+                },
+            }]
+            .into_iter(),
+        )
+        .await?[&tx_hash];
+    let swap = swap();
+    let meta = LogMeta {
+        transaction_id: tx_hash,
+        block_hash,
+        block_number: 50,
+        ..Default::default()
+    };
+    let row = || StorableCcrSwap {
+        swap: &swap,
+        meta: &meta,
+        txn_id,
+    };
+    let msg_id = synthetic_ccr_msg_id(&meta);
+    assert_eq!(db.ccr_pair_presence(msg_id).await?, None);
+    // Repeated input must insert one pair, then recognize the pair immediately.
+    assert_eq!(db.store_ccr_swaps_as_messages(1, &[row(), row()]).await?, 1);
+    assert_eq!(db.ccr_pair_presence(msg_id).await?, Some(true));
+    let original = message::Entity::find().one(&db.0).await?.unwrap();
+    assert_eq!(original.nonce, 0);
+    assert_eq!(db.store_ccr_swaps_as_messages(1, &[row()]).await?, 0);
+
+    delivered_message::Entity::delete_many()
+        .filter(delivered_message::Column::MsgId.eq(h256_to_bytes(&msg_id)))
+        .exec(&db.0)
+        .await?;
+    // An unrelated delivery must not cause the partial pair to appear complete.
+    db.store_deliveries(
+        1,
+        swap.destination_router,
+        [StorableDelivery {
+            message_id: H256::from_low_u64_be(999),
+            sequence: None,
+            meta: &meta,
+            txn_id: Some(txn_id),
+        }]
+        .into_iter(),
+    )
+    .await?;
+    assert_eq!(db.ccr_pair_presence(msg_id).await?, Some(false));
+    assert_eq!(db.store_ccr_swaps_as_messages(1, &[row()]).await?, 1);
+    assert_eq!(message::Entity::find().one(&db.0).await?.unwrap(), original);
+
+    // Retain another message so orphan repair must allocate MAX(nonce) + 1.
+    let other_meta = LogMeta {
+        log_index: U256::one(),
+        ..meta.clone()
+    };
+    assert_eq!(
+        db.store_ccr_swaps_as_messages(
+            1,
+            &[StorableCcrSwap {
+                swap: &swap,
+                meta: &other_meta,
+                txn_id
+            }]
+        )
+        .await?,
+        1
+    );
+    // An orphan delivery must not suppress message creation or nonce allocation.
+    message::Entity::delete_many()
+        .filter(message::Column::MsgId.eq(h256_to_bytes(&msg_id)))
+        .exec(&db.0)
+        .await?;
+    assert_eq!(db.ccr_pair_presence(msg_id).await?, None);
+    assert_eq!(db.store_ccr_swaps_as_messages(1, &[row(), row()]).await?, 1);
+    assert_eq!(db.ccr_pair_presence(msg_id).await?, Some(true));
+    let restored = message::Entity::find()
+        .filter(message::Column::MsgId.eq(h256_to_bytes(&msg_id)))
+        .one(&db.0)
+        .await?
+        .unwrap();
+    assert_eq!(restored.msg_id, original.msg_id);
+    assert_eq!(restored.nonce, 2);
+    assert_eq!(restored.msg_body, original.msg_body);
+    assert_eq!(restored.origin_tx_id, Some(txn_id));
+    Ok(())
+}


### PR DESCRIPTION
## Problem

CCR replay checked message and delivery presence separately. Its cursor caller could also repeat an upsert immediately after a successful throttled flush.

## Solution

Combine pair presence into one three-state lookup: absent message, message without delivery, or complete pair. Retain nonce allocation for absent messages, including orphan deliveries. Reuse successful cursor flushes while retaining forced persistence and immediate retry when the initial flush fails. Presence shares one statement snapshot; nonce allocation retains the existing single-writer-per-domain assumption.

Consolidates #9521 and #9522. Stacked on #9468's consolidated lookup/enrichment changes.

## Numerical evidence

Complete replay 2→1 SQL commands; partial repair 5→4; fresh pairs remain 8. An advancing CCR cursor whose throttle expired and first flush succeeds uses 1 rather than 2 upserts. Throttled/no-advance paths remain 1; failed-first-write paths retain 2 attempts. These are distinct mechanisms, not additive percentages. Eligible CCR volume and fleet latency savings are unknown.

## Validation

This consolidated intermediate tree passed 68 scraper tests (0 failures, 1 ignored; 31.82s). PostgreSQL tests cover complete/partial/orphan pairs, unrelated deliveries, duplicate replay, nonce continuation, concurrent/stale cursor writers, scoped height, and restart readback. Mock cursor tests cover throttle, no advance, success and both failure/retry outcomes. Final warning/range-advance source is unchanged; tests do not assert the complete polling loop's log output.

New strict scraper production Clippy passed (39.46s), and normal commit hooks passed (exit 0).
