### PR TITLE
chore(infra): remove Neutron deployment context

### DIFF
--- a/typescript/infra/config/contexts.ts
+++ b/typescript/infra/config/contexts.ts
@@ -2,7 +2,6 @@
 export enum Contexts {
   Hyperlane = 'hyperlane',
   ReleaseCandidate = 'rc',
-  Neutron = 'neutron',
   FastPath = 'fastpath',
 }
 

--- a/typescript/infra/config/environments/mainnet3/infrastructure.ts
+++ b/typescript/infra/config/environments/mainnet3/infrastructure.ts
@@ -40,7 +40,6 @@ export const infrastructure: InfrastructureConfig = {
       'mainnet2-',
       'hyperlane-mainnet3-',
       'rc-mainnet3-',
-      'neutron-mainnet3-',
       'fastpath-mainnet3-',
       'mainnet3-',
     ],

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -67,7 +67,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'celo',
       ),
@@ -79,7 +78,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPATH_VALIDATOR],
         },
         'ethereum',
@@ -92,7 +90,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'avalanche',
       ),
@@ -104,7 +101,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'worldchain',
       ),
@@ -116,7 +112,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'xlayer',
       ),
@@ -128,7 +123,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPATH_VALIDATOR],
         },
         'polygon',
@@ -141,7 +135,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPATH_VALIDATOR],
         },
         'bsc',
@@ -154,7 +147,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPATH_VALIDATOR],
         },
         'arbitrum',
@@ -167,7 +159,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'optimism',
       ),
@@ -179,7 +170,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'gnosis',
       ),
@@ -191,7 +181,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPATH_VALIDATOR],
         },
         'base',
@@ -204,7 +193,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'bob',
       ),
@@ -216,7 +204,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'fraxtal',
       ),
@@ -228,7 +215,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'linea',
       ),
@@ -240,7 +226,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'mantle',
       ),
@@ -252,7 +237,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'sei',
       ),
@@ -264,7 +248,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [''],
-          [Contexts.Neutron]: [],
         },
         'solanamainnet',
       ),
@@ -276,7 +259,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [''],
-          [Contexts.Neutron]: [],
         },
         'eclipsemainnet',
       ),
@@ -288,7 +270,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'taiko',
       ),
@@ -310,7 +291,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'viction',
       ),
@@ -322,7 +302,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'blast',
       ),
@@ -334,7 +313,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'mode',
       ),
@@ -346,7 +324,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [''],
-          [Contexts.Neutron]: [],
         },
         'lisk',
       ),
@@ -358,7 +335,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [''],
-          [Contexts.Neutron]: [],
         },
         'lukso',
       ),
@@ -370,7 +346,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [''],
-          [Contexts.Neutron]: [],
         },
         'metis',
       ),
@@ -881,8 +856,8 @@ export const validatorChainConfig = (
   };
 
   // Opt-in quorum RPC verification (ValidatorMultiRpcQuorumMerkleTreeHook) for
-  // every EVM chain's Hyperlane and FastPath validators. ReleaseCandidate/Neutron
-  // validator sets are unaffected.
+  // every EVM chain's Hyperlane and FastPath validators. The ReleaseCandidate
+  // validator set is unaffected.
   if (context !== Contexts.Hyperlane && context !== Contexts.FastPath) {
     return configs;
   }

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -417,48 +417,6 @@ export const kesselRunnerNetworks = [
   'optimismsepolia',
 ];
 
-// Relayer Neutron Testnet is not running at the moment, but we keep the config
-// If you would like to run it for testing purposes, you should configure it
-// only for chains you would like to run it.
-const neutron: RootAgentConfig = {
-  ...contextBase,
-  context: Contexts.Neutron,
-  contextChainNames: hyperlaneContextAgentChainNames,
-  rolesWithKeys: [Role.Relayer],
-  relayer: {
-    rpcConsensusType: RpcConsensusType.Fallback,
-    ...fallbackHedgeConfig,
-    docker: {
-      repo: DockerImageRepos.AGENT,
-      tag: testnetDockerTags.relayerRC,
-    },
-    blacklist: relayBlacklist,
-    gasPaymentEnforcement,
-    metricAppContextsGetter,
-    ismCacheConfigs,
-    processAltOverrides,
-    batch: {
-      batchSizeOverrides: {
-        starknetsepolia: 16,
-        paradexsepolia: 16,
-      },
-    },
-    cache: {
-      enabled: true,
-    },
-    resources: relayerResources,
-  },
-  validators: {
-    rpcConsensusType: RpcConsensusType.Fallback,
-    docker: {
-      repo: DockerImageRepos.AGENT,
-      tag: testnetDockerTags.validatorRC,
-    },
-    chains: validatorChainConfig(Contexts.ReleaseCandidate),
-    resources: validatorResources,
-  },
-};
-
 const fastPath: RootAgentConfig = {
   ...contextBase,
   context: Contexts.FastPath,
@@ -501,6 +459,5 @@ const fastPath: RootAgentConfig = {
 export const agents = {
   [Contexts.Hyperlane]: hyperlane,
   [Contexts.ReleaseCandidate]: releaseCandidate,
-  [Contexts.Neutron]: neutron,
   [Contexts.FastPath]: fastPath,
 };

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -28,7 +28,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPAH_VALIDATOR],
         },
         'arbitrumsepolia',
