### PR TITLE
chore(infra): update mainnet relayer, fastpath and scraper images

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'fe8dde9-20260906-215204',
+  relayer: '9d27cc5-20260907-032037',
   relayerRC: '9008ed6-20260903-002629',
-  relayerFastPath: '9008ed6-20260903-002629',
+  relayerFastPath: '9d27cc5-20260907-032037',
   validator: '9008ed6-20260903-002629',
   validatorRC: '9008ed6-20260903-002629',
   validatorFastPath: '9008ed6-20260903-002629',
-  scraper: 'fe8dde9-20260906-215204',
+  scraper: '9d27cc5-20260907-032037',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',


### PR DESCRIPTION
Points mainnet relayer, fastpath relayer and scraper at `9d27cc5-20260907-032037` (post-#9541 main). Draft: deploy trials before settling on final tag.