### PR TITLE
perf(infra): enable fallback RPC hedging

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -43,6 +43,7 @@ import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';
 import { DockerImageRepos, mainnetDockerTags } from '../../docker.js';
 import { getDomainId, getWarpAddresses } from '../../registry.js';
+import { fallbackHedgeConfig } from '../utils.js';
 
 import { environment, ethereumChainNames } from './chains.js';
 import { blacklistedMessageIds } from './customBlacklist.js';
@@ -59,11 +60,6 @@ import {
   validatorChainConfig,
 } from './validators.js';
 import { WarpRouteIds } from './warp/warpIds.js';
-
-const fallbackHedgeConfig = {
-  fallbackHedgeDelayMillis: 250,
-  fallbackHedgeTimeoutMillis: 30_000,
-};
 
 // The chains here must be consistent with the environment's supportedChainNames, which is
 // checked / enforced at runtime & in the CI pipeline.

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -60,6 +60,11 @@ import {
 } from './validators.js';
 import { WarpRouteIds } from './warp/warpIds.js';
 
+const fallbackHedgeConfig = {
+  fallbackHedgeDelayMillis: 250,
+  fallbackHedgeTimeoutMillis: 30_000,
+};
+
 // The chains here must be consistent with the environment's supportedChainNames, which is
 // checked / enforced at runtime & in the CI pipeline.
 //
