### PR TITLE
perf(lander): borrow building results through channel handoff

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -52,10 +52,7 @@ impl BuildingStage {
         for tx_building_result in tx_building_results {
             // push payloads that failed to be processed (but didn't fail simulation)
             // to the back of the queue
-            if let Err(err) = self
-                .handle_tx_building_result(tx_building_result.clone())
-                .await
-            {
+            if let Err(err) = self.handle_tx_building_result(&tx_building_result).await {
                 error!(?err, payloads=?tx_building_result.payloads, "Error handling tx building result");
                 let full_payloads =
                     get_full_payloads_from_details(payloads, &tx_building_result.payloads);
@@ -74,7 +71,7 @@ impl BuildingStage {
     )]
     async fn handle_tx_building_result(
         &self,
-        tx_building_result: TxBuildingResult,
+        tx_building_result: &TxBuildingResult,
     ) -> eyre::Result<(), LanderError> {
         let TxBuildingResult { payloads, maybe_tx } = tx_building_result;
         let Some(tx) = maybe_tx else {
@@ -84,18 +81,18 @@ impl BuildingStage {
             );
             self.state
                 .update_status_for_payloads(
-                    &payloads,
+                    payloads,
                     PayloadStatus::Dropped(DropReason::FailedToBuildAsTransaction),
                 )
                 .await;
             return Ok(());
         };
         info!(?tx, "Transaction built successfully");
-        self.state.store_tx(&tx).await;
+        self.state.store_tx(tx).await;
         // Only send tx to inclusion stage after we stored it
         // This prevents TX from dropping in case the send operation fails
         call_until_success_or_nonretryable_error(
-            || self.send_tx_to_inclusion_stage(tx.clone()),
+            || self.send_tx_to_inclusion_stage(tx),
             "Sending transaction to inclusion stage",
             &self.state,
         )
@@ -103,7 +100,7 @@ impl BuildingStage {
         Ok(())
     }
 
-    async fn send_tx_to_inclusion_stage(&self, tx: Transaction) -> eyre::Result<(), LanderError> {
+    async fn send_tx_to_inclusion_stage(&self, tx: &Transaction) -> eyre::Result<(), LanderError> {
         if let Err(err) = self.inclusion_stage_sender.send(tx.clone()).await {
             return Err(LanderError::ChannelSendFailure(Box::new(err)));
         }

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building/tests.rs
@@ -9,6 +9,7 @@ use crate::tests::test_utils::{dummy_tx, initialize_payload_db, tmp_dbs, MockAda
 use crate::transaction::{Transaction, TransactionStatus, TransactionUuid};
 
 use super::{BuildingStage, BuildingStageQueue};
+use crate::LanderError;
 
 #[tokio::test]
 async fn test_empty_queue_no_payloads_processed() {
@@ -389,4 +390,91 @@ async fn assert_db_status_for_payloads(
             .unwrap();
         assert_eq!(payload_from_db.status, expected_status);
     }
+}
+
+#[tokio::test]
+async fn borrowed_build_result_preserves_storage_channel_and_error_ownership() {
+    for closed in [false, true] {
+        let (stage, mut receiver, _) = test_setup(0, true);
+        let mut payload = FullPayload::random();
+        payload.details.success_criteria = Some(vec![7; 4096]);
+        initialize_payload_db(&stage.state.payload_db, &payload).await;
+        let result = dummy_built_tx(vec![payload], true).pop().unwrap();
+        let original = result.clone();
+        let tx = result.maybe_tx.as_ref().unwrap();
+        let pointer = tx.payload_details[0]
+            .success_criteria
+            .as_ref()
+            .unwrap()
+            .as_ptr();
+        if closed {
+            receiver.close();
+        }
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            stage.handle_tx_building_result(&result),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, original);
+        assert_eq!(
+            tx.payload_details[0]
+                .success_criteria
+                .as_ref()
+                .unwrap()
+                .as_ptr(),
+            pointer
+        );
+        let stored = stage
+            .state
+            .tx_db
+            .retrieve_transaction_by_uuid(&tx.uuid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored, *tx);
+        if closed {
+            assert!(matches!(
+                outcome.unwrap_err(),
+                LanderError::NonRetryableError(_)
+            ));
+            match stage.send_tx_to_inclusion_stage(tx).await.unwrap_err() {
+                LanderError::ChannelSendFailure(error) => assert_eq!(error.0, *tx),
+                error => panic!("unexpected error: {error}"),
+            }
+        } else {
+            outcome.unwrap();
+            let received = receiver.try_recv().unwrap();
+            assert_eq!(received, *tx);
+            assert_ne!(
+                received.payload_details[0]
+                    .success_criteria
+                    .as_ref()
+                    .unwrap()
+                    .as_ptr(),
+                pointer
+            );
+            assert!(receiver.try_recv().is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn failed_build_handoff_requeues_exact_payloads_in_order() {
+    let (stage, receiver, queue) = test_setup(1, true);
+    drop(receiver);
+    let mut first = FullPayload::random();
+    first.data = vec![3; 4096];
+    let mut second = FullPayload::random();
+    second.data = vec![4; 4096];
+    let payloads = vec![first, second];
+    for payload in &payloads {
+        initialize_payload_db(&stage.state.payload_db, payload).await;
+    }
+    stage.build_transactions(&payloads).await;
+    let requeued = tokio::time::timeout(std::time::Duration::from_secs(1), queue.pop_n_or_wait(2))
+        .await
+        .unwrap();
+    assert_eq!(requeued, payloads);
+    assert_eq!(queue.len().await, 0);
 }


### PR DESCRIPTION
Consolidated into #9496 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

Problem: Building Stage cloned each complete transaction-building result to retain payload details for error recovery. Its channel-send wrapper then cloned the transaction again before a second clone created the channel-owned value.

Solution: borrow the build result and transaction through the existing handling/retry helpers. Keep the channel-owned clone, persistence before send, original payload recovery, logging and error wrapping unchanged.

Measured removed ownership work using actual Transaction and PayloadDetails fixtures:

| Fixture | Removed allocation calls | Removed requested bytes |
| --- | --- | --- |
| EVM, one 4 KiB payload criterion | 13 | 13,342 |
| EVM, sixteen 4 KiB payload criteria | 103 | 201,082 |
| CosmWasm, one 4 KiB payload criterion | 9 | 12,516 |

These counts cover two redundant transaction copies and one payload-detail vector copy per successful build/handoff. They exclude the retained channel-owned clone, DB work, logging and future allocations; EVM calldata uses its real shared-Bytes behavior. No overall CPU/RSS or RPC claim.

Validation: 19 focused Building Stage tests passed; they include successful and closed-channel ownership, exact persisted transaction, and exact full-payload requeue order. Closed-channel errors remain nonretryable under the existing utility. Strict production Lander Clippy and normal commit hooks passed.

Stack: follows #9525. Existing #7244 changes queue wake scheduling, not these handlers.
