### PR TITLE
fix(ci): retry SBF platform tools download

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,6 +142,26 @@ jobs:
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.14/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+      # cargo-build-sbf keeps its pinned toolchain outside Cargo's target cache.
+      - name: Cache SBF platform tools
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/solana
+          key: sbf-platform-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust/main/utils/run-locally/src/sealevel/solana.rs') }}
+      - name: Install SBF platform tools
+        run: |
+          for attempt in 1 2 3; do
+            if cargo build-sbf --install-only; then
+              exit 0
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              echo "Failed to install SBF platform tools after $attempt attempts"
+              exit 1
+            fi
+            echo "SBF platform-tools download failed; retrying in $((attempt * 10)) seconds"
+            sleep $((attempt * 10))
+          done
+        working-directory: ./rust/sealevel
       - name: Run tests for main workspace
         run: cargo test --all-targets --features aleo,integration_test
         working-directory: ./rust/main


### PR DESCRIPTION
## Problem

Rust CI can fail before SBF compilation when `cargo-build-sbf` implicitly downloads Anza platform tools. [Run 34132804019](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34132804019) received a 504 downloading `platform-tools v1.51`.

## Solution

1. Reuse the Rust E2E cache for `~/.cache/solana`, keyed by platform and the canonical Solana setup source.
2. Isolate `cargo build-sbf --install-only` and retry that network step up to three times with 10s/20s backoff. SBF compilation remains single-shot.

## Validation

- `git diff --check`
- `bash -n` on the retry loop
- `actionlint .github/workflows/rust.yml` (no new diagnostics in the changed block)
- Commit hooks, including gitleaks and YAML formatting