@@ -788,6 +793,7 @@ const hyperlane: RootAgentConfig = {
   rolesWithKeys: ALL_KEY_ROLES,
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayer,
@@ -832,6 +838,7 @@ const hyperlane: RootAgentConfig = {
   scraper: {
     scraperOnlyChains,
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.scraper,
@@ -859,6 +866,7 @@ const releaseCandidate: RootAgentConfig = {
   rolesWithKeys: [Role.Relayer, Role.Validator],
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerRC,
@@ -1000,6 +1008,7 @@ const fastPath: RootAgentConfig = {
   rolesWithKeys: [Role.Relayer, Role.Validator],
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerFastPath,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -23,6 +23,7 @@ import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';
 import { DockerImageRepos, testnetDockerTags } from '../../docker.js';
 import { getDomainId } from '../../registry.js';
+import { fallbackHedgeConfig } from '../utils.js';
 
 import { environment, ethereumChainNames } from './chains.js';
 import {
@@ -33,11 +34,6 @@ import {
   fastPathReorgPeriodOverrides,
   validatorChainConfig,
 } from './validators.js';
-
-const fallbackHedgeConfig = {
-  fallbackHedgeDelayMillis: 250,
-  fallbackHedgeTimeoutMillis: 30_000,
-};
 
 // The chains here must be consistent with the environment's supportedChainNames, which is
 // checked / enforced at runtime & in the CI pipeline.

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -34,6 +34,11 @@ import {
   validatorChainConfig,
 } from './validators.js';
 
+const fallbackHedgeConfig = {
+  fallbackHedgeDelayMillis: 250,
+  fallbackHedgeTimeoutMillis: 30_000,
+};
+
 // The chains here must be consistent with the environment's supportedChainNames, which is
 // checked / enforced at runtime & in the CI pipeline.
 //
@@ -314,6 +319,7 @@ const hyperlane: RootAgentConfig = {
   rolesWithKeys: ALL_KEY_ROLES,
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayer,
@@ -352,6 +358,7 @@ const hyperlane: RootAgentConfig = {
   },
   scraper: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.scraper,
@@ -367,6 +374,7 @@ const releaseCandidate: RootAgentConfig = {
   rolesWithKeys: [Role.Relayer, Role.Validator],
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerRC,
@@ -423,6 +431,7 @@ const neutron: RootAgentConfig = {
   rolesWithKeys: [Role.Relayer],
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerRC,
@@ -465,6 +474,7 @@ const fastPath: RootAgentConfig = {
   rolesWithKeys: [Role.Relayer, Role.Validator],
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
+    ...fallbackHedgeConfig,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerFastPath,

--- a/typescript/infra/config/environments/utils.ts
+++ b/typescript/infra/config/environments/utils.ts
@@ -14,6 +14,11 @@ export const DEFAULT_OFFCHAIN_LOOKUP_ISM_URLS = [
   'https://offchain-lookup.services.hyperlane.xyz/callCommitments/getCallsFromRevealMessage',
 ];
 
+export const fallbackHedgeConfig = {
+  fallbackHedgeDelayMillis: 250,
+  fallbackHedgeTimeoutMillis: 30_000,
+};
+
 export type ValidatorKey = {
   identifier: string;
   address: string;

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -134,6 +134,15 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
           return {
             name: chain,
             rpcConsensusType: this.rpcConsensusType(chain),
+            ...(metadata.protocol === ProtocolType.Ethereum &&
+            this.config.agentRoleConfig.fallbackHedgeDelayMillis !== undefined
+              ? {
+                  fallbackHedgeDelayMillis:
+                    this.config.agentRoleConfig.fallbackHedgeDelayMillis,
+                  fallbackHedgeTimeoutMillis:
+                    this.config.agentRoleConfig.fallbackHedgeTimeoutMillis,
+                }
+              : {}),
             protocol: metadata.protocol,
             blocks: { reorgPeriod },
             maxBatchSize: batchConfig.maxBatchSize,

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -8,7 +8,7 @@ import {
   RelayerConfig,
   RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType, objOmitKeys } from '@hyperlane-xyz/utils';
+import { ProtocolType, assert, objOmitKeys } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
 import { getChain } from '../../config/registry.js';
@@ -87,6 +87,18 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
 
   async helmValues(): Promise<HelmRootAgentValues> {
     const dockerImage = this.dockerImage;
+    const { fallbackHedgeDelayMillis, fallbackHedgeTimeoutMillis } =
+      this.config.agentRoleConfig;
+    const hasFallbackHedgeDelay = fallbackHedgeDelayMillis !== undefined;
+    const hasFallbackHedgeTimeout = fallbackHedgeTimeoutMillis !== undefined;
+    assert(
+      hasFallbackHedgeDelay === hasFallbackHedgeTimeout,
+      'fallbackHedgeDelayMillis and fallbackHedgeTimeoutMillis must be configured together',
+    );
+    const fallbackHedgeConfig = hasFallbackHedgeDelay
+      ? { fallbackHedgeDelayMillis, fallbackHedgeTimeoutMillis }
+      : undefined;
+
     return {
       image: {
         repository: dockerImage.repo,
@@ -135,13 +147,8 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
             name: chain,
             rpcConsensusType: this.rpcConsensusType(chain),
             ...(metadata.protocol === ProtocolType.Ethereum &&
-            this.config.agentRoleConfig.fallbackHedgeDelayMillis !== undefined
-              ? {
-                  fallbackHedgeDelayMillis:
-                    this.config.agentRoleConfig.fallbackHedgeDelayMillis,
-                  fallbackHedgeTimeoutMillis:
-                    this.config.agentRoleConfig.fallbackHedgeTimeoutMillis,
-                }
+            fallbackHedgeConfig
+              ? fallbackHedgeConfig
               : {}),
             protocol: metadata.protocol,
             blocks: { reorgPeriod },

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -134,6 +134,8 @@ interface AgentRoleConfig {
 
   // Agent-specific
   rpcConsensusType: RpcConsensusType;
+  fallbackHedgeDelayMillis?: number;
+  fallbackHedgeTimeoutMillis?: number;
   index?: IndexingConfig;
 }
 

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -41,6 +41,23 @@ const environmentChainConfigs = {
 };
 
 describe('Agent configs', () => {
+  it('enables fallback hedging for relayers and scrapers, not validators', () => {
+    for (const agentConfigs of [mainnet3Agents, testnet4Agents]) {
+      for (const config of Object.values(agentConfigs)) {
+        for (const role of ['relayer', 'scraper'] as const) {
+          if (!config[role]) continue;
+          expect(config[role].fallbackHedgeDelayMillis).to.equal(250);
+          expect(config[role].fallbackHedgeTimeoutMillis).to.equal(30_000);
+        }
+
+        expect(config.validators?.fallbackHedgeDelayMillis).to.equal(undefined);
+        expect(config.validators?.fallbackHedgeTimeoutMillis).to.equal(
+          undefined,
+        );
+      }
+    }
+  });
+
   it('polls fastpath relayer indexes every two seconds', () => {
     expect(
       mainnet3Agents[Contexts.FastPath].relayer?.interval,

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { AgentConfig } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../config/contexts.js';
@@ -14,12 +15,20 @@ import {
   hyperlaneContextAgentChainConfig as testnet4AgentChainConfig,
 } from '../config/environments/testnet4/agent.js';
 import { testnet4SupportedChainNames } from '../config/environments/testnet4/supportedChainNames.js';
+import { getChain } from '../config/registry.js';
 import { getAgentConfigJsonPath } from '../scripts/agent-utils.js';
 import {
+  AgentConfigHelper,
   AgentChainConfig,
+  RootAgentConfig,
   ensureAgentChainConfigIncludesAllChainNames,
 } from '../src/config/agent/agent.js';
+import { AgentHelmManager } from '../src/agents/index.js';
+import { RelayerConfigHelper } from '../src/config/agent/relayer.js';
+import { ScraperConfigHelper } from '../src/config/agent/scraper.js';
+import { ValidatorConfigHelper } from '../src/config/agent/validator.js';
 import { AgentEnvironment } from '../src/config/deploy-environment.js';
+import { AgentRole, Role } from '../src/roles.js';
 
 const environmentChainConfigs = {
   mainnet3: {
@@ -40,19 +49,100 @@ const environmentChainConfigs = {
   },
 };
 
+class TestAgentHelmManager extends AgentHelmManager {
+  readonly helmReleaseName = 'test';
+
+  constructor(
+    protected readonly config: AgentConfigHelper,
+    readonly role: AgentRole,
+  ) {
+    super();
+  }
+}
+
+function agentConfigHelper(
+  config: RootAgentConfig,
+  role: AgentRole,
+): AgentConfigHelper {
+  switch (role) {
+    case Role.Relayer:
+      return new RelayerConfigHelper(config);
+    case Role.Scraper:
+      return new ScraperConfigHelper(config);
+    case Role.Validator: {
+      const chain = config.contextChainNames[Role.Validator][0];
+      if (!chain) throw new Error('Validator context has no configured chain');
+      return new ValidatorConfigHelper(config, chain);
+    }
+  }
+}
+
 describe('Agent configs', () => {
-  it('enables fallback hedging for relayers and scrapers, not validators', () => {
+  it('renders fallback hedging only for EVM relayers and scrapers', async () => {
+    let sawEthereum = false;
+    let sawNonEthereum = false;
+
     for (const agentConfigs of [mainnet3Agents, testnet4Agents]) {
       for (const config of Object.values(agentConfigs)) {
-        for (const role of ['relayer', 'scraper'] as const) {
-          if (!config[role]) continue;
-          expect(config[role].fallbackHedgeDelayMillis).to.equal(250);
-          expect(config[role].fallbackHedgeTimeoutMillis).to.equal(30_000);
-        }
+        for (const role of [
+          Role.Relayer,
+          Role.Scraper,
+          Role.Validator,
+        ] as const) {
+          const roleDefined =
+            role === Role.Validator ? config.validators : config[role];
+          if (!roleDefined) continue;
 
-        expect(config.validators?.fallbackHedgeDelayMillis).to.equal(undefined);
-        expect(config.validators?.fallbackHedgeTimeoutMillis).to.equal(
-          undefined,
+          const manager = new TestAgentHelmManager(
+            agentConfigHelper(config, role),
+            role,
+          );
+          const values = await manager.helmValues();
+
+          for (const chain of values.hyperlane.chains) {
+            const isEthereum =
+              getChain(chain.name).protocol === ProtocolType.Ethereum;
+            sawEthereum ||= isEthereum;
+            sawNonEthereum ||= !isEthereum;
+
+            const shouldHedge = isEthereum && role !== Role.Validator;
+            expect(chain.fallbackHedgeDelayMillis).to.equal(
+              shouldHedge ? 250 : undefined,
+            );
+            expect(chain.fallbackHedgeTimeoutMillis).to.equal(
+              shouldHedge ? 30_000 : undefined,
+            );
+          }
+        }
+      }
+    }
+
+    expect(sawEthereum).to.equal(true);
+    expect(sawNonEthereum).to.equal(true);
+  });
+
+  it('rejects partial fallback hedge configuration', async () => {
+    const config = testnet4Agents[Contexts.Hyperlane];
+    for (const relayer of [
+      { ...config.relayer!, fallbackHedgeTimeoutMillis: undefined },
+      { ...config.relayer!, fallbackHedgeDelayMillis: undefined },
+    ]) {
+      const partialConfig = { ...config, relayer };
+      const manager = new TestAgentHelmManager(
+        new RelayerConfigHelper(partialConfig),
+        Role.Relayer,
+      );
+
+      let rejection: unknown;
+      try {
+        await manager.helmValues();
+      } catch (error) {
+        rejection = error;
+      }
+      expect(rejection).to.be.instanceOf(Error);
+      if (rejection instanceof Error) {
+        expect(rejection.message).to.equal(
+          'fallbackHedgeDelayMillis and fallbackHedgeTimeoutMillis must be configured together',
         );
       }
     }


### PR DESCRIPTION
## Problem

#9395 was merged and deployed, but our infra-generated agent config did not forward its hedge settings. Relayers and scrapers therefore still used sequential fallback reads and emitted no hedge metrics.

## Solution

- pass the existing `fallbackHedgeDelayMillis` and `fallbackHedgeTimeoutMillis` settings from each agent role into Ethereum chain config
- reject delay-only or timeout-only configuration before generating Helm values
- share the 250ms grace and 30s per-attempt timeout across mainnet3/testnet4 environment configs
- enable hedging for every mainnet3/testnet4 relayer and scraper context using fallback consensus
- omit hedge settings from non-Ethereum chains and all validator configs
- test the generated Helm chain values across every configured environment, context and role

## Performance evidence

**Production-observed baseline, before activation:** over the trailing hour, successful relayer `eth_getBalance` calls averaged 61.4ms at 1.16 requests/s and `eth_getCode` averaged 22.6ms at 2.01 requests/s. The 250ms grace is 4.1x and 11.1x those ordinary means, respectively, so it targets slow-tail requests rather than the normal path. Scraper had no matching eligible-method series in that window.

The combined 3.17 requests/s across those two methods is a conservative ceiling on added hedge traffic: #9395 permits only the block-hash-pinned subset, and a hedge starts only when that subset exceeds 250ms. It is not a forecast of the extra-request ratio.

**Modeled tail improvement:** a 5s stalled primary followed by a secondary completing within the observed 23-61ms ordinary range should complete in roughly 273-311ms: **16.1-18.3x faster / 93.8-94.5% lower latency**. This is modeled, not canary evidence.

## Initial tuning rationale

The pre-activation request-duration metric is a counter, not a histogram, so it cannot recover individual-request p95. As a sensitivity check, the trailing 24h maximum five-minute mean was measured for each populated mainnet3 relayer/scraper provider series on methods that can hedge:

| Grace | Series crossing threshold | Initial guidance |
|---:|---:|---|
| 100ms | 53/114 | Aggressive; likely too much routine duplication for the first canary |
| **250ms** | **11/114** | Selected: catches clear slow paths without targeting most routine traffic |
| 500ms | 3/114 | Lowest extra traffic, but leaves the 250-500ms band uncovered |

These method-level series include moving-block calls that #9395 rejects, so this is an upper-bound sensitivity screen rather than a predicted hedge rate.

Keep 250ms if the canary lowers tail latency without increasing errors and speculative starts remain acceptable. Raise to 500ms if starts exceed roughly 2% of eligible logical requests while fewer than roughly 10% of started hedges win, or p95 does not improve. Consider 100-150ms only if tail latency remains unacceptable, started hedges frequently win, and provider capacity permits the extra traffic.

The 30s per-attempt timeout matches #9395's default and minimizes the initial behavior change. Consider 10s only after canaries show no valid eligible success beyond 10s; consider 60s only if 30s creates false timeouts on otherwise healthy chains.

## Safety and rollout

#9395 still owns the correctness boundary: only block-by-hash and EIP-1898 block-hash-pinned reads can hedge; moving block selectors, chain identity, transaction lifecycle, submission, nonce, fees and estimation remain sequential.

Roll deployments through RC testnet -> prod testnet -> RC mainnet -> remaining relayer/scraper contexts. Before promotion, compare p95 `fallback_hedge_duration_seconds`, errors and total provider request rate. Track `fallback_hedge_events_total` starts, primary/hedge winners, cancellations and timeouts. Hedge starts divided by `fallback_hedge_duration_seconds_count` is the realized additional-attempt ratio. Rollback is config/image only.

## Early rollout readback

The standard relayer and scraper became Ready with the 250ms/30s pair at about 23:07 UTC on the already-live exact image. Live ConfigMaps contain complete pairs for 63 relayer and 64 scraper EVM chains and no hedge keys in the 79 ConfigMaps referenced by active validator workloads. Both pods remained Ready with zero restarts and no critical errors.

After about 20 minutes, neither pod exposed hedge event or duration series. Because duration is recorded even when the primary wins before the grace, the leading explanation is that no qualifying pinned reads reached the path in this window. Relayer traffic was catch-up dominated and scraper EVM traffic was flat, so neither supplies an attributable latency or request-rate result. Keep 250ms/30s and recheck after 24 hours or at least 1,000 eligible duration observations. This is deployment evidence, not a realized performance claim.

## Validation

- exact-head GitHub CI passed, including both generated agent-config matrices, infra tests, pnpm tests and lint/prettier
- pnpm -C typescript/infra check
- type-aware oxlint, git diff --check and commit hooks passed
- the focused local test remains blocked before collection by the current @provablehq/sdk import of removed core-js/proposals/json-parse-with-source.js; exact-head CI passed the generated-values regressions

Closes #9381. Related to #9395 and #9386.
