### PR TITLE
fix(relayer): prevent idle loaders starving destination ingress

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -601,10 +601,31 @@ impl MessageDbLoader {
     /// Wake for new index work, polling for destination capacity without reserving it.
     async fn wait_for_work(&mut self) {
         const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(1);
+        const CAPACITY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
         // Origins share destination channels. Reserving capacity just to observe
         // readiness lets idle loaders pass the sole slot between their queued
         // reservations, starving loaders that have real work to try_send.
+        let blocked_senders: Vec<_> = self
+            .send_channels
+            .values()
+            .filter(|sender| sender.capacity() == 0 && !sender.is_closed())
+            .cloned()
+            .collect();
+        let capacity_available = async {
+            if blocked_senders.is_empty() {
+                std::future::pending::<()>().await;
+            }
+            loop {
+                tokio::time::sleep(CAPACITY_POLL_INTERVAL).await;
+                if blocked_senders
+                    .iter()
+                    .any(|sender| sender.capacity() > 0 || sender.is_closed())
+                {
+                    break;
+                }
+            }
+        };
         let (disconnected, notification) = if let Some(receiver) = self.index_notifications.as_mut()
         {
             tokio::select! {
@@ -612,10 +633,14 @@ impl MessageDbLoader {
                     Some(notification) => (false, Some(notification)),
                     None => (true, None),
                 },
+                _ = capacity_available => (false, None),
                 _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, None),
             }
         } else {
-            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
+            tokio::select! {
+                _ = capacity_available => {},
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => {},
+            }
             (false, None)
         };
 

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use derive_new::new;
 use ethers::utils::hex;
 use eyre::Result;
-use futures_util::{stream::FuturesUnordered, StreamExt};
 use hyperlane_base::{
     broadcast::IndexingNotification,
     db::{HyperlaneDb, HyperlaneRocksDB},
@@ -599,25 +598,13 @@ impl MessageDbLoader {
         }
     }
 
-    /// Wake for new index work or destination capacity, retaining a polling fallback.
+    /// Wake for new index work, polling for destination capacity without reserving it.
     async fn wait_for_work(&mut self) {
         const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
-        let mut capacity_waiters: FuturesUnordered<_> = self
-            .send_channels
-            .values()
-            .filter(|sender| sender.capacity() == 0 && !sender.is_closed())
-            .cloned()
-            .map(Sender::reserve_owned)
-            .collect();
-        let capacity_wait = async {
-            if capacity_waiters.is_empty() {
-                std::future::pending::<()>().await
-            } else {
-                let _ = capacity_waiters.next().await;
-            }
-        };
-
+        // Origins share destination channels. Reserving capacity just to observe
+        // readiness lets idle loaders pass the sole slot between their queued
+        // reservations, starving loaders that have real work to try_send.
         let (disconnected, notification) = if let Some(receiver) = self.index_notifications.as_mut()
         {
             tokio::select! {
@@ -625,14 +612,11 @@ impl MessageDbLoader {
                     Some(notification) => (false, Some(notification)),
                     None => (true, None),
                 },
-                _ = capacity_wait => (false, None),
                 _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, None),
             }
         } else {
-            tokio::select! {
-                _ = capacity_wait => (false, None),
-                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, None),
-            }
+            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
+            (false, None)
         };
 
         if disconnected {

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -168,6 +168,31 @@ async fn finish_legacy_migration(loader: &mut MessageDbLoader) {
 }
 
 #[tokio::test]
+async fn idle_loader_does_not_reserve_shared_destination_capacity() {
+    test_utils::run_test_db(|db| async move {
+        let origin = dummy_domain(0, "dummy_origin_domain");
+        let destination = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin, db);
+        let (mut loader, mut receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        let sender = loader.send_channels[&destination.id()].clone();
+        sender.try_send(vec![]).unwrap();
+
+        // Another origin shares this one-slot destination ingress. An idle
+        // loader must not claim the slot when the processor drains it.
+        let wait = loader.wait_for_work();
+        tokio::pin!(wait);
+        assert!(futures::poll!(&mut wait).is_pending());
+        receiver.try_recv().unwrap();
+        assert!(
+            sender.try_send(vec![]).is_ok(),
+            "idle loader reserved the slot needed by another origin"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_idle_tick_wakes_on_index_notification() {
     test_utils::run_test_db(|db| async move {
         let origin_domain = dummy_domain(0, "dummy_origin_domain");
@@ -1246,7 +1271,7 @@ async fn saturated_destination_does_not_block_another_destination() {
         );
         assert_eq!(receiver_a.len(), 1);
 
-        timeout(Duration::from_millis(750), async {
+        timeout(Duration::from_millis(1_500), async {
             let release_capacity = async {
                 sleep(Duration::from_millis(20)).await;
                 receiver_a.recv().await.unwrap();
@@ -1255,7 +1280,12 @@ async fn saturated_destination_does_not_block_another_destination() {
             tick_result.unwrap();
         })
         .await
-        .expect("loader should wake when destination capacity becomes available");
+        .expect("loader should poll after destination capacity becomes available");
+        loader.tick().await.unwrap();
+        assert_eq!(
+            only_operation(receiver_a.try_recv().unwrap()).id(),
+            message_a.id()
+        );
     })
     .await;
 }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -193,17 +193,33 @@ async fn idle_loader_does_not_reserve_shared_destination_capacity() {
 }
 
 #[tokio::test]
-async fn indexed_backlog_drains_without_waiting_for_fallback_poll() {
+async fn indexed_backlog_drains_with_idle_origins_sharing_ingress() {
     test_utils::run_test_db(|db| async move {
         let origin = dummy_domain(0, "dummy_origin_domain");
         let destination = dummy_domain(1, "dummy_destination_domain");
-        let db = HyperlaneRocksDB::new(&origin, db);
+        let origin_db = HyperlaneRocksDB::new(&origin, db.clone());
         for nonce in 0..3 {
-            add_db_entry(&db, &dummy_hyperlane_message(&destination, nonce), 0);
+            add_db_entry(&origin_db, &dummy_hyperlane_message(&destination, nonce), 0);
         }
         let (mut loader, mut receiver) =
-            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+            dummy_message_loader(&origin, &destination, &origin_db, OptionalCache::new(None));
         finish_legacy_migration(&mut loader).await;
+        let sender = loader.send_channels[&destination.id()].clone();
+        sender.try_send(vec![]).expect("fill shared ingress");
+        let mut idle_loaders = Vec::new();
+        for id in 2..4 {
+            let idle_origin = dummy_domain(id, "idle_origin");
+            let idle_db = HyperlaneRocksDB::new(&idle_origin, db.clone());
+            let (mut idle, _) = dummy_message_loader(
+                &idle_origin,
+                &destination,
+                &idle_db,
+                OptionalCache::new(None),
+            );
+            idle.send_channels.insert(destination.id(), sender.clone());
+            finish_legacy_migration(&mut idle).await;
+            idle_loaders.push(idle);
+        }
         timeout(Duration::from_millis(750), async {
             tokio::select! {
                 _ = async {
@@ -211,7 +227,16 @@ async fn indexed_backlog_drains_without_waiting_for_fallback_poll() {
                         loader.tick().await.expect("loader tick should succeed");
                     }
                 } => {},
+                _ = futures::future::join_all(idle_loaders.iter_mut().map(|idle| async move {
+                    loop {
+                        idle.tick().await.expect("idle loader tick should succeed");
+                    }
+                })) => {},
                 _ = async {
+                    // Let all origin loops observe the full channel before
+                    // the processor releases its sole ingress slot.
+                    sleep(Duration::from_millis(20)).await;
+                    assert!(receiver.recv().await.expect("initial batch").is_empty());
                     let mut admitted = Vec::new();
                     for _ in 0..3 {
                         admitted.push(only_operation(receiver.recv().await.expect("ingress open")));

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -193,6 +193,41 @@ async fn idle_loader_does_not_reserve_shared_destination_capacity() {
 }
 
 #[tokio::test]
+async fn indexed_backlog_drains_without_waiting_for_fallback_poll() {
+    test_utils::run_test_db(|db| async move {
+        let origin = dummy_domain(0, "dummy_origin_domain");
+        let destination = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin, db);
+        for nonce in 0..3 {
+            add_db_entry(&db, &dummy_hyperlane_message(&destination, nonce), 0);
+        }
+        let (mut loader, mut receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        finish_legacy_migration(&mut loader).await;
+        timeout(Duration::from_millis(750), async {
+            tokio::select! {
+                _ = async {
+                    loop {
+                        loader.tick().await.expect("loader tick should succeed");
+                    }
+                } => {},
+                _ = async {
+                    let mut admitted = Vec::new();
+                    for _ in 0..3 {
+                        admitted.push(only_operation(receiver.recv().await.expect("ingress open")));
+                    }
+                    let ids: BTreeSet<_> = admitted.iter().map(|op| op.id()).collect();
+                    assert_eq!(ids.len(), 3, "each message must be admitted once");
+                } => {}
+            }
+        })
+        .await
+        .expect("indexed backlog should drain promptly without notifications");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_idle_tick_wakes_on_index_notification() {
     test_utils::run_test_db(|db| async move {
         let origin_domain = dummy_domain(0, "dummy_origin_domain");
@@ -1271,7 +1306,7 @@ async fn saturated_destination_does_not_block_another_destination() {
         );
         assert_eq!(receiver_a.len(), 1);
 
-        timeout(Duration::from_millis(1_500), async {
+        timeout(Duration::from_millis(750), async {
             let release_capacity = async {
                 sleep(Duration::from_millis(20)).await;
                 receiver_a.recv().await.unwrap();

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -176,14 +176,14 @@ async fn idle_loader_does_not_reserve_shared_destination_capacity() {
         let (mut loader, mut receiver) =
             dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
         let sender = loader.send_channels[&destination.id()].clone();
-        sender.try_send(vec![]).unwrap();
+        sender.try_send(vec![]).expect("ingress should start empty");
 
         // Another origin shares this one-slot destination ingress. An idle
         // loader must not claim the slot when the processor drains it.
         let wait = loader.wait_for_work();
         tokio::pin!(wait);
         assert!(futures::poll!(&mut wait).is_pending());
-        receiver.try_recv().unwrap();
+        receiver.try_recv().expect("ingress should contain a batch");
         assert!(
             sender.try_send(vec![]).is_ok(),
             "idle loader reserved the slot needed by another origin"
@@ -1281,9 +1281,9 @@ async fn saturated_destination_does_not_block_another_destination() {
         })
         .await
         .expect("loader should poll after destination capacity becomes available");
-        loader.tick().await.unwrap();
+        loader.tick().await.expect("loader should resume admission");
         assert_eq!(
-            only_operation(receiver_a.try_recv().unwrap()).id(),
+            only_operation(receiver_a.try_recv().expect("message should be admitted")).id(),
             message_a.id()
         );
     })


### PR DESCRIPTION
Idle origin loaders could starve real messages by reserving shared destination ingress capacity only to drop it. With a one-slot channel, queued idle waiters can pass the slot between themselves while producers using `try_send` keep seeing a full channel.

Removed capacity reservations from the loader's idle wait. Index notifications still wake it immediately. Previously full destinations are checked every 50 ms without taking a permit; the existing one-second fallback remains for idle discovery. Capacity checks do not read the database.

Incident evidence: on image `1be48b5-20260907-010209`, ENI indexing reached nonce 95100 while the loader stayed at 95077 and BSC ingress reported full. After the operator rolled back to `fe8dde9-20260906-215204`, the loader advanced to 95100 and 23 ENI-to-BSC operations were submitted. Submission is not confirmation of delivery.

Validation:

- New deterministic regression test failed on the original code and passed with the fix.
- All 28 message DB loader tests passed, including notification wakeups, fallback polling, resumed admission after a saturated destination drains, and prompt draining of already-indexed backlog without notifications.
- Adversarial review identified slow backlog draining in the initial one-second-only fix. A new three-message backlog test failed on that version and passed after adding non-reserving capacity checks. Other model claims were checked against source and the demonstrated red/green regression.
- `cargo fmt --all` and `git diff --check` passed.
- `cargo clippy -p relayer --lib -- -D warnings` passed on the initial fix; rerun pending for the capacity-poll follow-up. The additional `--tests` run was blocked by existing test `unwrap()`/panic lint violations; newly added calls use `expect()`.
- Self-review completed against `REVIEW.md`; commit hooks passed. CI pending.

This PR has not been deployed. Rollout verification should check continued loader progress and on-chain delivery of the affected messages.