@@ -41,7 +40,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPAH_VALIDATOR],
         },
         'basesepolia',
@@ -54,7 +52,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'fuji',
       ),
@@ -66,7 +63,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
         },
         'bsctestnet',
       ),
@@ -78,7 +74,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [AW_RC_VALIDATOR],
-          [Contexts.Neutron]: [],
           [Contexts.FastPath]: [AW_FASTPAH_VALIDATOR],
         },
         'sepolia',
@@ -91,7 +86,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'optimismsepolia',
       ),
@@ -103,7 +97,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'polygonamoy',
       ),
@@ -115,7 +108,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'solanatestnet',
       ),
@@ -127,7 +119,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'solanadevnet',
       ),
@@ -139,7 +130,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'sonicsvmtestnet',
       ),
@@ -151,7 +141,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'hyperliquidevmtestnet',
       ),
@@ -163,7 +152,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'paradexsepolia',
       ),
@@ -175,7 +163,6 @@ export const validatorChainConfig = (
         {
           [Contexts.Hyperlane]: [AW_VALIDATOR],
           [Contexts.ReleaseCandidate]: [],
-          [Contexts.Neutron]: [],
         },
         'starknetsepolia',
       ),

--- a/typescript/infra/config/relayer.json
+++ b/typescript/infra/config/relayer.json
@@ -6,12 +6,10 @@
   },
   "test": {
     "hyperlane": "",
-    "neutron": "",
     "rc": ""
   },
   "testnet4": {
     "hyperlane": "0x16626cd24fd1f228a031e48b77602ae25f8930db",
-    "neutron": "0xf2c72c0befa494d62949a1699a99e2c605a0b636",
     "rc": "0x7fe8c60ead4ab10be736f4de2b3090db5a851f16",
     "fastpath": "0xde216ffd0f7319860f966191d995c250d6070ba2"
   }

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -509,7 +509,6 @@ export async function getAgentConfigsBasedOnArgs(argv?: {
     const baseConfig = {
       [Contexts.Hyperlane]: [],
       [Contexts.ReleaseCandidate]: [],
-      [Contexts.Neutron]: [],
       [Contexts.FastPath]: [],
     };
     // supplementing with dummy addresses for validator as part of missingChains
@@ -601,7 +600,7 @@ export function ensureValidatorConfigConsistency(
     ]}`;
 
     // So only throw if there are missing chains in the Hyperlane context.
-    // Only a subset of chains will have ephemeral validators in RC/Neutron contexts.
+    // Only a subset of chains will have ephemeral validators in the RC context.
     if (context === Contexts.Hyperlane) {
       throw new Error(
         chalk.bold.red(`Validator config invalid.\n${errorMessage}`),
@@ -610,7 +609,7 @@ export function ensureValidatorConfigConsistency(
       rootLogger.info(chalk.grey(errorMessage));
       rootLogger.info(
         chalk.bold.grey(
-          'This is expected for RC/Neutron contexts, as we only run validators for a subset of chains in them.',
+          'This is expected for the RC context, as we only run validators for a subset of chains in it.',
         ),
       );
     }

--- a/typescript/infra/scripts/agents/retry-messages.ts
+++ b/typescript/infra/scripts/agents/retry-messages.ts
@@ -215,10 +215,7 @@ async function main() {
         '$0 -e mainnet3 -s 0x1234... -r 0x5678...',
         'Retry messages from sender to recipient',
       ],
-      [
-        '$0 -e testnet4 -x neutron',
-        'Retry messages in testnet4 with neutron context',
-      ],
+      ['$0 -e testnet4 -x rc', 'Retry messages in testnet4 with rc context'],
     ]).argv;
 
   // Validate that at least one filter method is provided when using whitelist


### PR DESCRIPTION
Removes the dead Neutron deployment context (Contexts.Neutron, 'neutron') from infra.

- Drop Neutron from the Contexts enum, relayer.json, and testnet4 agent config (the not-running Neutron relayer block + agents map entry)
- Drop all [Contexts.Neutron] validator entries (mainnet3, testnet4) and reword RC/Neutron comments
- Drop neutron-mainnet3- GCP secret prefix; fix retry-messages example to use rc

Scope note: this removes the deployment context only. Neutron chain references are intentionally kept: neutron1 bech32 test fixtures, the TIA warp-leg routerConfig.neutron, CLI prefix docs, and historic CHANGELOG/migration rows.