### PR TITLE
perf(validator): share submitter ownership during latest-index retries

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -519,7 +519,7 @@ impl ValidatorSubmitter {
     }
 
     /// Publishes availability only after the highest checkpoint itself is durable.
-    async fn publish_latest_checkpoint_index(&self, index: u32) {
+    async fn publish_latest_checkpoint_index(self: &Arc<Self>, index: u32) {
         call_and_retry_indefinitely(|| {
             let self_clone = self.clone();
             Box::pin(async move {

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -1617,3 +1617,75 @@ async fn unchanged_tree_checkpoint_preserves_root_index_namespace_and_block() {
         assert_eq!(tree.index(), expected.index);
     }
 }
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_publication_reuses_submitter_handles_across_retries() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let syncer = Arc::new_cyclic(|weak: &std::sync::Weak<MockCheckpointSyncer>| {
+        let weak = weak.clone();
+        let attempts = Arc::clone(&attempts);
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq(8))
+            .times(2)
+            .returning(move |_| {
+                assert_eq!(
+                    weak.strong_count(),
+                    1,
+                    "publication must reuse the submitter, not clone its storage handle"
+                );
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(eyre::eyre!("latest index unavailable"))
+                } else {
+                    Ok(())
+                }
+            });
+        syncer
+    });
+    let readiness = dummy_readiness();
+    let mut submitter =
+        submission_test_submitter(MockCheckpointSyncer::new(), Arc::clone(&readiness));
+    submitter.checkpoint_syncer = syncer;
+    let submitter = Arc::new(submitter);
+    let start = tokio::time::Instant::now();
+    submitter.publish_latest_checkpoint_index(8).await;
+    assert_eq!(
+        start.elapsed(),
+        hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION
+    );
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(Arc::strong_count(&submitter), 1);
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_publication_cancellation_stops_retry_and_releases_submitter() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer.expect_update_latest_index().once().returning({
+        let attempts = Arc::clone(&attempts);
+        move |_| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err(eyre::eyre!("latest index unavailable"))
+        }
+    });
+    let readiness = dummy_readiness();
+    let submitter = Arc::new(submission_test_submitter(syncer, Arc::clone(&readiness)));
+    let task = tokio::spawn({
+        let submitter = Arc::clone(&submitter);
+        async move { submitter.publish_latest_checkpoint_index(8).await }
+    });
+    while attempts.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        readiness.snapshot().blocked_operations,
+        vec!["checkpoint_latest_index"]
+    );
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(Arc::strong_count(&submitter), 1);
+    tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
Consolidated into #9471 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Stack: follows #9520.

## Problem

Latest-checkpoint-index publication clones the whole validator submitter on every retry attempt, including its signer and shared handles, although the caller already owns an Arc to that submitter.

## Solution

Change the private method receiver to `self: &Arc<Self>`. Its existing retry closure now clones that Arc. The sole caller, retry helper, storage/readiness operations and timing remain unchanged.

## Numerical evidence

Measured layout using the actual production attempt body and validator fixture: boxed future 64→48 bytes, a 16-byte (25%) reduction per attempt on this 64-bit build. Both versions still allocate one Box; this is not a runtime/RSS estimate.

Separate optimized actual-signer clone probe: a GCP signer with a synthetic 88-byte key-version name allocates 1 time/88 bytes when cloned, versus 0/0 for its Arc. The SDK fixture uses an in-process public-key stub with no network or credentials. A local signer allocates 0/0 in both cases. These are signer-component measurements, not end-to-end publication allocation or fleet CPU claims; AWS is unbenchmarked.

## Validation

Full validator suite: 86 passed, zero failures. New tests prove shared storage-handle reuse through a failed/successful retry, exact 2-second retry delay, readiness cleanup, and cancellation stopping further attempts/releasing Arcs. Existing publication/durability tests remain. Independent scraper review clear. Strict production validator Clippy passed (`--no-deps -- -D warnings`); existing dependency warnings remain outside that package check.

The change is private and composes with prior checkpoint batching/publication work. It does not duplicate excluded snapshot, cache or provider work.

Normal commit hooks passed.
