### PR TITLE
fix(infra): allow empty Turnkey signer config in http registry

### DIFF
--- a/typescript/infra/scripts/http-registry.ts
+++ b/typescript/infra/scripts/http-registry.ts
@@ -4,17 +4,15 @@ import {
 } from '@hyperlane-xyz/http-registry-server';
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { assert } from '@hyperlane-xyz/utils';
-import { z } from 'zod';
 
 import { getRegistry as getMainnet3Registry } from '../config/environments/mainnet3/chains.js';
 import { getRegistry as getTestnet4Registry } from '../config/environments/testnet4/chains.js';
 import { resetRegistry } from '../config/registry.js';
 import { assertEnvironment } from '../src/config/deploy-environment.js';
 import {
-  TURNKEY_ROLE_PROTOCOL,
   TURNKEY_SIGNER_PROTOCOLS,
-  TurnkeyRole,
   getTurnkeyRolesForProtocol,
+  signerConfigSchema,
 } from '../src/roles.js';
 import {
   TurnkeyTransactionSignerBackend,
@@ -46,21 +44,7 @@ async function main() {
   } = await args.argv;
 
   const environment = assertEnvironment(rawEnvironment);
-  const signer = z
-    .record(z.enum(TURNKEY_SIGNER_PROTOCOLS), z.nativeEnum(TurnkeyRole))
-    .superRefine((config, context) => {
-      for (const protocol of TURNKEY_SIGNER_PROTOCOLS) {
-        const role = config[protocol];
-        if (role && TURNKEY_ROLE_PROTOCOL[role] !== protocol) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: [protocol],
-            message: `${role} is not a ${protocol} Turnkey role`,
-          });
-        }
-      }
-    })
-    .parse(rawSigner ?? {});
+  const signer = signerConfigSchema.parse(rawSigner ?? {});
 
   const environmentToRegistry: Record<string, () => Promise<IRegistry>> = {
     mainnet3: getMainnet3Registry,

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -1,4 +1,5 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
+import { z } from 'zod';
 
 export enum Role {
   Validator = 'validator',
@@ -90,3 +91,23 @@ export function getTurnkeyRolesForProtocol(
     (role) => TURNKEY_ROLE_PROTOCOL[role] === protocol,
   );
 }
+
+// CLI `--signer.<protocol>` overrides. Protocols are optional: deployments
+// without Turnkey signers pass none. Note z.record() with enum keys requires
+// every key under zod v4, so this must stay a partial record.
+export const signerConfigSchema = z
+  .partialRecord(z.enum(TURNKEY_SIGNER_PROTOCOLS), z.nativeEnum(TurnkeyRole))
+  .superRefine((config, context) => {
+    for (const protocol of TURNKEY_SIGNER_PROTOCOLS) {
+      const role = config[protocol];
+      if (role && TURNKEY_ROLE_PROTOCOL[role] !== protocol) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [protocol],
+          message: `${role} is not a ${protocol} Turnkey role`,
+        });
+      }
+    }
+  });
+
+export type SignerConfig = z.infer<typeof signerConfigSchema>;

--- a/typescript/infra/test/turnkey-signer-config.test.ts
+++ b/typescript/infra/test/turnkey-signer-config.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { signerConfigSchema } from '../src/roles.js';
+
+describe('signerConfigSchema', () => {
+  it('accepts an empty config', () => {
+    expect(signerConfigSchema.parse({})).to.deep.equal({});
+  });
+
+  it('accepts a partial config', () => {
+    expect(
+      signerConfigSchema.parse({ ethereum: 'evm-deployer' }),
+    ).to.deep.equal({ ethereum: 'evm-deployer' });
+  });
+
+  it('rejects unknown roles', () => {
+    expect(() => signerConfigSchema.parse({ ethereum: 'nope' })).to.throw();
+  });
+
+  it('rejects roles from the wrong protocol', () => {
+    expect(() =>
+      signerConfigSchema.parse({ ethereum: 'sealevel-deployer' }),
+    ).to.throw(/not a ethereum Turnkey role/);
+  });
+});


### PR DESCRIPTION
Fixes the private-rpc-registry crashloop: `z.record()` with enum keys requires every key under zod v4, so startups without `--signer.*` flags failed validation. Switches the schema to `z.partialRecord` and adds regression coverage. Verified by reproducing the exact crash locally before the fix and confirming startup proceeds past validation after.