### PR TITLE
feat(metrics): measure Lander status-read batching

### DIFF
--- a/rust/main/lander/src/dispatcher/metrics.rs
+++ b/rust/main/lander/src/dispatcher/metrics.rs
@@ -34,6 +34,12 @@ pub struct DispatcherMetrics {
     pub status_scan_duration_milliseconds: IntGaugeVec,
     /// Age since the least recently checked transaction's last status read.
     pub oldest_unchecked_transaction_age_seconds: IntGaugeVec,
+    /// Transactions included in scheduled status-read batches.
+    pub status_read_transactions: IntCounterVec,
+    /// Non-empty status-read batches scheduled, excluding retries and provider fanout.
+    pub status_read_requests: IntCounterVec,
+    /// Requests avoided compared with scheduling one request per transaction.
+    pub status_read_requests_avoided: IntCounterVec,
 
     // tracks inclusion stage errors
     pub inclusion_stage_error: IntCounterVec,
@@ -114,6 +120,30 @@ impl DispatcherMetrics {
             opts!(
                 namespaced("oldest_unchecked_transaction_age_seconds"),
                 "Age since the oldest transaction status check at scan start",
+            ),
+            &["destination", "stage"],
+            registry.clone()
+        )?;
+        let status_read_transactions = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced("status_read_transactions"),
+                "Transactions included in scheduled status-read batches",
+            ),
+            &["destination", "stage"],
+            registry.clone()
+        )?;
+        let status_read_requests = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced("status_read_requests"),
+                "Non-empty status-read batches scheduled, excluding retries and provider fanout",
+            ),
+            &["destination", "stage"],
+            registry.clone()
+        )?;
+        let status_read_requests_avoided = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced("status_read_requests_avoided"),
+                "Status-read requests avoided compared with scheduling one request per transaction",
             ),
             &["destination", "stage"],
             registry.clone()
