### PR TITLE
perf(core): reserve canonical message encoding buffers

### DIFF
--- a/rust/main/hyperlane-core/src/types/message.rs
+++ b/rust/main/hyperlane-core/src/types/message.rs
@@ -18,9 +18,7 @@ pub type RawHyperlaneMessage = Vec<u8>;
 
 impl From<&HyperlaneMessage> for RawHyperlaneMessage {
     fn from(m: &HyperlaneMessage) -> Self {
-        let mut message_vec = vec![];
-        m.write_to(&mut message_vec).expect("!write_to");
-        message_vec
+        m.to_vec()
     }
 }
 
@@ -107,6 +105,13 @@ impl From<&RawHyperlaneMessage> for HyperlaneMessage {
 }
 
 impl Encode for HyperlaneMessage {
+    fn to_vec(&self) -> Vec<u8> {
+        let mut bytes =
+            Vec::with_capacity(HYPERLANE_MESSAGE_PREFIX_LEN.saturating_add(self.body.len()));
+        self.write_to(&mut bytes).expect("!alloc");
+        bytes
+    }
+
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
         W: std::io::Write,
@@ -186,6 +191,30 @@ mod tests {
 
     fn valid_message_bytes() -> RawHyperlaneMessage {
         RawHyperlaneMessage::from(&sample_message())
+    }
+
+    #[test]
+    fn owned_encodings_match_canonical_writer_at_capacity_boundaries() {
+        use crate::Encode;
+
+        for body_len in [0, 1, 4, 5, 31, 32, 63, 64, 127, 128, 4096, 65536] {
+            for nonce in [0, 42, u32::MAX] {
+                let message = HyperlaneMessage {
+                    nonce,
+                    body: (0..body_len).map(|i| i as u8).collect(),
+                    ..sample_message()
+                };
+                let mut canonical = Vec::new();
+                let written = message.write_to(&mut canonical).unwrap();
+                assert_eq!(written, HYPERLANE_MESSAGE_PREFIX_LEN + body_len);
+                assert_eq!(message.to_vec(), canonical);
+                assert_eq!(RawHyperlaneMessage::from(&message), canonical);
+                assert_eq!(
+                    HyperlaneMessage::read_from(&mut canonical.as_slice()).unwrap(),
+                    message
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Consolidated into #9489 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Problem: owned Hyperlane message encoding grows an initially empty Vec across the fixed 77-byte header and body. Both Encode::to_vec and RawHyperlaneMessage conversion need a final owned buffer, but currently reallocate it repeatedly.

Solution: reserve the canonical header-plus-body length once, then use the unchanged writer. Route raw-message conversion through the same implementation. Arbitrary writers, wire bytes and decoding stay unchanged.

Numerical evidence: optimized allocation probe using the actual message type and source-equivalent reservation path, with fixture construction excluded:

| Body bytes | Allocation/reallocation calls before → after | Requested bytes before → after |
| --- | --- | --- |
| 0 | 4 → 1 | 147 → 77 |
| 32 | 5 → 1 | 311 → 109 |
| 4,096 | 5 → 1 | 4,320 → 4,173 |
| 65,536 | 5 → 1 | 65,760 → 65,613 |

All ten probed sizes preserve exact output bytes. These are per-owned-encoding allocation counts, not CPU, native database allocation, retained memory or fleet RSS measurements. One output allocation remains. This applies to remaining owned encodings; do not add it to #9493's streaming message-ID savings.

Validation: 55 default-feature core tests and 64 agent/matching-list core tests passed (two existing ignored in each suite; overlapping suites are not additive). New regression covers 36 body-length/nonce combinations, canonical writer equivalence, both owned entry points and decoding. Shared-crate Clippy passed with documented existing cfg(dev)/derivable_impls diagnostics allowed; no source suppressions. Normal commit hooks passed. Independent review found no blocking issue. The two stacks compose without a source conflict and retain both message-ID and owned-encoding tests.

Stack: follows #9524; shared core change carried on the validator stack.
