### PR TITLE
feat(aleo): expose delegated prover phase metrics

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6245,6 +6245,7 @@ dependencies = [
  "hyperlane-warp-route",
  "indexmap 2.12.0",
  "num-traits",
+ "prometheus",
  "rand 0.10.2",
  "rand_chacha 0.10.0",
  "reqwest 0.11.27",

--- a/rust/main/chains/hyperlane-aleo/Cargo.toml
+++ b/rust/main/chains/hyperlane-aleo/Cargo.toml
@@ -51,3 +51,6 @@ rand = "0.10"
 rand_chacha = "0.10.0"
 sodiumbox = "0.1.0"
 base64.workspace = true
+
+[dev-dependencies]
+prometheus.workspace = true

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -33,8 +33,9 @@ use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
 
 use crate::{
     provider::{
-        fallback::FallbackHttpClient, AleoClient, BaseHttpClient, JWTBaseHttpClient, ProvingClient,
-        RpcClient,
+        fallback::FallbackHttpClient,
+        metric::{record_execution_phase, ExecutionPhase},
+        AleoClient, BaseHttpClient, JWTBaseHttpClient, ProvingClient, RpcClient,
     },
     utils::{get_tx_id, to_h256},
     AleoSigner, ConnectionConf, CurrentNetwork, FeeEstimate, HyperlaneAleoError,
@@ -51,6 +52,8 @@ struct FeeEstimateCacheKey {
 #[derive(Clone)]
 pub struct AleoProvider<C: AleoClient = FallbackHttpClient> {
     client: RpcClient<C>,
+    execution_metrics: PrometheusClientMetrics,
+    execution_metrics_config: hyperlane_metric::prometheus_metric::PrometheusConfig,
     domain: HyperlaneDomain,
     network: u16,
     proving_service: Option<ProvingClient<FallbackHttpClient<JWTBaseHttpClient>>>,
@@ -112,10 +115,15 @@ impl AleoProvider<FallbackHttpClient> {
         Ok(Self {
             client: RpcClient::new(FallbackHttpClient::new::<BaseHttpClient>(
                 conf.rpcs.clone(),
-                metrics,
-                chain,
+                metrics.clone(),
+                chain.clone(),
                 conf.chain_id,
             )?),
+            execution_metrics: metrics,
+            execution_metrics_config: hyperlane_metric::prometheus_metric::PrometheusConfig {
+                chain,
+                ..Default::default()
+            },
             domain,
             network: conf.chain_id,
             proving_service,
@@ -146,6 +154,8 @@ impl<C: AleoClient> AleoProvider<C> {
     ) -> Self {
         Self {
             client: RpcClient::new(client),
+            execution_metrics: Default::default(),
+            execution_metrics_config: Default::default(),
             domain,
             network: chain_id,
             proving_service: None,
@@ -443,16 +453,35 @@ impl<C: AleoClient> AleoProvider<C> {
         // Check delegated prover availability before performing expensive local authorization.
         // This keeps an auth or service outage from repeatedly consuming memory and CPU.
         if let Some(client) = self.proving_service.as_ref() {
-            client.get_public_key().await.map_err(|error| {
+            let preflight_start = Instant::now();
+            let preflight = client.get_public_key().await;
+            record_execution_phase(
+                &self.execution_metrics,
+                &self.execution_metrics_config,
+                ExecutionPhase::DelegatedProverPreflight,
+                preflight_start,
+                preflight.is_ok(),
+            );
+            preflight.map_err(|error| {
                 warn!(%error, "Delegated proving preflight failed");
                 error
             })?;
         }
 
         // Prepare VM + Authorization for execution.
-        let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) = self
+        let authorization_start = Instant::now();
+        let authorization = self
             .prepare_authorization::<N, I, V>(program_id, function_name, input, vm)
-            .await?;
+            .await;
+        record_execution_phase(
+            &self.execution_metrics,
+            &self.execution_metrics_config,
+            ExecutionPhase::Authorization,
+            authorization_start,
+            authorization.is_ok(),
+        );
+        let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) =
+            authorization?;
 
         // Calculate fees
         let base_fee = self
@@ -489,16 +518,19 @@ impl<C: AleoClient> AleoProvider<C> {
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
-                client
-                    .proving_request(authorization, fee)
-                    .await
-                    .map_err(|error| {
-                        warn!(
-                            %error,
-                            "Delegated proving failed"
-                        );
-                        error
-                    })?
+                let proof_start = Instant::now();
+                let proof = client.proving_request(authorization, fee).await;
+                record_execution_phase(
+                    &self.execution_metrics,
+                    &self.execution_metrics_config,
+                    ExecutionPhase::DelegatedProverProof,
+                    proof_start,
+                    proof.is_ok(),
+                );
+                proof.map_err(|error| {
+                    warn!(%error, "Delegated proving failed");
+                    error
+                })?
             }
             None => {
                 debug!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
@@ -9,6 +9,34 @@ use hyperlane_metric::prometheus_metric::{PrometheusClientMetrics, PrometheusCon
 
 use crate::provider::{AleoClient, BaseHttpClient, HttpClient, HttpClientBuilder, RpcClient};
 
+#[derive(Clone, Copy)]
+pub enum ExecutionPhase {
+    DelegatedProverPreflight,
+    Authorization,
+    DelegatedProverProof,
+}
+
+impl ExecutionPhase {
+    const fn method(self) -> &'static str {
+        match self {
+            Self::DelegatedProverPreflight => "delegated_prover_preflight",
+            Self::Authorization => "aleo_authorization",
+            Self::DelegatedProverProof => "delegated_prover_proof",
+        }
+    }
+}
+
+/// Records a bounded high-level Aleo execution phase using the standard client metrics.
+pub fn record_execution_phase(
+    metrics: &PrometheusClientMetrics,
+    metrics_config: &PrometheusConfig,
+    phase: ExecutionPhase,
+    start: Instant,
+    success: bool,
+) {
+    metrics.increment_metrics(metrics_config, phase.method(), start, success);
+}
+
 /// Fallback Http Client that tries multiple RpcClients in order
 #[derive(Debug)]
 pub struct MetricHttpClient<C: AleoClient = BaseHttpClient> {
@@ -129,7 +157,14 @@ impl<C: AleoClient> HttpClient for MetricHttpClient<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::MetricHttpClient;
+    use std::time::Instant;
+
+    use hyperlane_metric::prometheus_metric::{
+        ChainInfo, PrometheusClientMetricsBuilder, REQUEST_COUNT_LABELS,
+    };
+    use prometheus::{IntCounterVec, Opts};
+
+    use super::{record_execution_phase, ExecutionPhase, MetricHttpClient};
     use crate::provider::BaseHttpClient;
 
     #[test]
@@ -146,5 +181,63 @@ mod tests {
             MetricHttpClient::<BaseHttpClient>::method("transaction/broadcast"),
             "transaction_broadcast"
         );
+    }
+
+    #[test]
+    fn execution_phase_metrics_use_a_fixed_phase_label() {
+        let request_count = IntCounterVec::new(
+            Opts::new("test_request_count", "test request count"),
+            REQUEST_COUNT_LABELS,
+        )
+        .expect("valid request metric");
+        let metrics = PrometheusClientMetricsBuilder::default()
+            .request_count(request_count.clone())
+            .build()
+            .expect("valid client metrics");
+        let metrics_config = hyperlane_metric::prometheus_metric::PrometheusConfig {
+            chain: Some(ChainInfo {
+                name: Some("aleo-testnet".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        for (phase, method, status) in [
+            (
+                ExecutionPhase::DelegatedProverPreflight,
+                "delegated_prover_preflight",
+                "failure",
+            ),
+            (
+                ExecutionPhase::Authorization,
+                "aleo_authorization",
+                "success",
+            ),
+            (
+                ExecutionPhase::DelegatedProverProof,
+                "delegated_prover_proof",
+                "success",
+            ),
+        ] {
+            record_execution_phase(
+                &metrics,
+                &metrics_config,
+                phase,
+                Instant::now(),
+                status == "success",
+            );
+            assert_eq!(
+                request_count
+                    .with_label_values(&[
+                        "unknown",
+                        "rpc",
+                        "aleo-testnet",
+                        method,
+                        status,
+                        "primary",
+                    ])
+                    .get(),
+                1,
+            );
+        }
     }
 }


### PR DESCRIPTION
Replaces #9461, which GitHub refuses to reopen after the head was force-pushed while closed. Identical change, rebased onto current main (`446dceba2e`).