@@ -237,6 +267,9 @@ impl DispatcherMetrics {
             finality_stage_pool_length,
             status_scan_duration_milliseconds,
             oldest_unchecked_transaction_age_seconds,
+            status_read_transactions,
+            status_read_requests,
+            status_read_requests_avoided,
             batched_transactions,
             dropped_payloads,
             dropped_transactions,
@@ -310,6 +343,21 @@ impl DispatcherMetrics {
         self.oldest_unchecked_transaction_age_seconds
             .with_label_values(&[domain, stage])
             .set(i64::try_from(oldest_unchecked_age.as_secs()).unwrap_or(i64::MAX));
+    }
+
+    pub fn observe_status_read_batch(&self, stage: &str, transaction_count: usize, domain: &str) {
+        if transaction_count == 0 {
+            return;
+        }
+        let transaction_count = u64::try_from(transaction_count).unwrap_or(u64::MAX);
+        let labels = &[domain, stage];
+        self.status_read_transactions
+            .with_label_values(labels)
+            .inc_by(transaction_count);
+        self.status_read_requests.with_label_values(labels).inc();
+        self.status_read_requests_avoided
+            .with_label_values(labels)
+            .inc_by(transaction_count.saturating_sub(1));
     }
 
     pub fn update_dropped_payloads_metric(&self, reason: &str, domain: &str) {
@@ -443,7 +491,7 @@ mod tests {
     use super::DispatcherMetrics;
 
     #[test]
-    fn status_scan_metrics_are_exported() {
+    fn status_scan_and_read_metrics_are_exported() {
         let metrics = DispatcherMetrics::dummy_instance();
         metrics.update_status_scan_duration_metric(
             "InclusionStage",
@@ -455,6 +503,8 @@ mod tests {
             Duration::from_secs(45),
             "test",
         );
+        metrics.observe_status_read_batch("InclusionStage", 4, "test");
+        metrics.observe_status_read_batch("InclusionStage", 0, "empty");
         let gathered = String::from_utf8(metrics.gather().unwrap()).unwrap();
 
         assert!(gathered.contains(
@@ -463,5 +513,15 @@ mod tests {
         assert!(gathered.contains(
             "hyperlane_lander_oldest_unchecked_transaction_age_seconds{destination=\"test\",stage=\"InclusionStage\"} 45"
         ));
+        assert!(gathered.contains(
+            "hyperlane_lander_status_read_transactions{destination=\"test\",stage=\"InclusionStage\"} 4"
+        ));
+        assert!(gathered.contains(
+            "hyperlane_lander_status_read_requests{destination=\"test\",stage=\"InclusionStage\"} 1"
+        ));
+        assert!(gathered.contains(
+            "hyperlane_lander_status_read_requests_avoided{destination=\"test\",stage=\"InclusionStage\"} 3"
+        ));
+        assert!(!gathered.contains("destination=\"empty\""));
     }
 }

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -177,7 +177,12 @@ impl FinalityStage {
                 .map(<[Transaction]>::to_vec)
                 .collect::<Vec<_>>();
             let status_reads = status_batches.into_iter().map(|batch| {
-                read_transaction_status_batch(state, batch, FinalizedStatusRead::TrustPersisted)
+                read_transaction_status_batch(
+                    state,
+                    batch,
+                    FinalizedStatusRead::TrustPersisted,
+                    STAGE_NAME,
+                )
             });
             buffer_ordered_bounded(status_reads, status_batch_concurrency)
                 .flat_map(futures_util::stream::iter)
@@ -260,6 +265,9 @@ impl FinalityStage {
         let tx_status = match &tx.status {
             TransactionStatus::Finalized => Ok(tx.status.clone()),
             _ => {
+                state
+                    .metrics
+                    .observe_status_read_batch(STAGE_NAME, 1, &state.domain);
                 call_until_success_or_nonretryable_error(
                     || state.adapter.tx_status(&tx),
                     "Querying transaction status",

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -210,9 +210,9 @@ impl InclusionStage {
             .chunks(status_batch_size)
             .map(<[Transaction]>::to_vec)
             .collect::<Vec<_>>();
-        let status_reads = status_batches
-            .into_iter()
-            .map(|batch| read_transaction_status_batch(state, batch, FinalizedStatusRead::Query));
+        let status_reads = status_batches.into_iter().map(|batch| {
+            read_transaction_status_batch(state, batch, FinalizedStatusRead::Query, STAGE_NAME)
+        });
         let status_reads = buffer_ordered_bounded(status_reads, status_batch_concurrency);
         let status_reads = status_reads.flat_map(futures_util::stream::iter);
         futures_util::pin_mut!(status_reads);

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -43,6 +43,7 @@ pub(super) async fn read_transaction_status_batch(
     state: &DispatcherState,
     snapshot_txs: Vec<Transaction>,
     finalized_status_read: FinalizedStatusRead,
+    stage: &str,
 ) -> Vec<(
     Transaction,
     Transaction,
@@ -67,6 +68,9 @@ pub(super) async fn read_transaction_status_batch(
             }
         })
         .collect::<Vec<_>>();
+    state
+        .metrics
+        .observe_status_read_batch(stage, query_txs.len(), &state.domain);
     let queried_statuses = state.adapter.tx_statuses(&query_txs).await;
     assert_eq!(
         queried_statuses.len(),


### PR DESCRIPTION
## Problem

The aggregate `getSignatureStatuses` request count mixes Lander scan width with repeated polling, retries, and provider fanout. It therefore cannot show whether the merged Sealevel status batching work is realizing its modeled request reduction in production.

## Solution

Add monotonic Lander counters by destination and stage for:

- transactions included in scheduled status-read batches;
- non-empty status-read batches scheduled; and
- requests avoided relative to one request per transaction.

The counters cover both batched and single-transaction adapters. Empty batches are ignored, including finality batches whose persisted statuses require no read.

These are deliberately logical Lander request counters. Provider retries and fallback fanout remain visible through the existing RPC metrics rather than being conflated with batch width.

## Performance evidence

This PR changes observability only: **0% independent runtime speedup claimed**.

For an actual batch of `N`, it records `N` transactions, `1` request, and `N - 1` avoided requests. A full 16-transaction Sealevel batch therefore records `16 / 1 / 15`, directly proving a **93.75% logical request reduction**. Over any window:

- average batch width = `increase(status_read_transactions) / increase(status_read_requests)`;
- avoided percentage = `increase(status_read_requests_avoided) / increase(status_read_transactions) * 100`.

Cardinality is fixed at three series per active destination/stage pair. No network calls or control flow are added.

## Validation

- `cargo fmt --manifest-path Cargo.toml --all -- --check`
- `cargo clippy -p lander --lib -- -D warnings`
- `cargo test -p lander status_scan_and_read_metrics_are_exported`
- `cargo test -p lander transaction_statuses_share_one_rpc_batch`
- pre-commit hooks, including secret scan and Rust formatting