### PR TITLE
perf(lander): avoid copies at VM submission boundaries

### DIFF
--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -657,13 +657,7 @@ impl AdaptsChain for EthereumAdapter {
         use super::transaction::Precursor;
         use LanderError::TxAlreadyExists;
 
-        let tx_for_nonce = tx.clone();
-        let tx_for_gas_price = tx.clone();
-
-        let (nonce, gas_price) = try_join!(
-            self.calculate_nonce(&tx_for_nonce),
-            self.estimate_gas_price(&tx_for_gas_price)
-        )?;
+        let (nonce, gas_price) = try_join!(self.calculate_nonce(tx), self.estimate_gas_price(tx))?;
 
         // Update the transaction with nonce before checking if resubmission makes sense
         // This ensures the nonce is stored even if we decide not to resubmit due to gas price limits

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_submit.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_submit.rs
@@ -759,3 +759,64 @@ async fn build_and_store_transaction(
 
     tx_results[0].maybe_tx.clone().unwrap()
 }
+
+#[tokio::test]
+async fn failed_nonce_read_keeps_transaction_and_nonce_state_unchanged() {
+    let (payload_db, tx_db, nonce_db) = tmp_dbs();
+    let signer = Address::random();
+    let mut provider = MockEvmProvider::new();
+    provider
+        .expect_get_next_nonce_on_finalized_block()
+        .once()
+        .returning(|_, _| {
+            Err(ChainCommunicationError::CustomError(
+                "nonce read failure".to_owned(),
+            ))
+        });
+    // Gas reads may be polled before the nonce failure. They remain read-only;
+    // no send expectation means submitting before both reads finish would fail.
+    provider.expect_get_block().returning(|_| {
+        Ok(Some(ethers::types::Block {
+            number: Some(42.into()),
+            base_fee_per_gas: Some(100.into()),
+            gas_limit: 30_000_000.into(),
+            ..Default::default()
+        }))
+    });
+    provider.expect_fee_history().returning(|_, _, _| {
+        Ok(ethers::types::FeeHistory {
+            oldest_block: 0.into(),
+            reward: vec![vec![10.into()]],
+            base_fee_per_gas: vec![200_000.into()],
+            gas_used_ratio: vec![0.0],
+        })
+    });
+    let adapter = mock_ethereum_adapter(
+        provider,
+        payload_db.clone(),
+        tx_db,
+        nonce_db.clone(),
+        signer,
+        Duration::from_millis(100),
+        Duration::from_millis(100),
+    );
+    let mut tx = build_and_store_transaction(&adapter, &payload_db).await;
+    tx.payload_details[0].success_criteria = Some(vec![7; 4096]);
+    let before = tx.clone();
+    let error = adapter.submit(&mut tx).await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Failed to update boundary nonces: Provider error"
+    );
+    assert_eq!(tx, before);
+    assert!(nonce_db
+        .retrieve_finalized_nonce_by_signer_address(&signer)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(nonce_db
+        .retrieve_upper_nonce_by_signer_address(&signer)
+        .await
+        .unwrap()
+        .is_none());
+}

--- a/rust/main/lander/src/adapter/chains/radix/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/radix/adapter.rs
@@ -409,12 +409,11 @@ impl AdaptsChain for RadixAdapter {
             u64::from_le_bytes(b[0..8].try_into().expect("uuid is 16 bytes"))
         };
         let radix_tx = self.build_transaction(tx, intent_discriminator).await?;
-        self.provider
-            .send_transaction(radix_tx.raw.clone().to_vec())
-            .await?;
-
-        // once tx is built, we can figure out tx hash
+        // The hash is already available from the built transaction.
         let tx_hash = Self::extract_tx_hash(&radix_tx);
+        self.provider
+            .send_transaction(radix_tx.raw.to_vec())
+            .await?;
         if !tx.tx_hashes.contains(&tx_hash) {
             tx.tx_hashes.push(tx_hash);
         }

--- a/rust/main/lander/src/adapter/chains/radix/adapter/tests/tests_submit.rs
+++ b/rust/main/lander/src/adapter/chains/radix/adapter/tests/tests_submit.rs
@@ -54,9 +54,22 @@ async fn test_radix_submit_tx() {
             ..Default::default()
         })
     });
