### PR TITLE
fix(sealevel): tolerate empty RPC API versions

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
+use serde_json::{json, Value};
 use solana_client::{
+    client_error::ClientError,
     nonblocking::rpc_client::RpcClient,
     rpc_client::{GetConfirmedSignaturesForAddress2Config, SerializableTransaction},
     rpc_config::{
         RpcBlockConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig,
         RpcSimulateTransactionConfig, RpcTransactionConfig,
     },
+    rpc_request::RpcRequest,
     rpc_response::{
         Response, RpcConfirmedTransactionStatusWithSignature, RpcSimulateTransactionResult,
     },
@@ -35,6 +38,43 @@ use crate::tx_type::SealevelTxType;
 pub struct SealevelRpcClient(Arc<RpcClient>);
 
 impl SealevelRpcClient {
+    async fn get_signature_statuses_with_config(
+        &self,
+        signatures: &[Signature],
+        search_transaction_history: bool,
+    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+        let signatures = signatures
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let params = if search_transaction_history {
+            json!([signatures, { "searchTransactionHistory": true }])
+        } else {
+            json!([signatures])
+        };
+        let mut response: Value = self
+            .0
+            .send(RpcRequest::GetSignatureStatuses, params)
+            .await
+            .map_err(ChainCommunicationError::from_other)?;
+
+        // Some providers return an empty optional API version. Preserve valid
+        // versions while treating only the empty value as absent.
+        if let Some(api_version) = response.pointer_mut("/context/apiVersion") {
+            if api_version.as_str() == Some("") {
+                *api_version = Value::Null;
+            }
+        }
+
+        serde_json::from_value(response)
+            .map_err(|error| {
+                ClientError::new_with_request(error.into(), RpcRequest::GetSignatureStatuses)
+            })
+            .map_err(Box::new)
+            .map_err(HyperlaneSealevelError::ClientError)
+            .map_err(Into::into)
+    }
+
     /// constructor
     pub fn new(rpc_endpoint: String) -> Self {
         let rpc_client =
@@ -223,10 +263,8 @@ impl SealevelRpcClient {
         &self,
         signatures: &[Signature],
     ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
-        self.0
-            .get_signature_statuses(signatures)
+        self.get_signature_statuses_with_config(signatures, false)
             .await
-            .map_err(ChainCommunicationError::from_other)
     }
 
     /// Get signature statuses, including rooted transaction history.
@@ -234,10 +272,8 @@ impl SealevelRpcClient {
         &self,
         signatures: &[Signature],
     ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
-        self.0
-            .get_signature_statuses_with_history(signatures)
+        self.get_signature_statuses_with_config(signatures, true)
             .await
-            .map_err(ChainCommunicationError::from_other)
     }
 
     /// get slot

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -1,11 +1,29 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::rpc_request::RpcRequest;
 use solana_commitment_config::CommitmentConfig;
+use solana_sdk::signature::Signature;
 use solana_transaction_status::TransactionDetails;
 
 use super::{block_config, block_info_config};
 use crate::client::SealevelRpcClient;
+
+fn signature_status_client(api_version: serde_json::Value) -> SealevelRpcClient {
+    let response = serde_json::json!({
+        "context": {
+            "slot": 42,
+            "apiVersion": api_version,
+        },
+        "value": [null],
+    });
+    let mocks = HashMap::from([(RpcRequest::GetSignatureStatuses, response)]);
+    SealevelRpcClient::from_rpc_client(Arc::new(RpcClient::new_mock_with_mocks(
+        "succeeds".to_owned(),
+        mocks,
+    )))
+}
 
 //#[tokio::test]
 async fn _test_get_block() {
@@ -41,4 +59,54 @@ fn get_block_info_config_omits_transactions() {
 
     assert_eq!(config.transaction_details, Some(TransactionDetails::None));
     assert_eq!(config.rewards, Some(false));
+}
+
+#[tokio::test]
+async fn signature_statuses_treat_empty_api_version_as_absent() {
+    for search_transaction_history in [false, true] {
+        let client = signature_status_client(serde_json::json!(""));
+        let signatures = [Signature::default()];
+
+        let response = if search_transaction_history {
+            client
+                .get_signature_statuses_with_history(&signatures)
+                .await
+        } else {
+            client.get_signature_statuses(&signatures).await
+        }
+        .unwrap();
+
+        assert_eq!(response.context.slot, 42);
+        assert_eq!(response.context.api_version, None);
+        assert_eq!(response.value, vec![None]);
+    }
+}
+
+#[tokio::test]
+async fn signature_statuses_preserve_valid_api_version() {
+    let client = signature_status_client(serde_json::json!("2.1.0"));
+
+    let response = client
+        .get_signature_statuses_with_history(&[Signature::default()])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response
+            .context
+            .api_version
+            .map(|version| version.to_string()),
+        Some("2.1.0".to_owned())
+    );
+}
+
+#[tokio::test]
+async fn signature_statuses_reject_nonempty_invalid_api_version() {
+    let client = signature_status_client(serde_json::json!("invalid"));
+
+    let result = client
+        .get_signature_statuses_with_history(&[Signature::default()])
+        .await;
+
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Problem

One Solana provider returns valid `getSignatureStatuses` results with `context.apiVersion: ""`. Solana's client treats a present API version as semver, so it rejects the whole response and falls back to the next provider.

This predates #9544. On the current relayer it produced:

- 653 parse failures in 100 minutes, or about 392/hour
- 1,504 upstream calls for 801 logical Solana status reads (1.88 calls/read)

Fallback preserves liveness, but throws away usable status data, adds provider load, and sustains warning noise.

## Solution

- normalize only an empty optional `apiVersion` to absent before decoding signature-status responses
- cover both recent and history-enabled status reads
- preserve valid versions and reject other malformed non-empty versions
- preserve request context on decode errors

No RPC ordering or retry policy changes.

## Expected impact

- eliminate the observed ~392 parse warnings/hour while this provider behavior continues
- reduce a resolving status read from two providers to one when the first response is sufficient (up to 50% for those reads)
- no claimed reduction for non-final statuses where the provider quorum intentionally continues

## Validation

- `cargo test -p hyperlane-sealevel signature_statuses_` (3/3)
- `cargo clippy -p hyperlane-sealevel --lib -- -D warnings`
- package and pre-commit Rust formatting
- `git diff --check`