+    let submitted = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = submitted.clone();
     provider
         .expect_send_transaction()
-        .returning(|_| Ok(TransactionSubmitResponse::new(false)));
+        .times(3)
+        .returning(move |raw| {
+            let mut attempts = captured.lock().unwrap();
+            attempts.push(raw);
+            if attempts.len() == 1 {
+                Err(hyperlane_core::ChainCommunicationError::CustomError(
+                    "submission failed".to_owned(),
+                ))
+            } else {
+                Ok(TransactionSubmitResponse::new(false))
+            }
+        });
 
     let mut counter = 0;
     provider.expect_preview_tx().returning(move |_ops| {
@@ -134,6 +147,14 @@ async fn test_radix_submit_tx() {
         last_status_check: None,
     };
 
+    // Failed sends must not publish the already computed hash into the transaction.
+    let before = transaction.clone();
+    assert!(adapter.submit(&mut transaction).await.is_err());
+    assert_eq!(transaction, before);
+
+    let built = adapter.build_transaction(&transaction, 0).await.unwrap();
+    let expected_raw = built.raw.to_vec();
+
     // when
     adapter
         .submit(&mut transaction)
@@ -148,6 +169,11 @@ async fn test_radix_submit_tx() {
 
     let precursor = transaction.precursor();
     assert_eq!(precursor.tx_hash, Some(expected_hash));
+    adapter.submit(&mut transaction).await.unwrap();
+    assert_eq!(transaction.tx_hashes, vec![expected_hash]);
+    let attempts = submitted.lock().unwrap();
+    assert_eq!(attempts.len(), 3);
+    assert!(attempts.iter().all(|raw| raw == &expected_raw));
 }
 
 #[ignore]


### PR DESCRIPTION
## Problem

EVM submission clones the complete transaction twice before shared nonce/gas reads. Radix submission clones a freshly built signed byte buffer before passing ownership to its provider.

## Solution

Use shared EVM transaction borrows in the same try_join. Read Radix’s already computed hash, then consume the raw byte wrapper. All transaction mutations remain after the same successful acquisition/submission boundaries; signing and provider interfaces are unchanged.

## Numerical evidence

| Change / original PR | Measured removed work |
| --- | --- |
| EVM shared reads [#9523](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9523) | Actual 4 KiB transaction fixture: 10 allocations/9,170 requested bytes removed; 32 B: 1,042 bytes, 64 KiB: 132,050 bytes |
| Radix buffer move [#9525](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9525) | Signed synthetic V2 wire sizes 189/704/4,288/65,729 bytes each remove one allocation and that entire requested byte count |

EVM measures only the two removed clones. Radix measures clone-versus-move after signing/fixture construction and verifies exact bytes plus original buffer identity. Synthetic blob manifests demonstrate encoding, not chain execution. Provider, nonce/signing and future costs are excluded; no CPU, physical RPC or fleet RSS claim.

## Validation

Fresh at the consolidated commit: all Lander adapter-chain tests 230 passed / one existing ignored, strict production Lander Clippy passed, and normal commit hooks passed. EVM regression checks its exact existing provider-error wrapper and unchanged transaction/boundaries for that early failure; no general nonce-state rollback claim. Radix checks failed-send state preservation, known hash, repeated-hash dedup and byte-for-byte builder output. Existing nonce reset/resubmission suites retained.

Stack: follows [#9496](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9496). Consolidates the two linked PRs without code changes; final grouped tree exactly matches original `c6ca193`. Aggregate 49 evidence is retained explicitly. No deployment implied.
