### PR TITLE
feat(metrics): attribute destination loader outcomes

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -47,8 +47,10 @@ pub struct MessageDbLoader {
     destination_ctxs: HashMap<u32, Arc<MessageContext>>,
     metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
     db: HyperlaneRocksDB,
-    // Reconcile every startup so a rollback binary cannot leave records unindexed.
+    // Reconcile until completion is durable and the retained WAL proves that
+    // subsequent writers maintained the destination index.
     migration_iterator: Option<LegacyMessageIterator>,
+    migration_start_sequence: u64,
     destination_iterators: Vec<DestinationIndexIterator>,
     next_destination: usize,
     destination_scan_pending: bool,
@@ -497,8 +499,21 @@ impl MessageDbLoader {
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,
     ) -> Result<Self> {
-        let (migration_iterator, highest_seen_nonce) =
-            LegacyMessageIterator::new(Arc::new(db.clone()) as Arc<dyn HyperlaneDb>)?;
+        let migration_start_sequence = db.latest_sequence_number();
+        let migration_complete = {
+            let _timer = metrics
+                .scan_duration_seconds
+                .with_label_values(&[metrics.origin.as_str(), "all", "migration_validation"])
+                .start_timer();
+            db.pending_message_index_migration_complete()?
+        };
+        let (migration_iterator, highest_seen_nonce) = if migration_complete {
+            (None, db.retrieve_highest_seen_message_nonce()?)
+        } else {
+            let (iterator, highest_seen_nonce) =
+                LegacyMessageIterator::new(Arc::new(db.clone()) as Arc<dyn HyperlaneDb>)?;
+            (Some(iterator), highest_seen_nonce)
+        };
         let mut destinations: Vec<_> = send_channels.keys().copied().collect();
         destinations.sort_unstable();
         let destination_iterators = destinations
@@ -513,7 +528,8 @@ impl MessageDbLoader {
             send_channels,
             destination_ctxs,
             metric_app_contexts,
-            migration_iterator: Some(migration_iterator),
+            migration_iterator,
+            migration_start_sequence,
             db,
             destination_iterators,
             next_destination: 0,
@@ -695,6 +711,8 @@ impl MessageDbLoader {
             }
         }
         if iterator.migration_complete() {
+            self.db
+                .mark_pending_message_index_migration_complete(self.migration_start_sequence)?;
             self.migration_iterator = None;
         }
         Ok(())

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -487,6 +487,7 @@ impl DbLoaderExt for MessageDbLoader {
 }
 
 impl MessageDbLoader {
+    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         db: HyperlaneRocksDB,

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::max,
     collections::{BTreeSet, HashMap, HashSet},
     fmt::{Debug, Formatter},
-    sync::Arc,
+    sync::{atomic::AtomicBool, Arc},
     time::Duration,
 };
 
@@ -499,13 +499,40 @@ impl MessageDbLoader {
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,
     ) -> Result<Self> {
+        Self::new_with_cancellation(
+            db,
+            message_whitelist,
+            message_blacklist,
+            address_blacklist,
+            metrics,
+            send_channels,
+            destination_ctxs,
+            metric_app_contexts,
+            max_retries,
+            &AtomicBool::new(false),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_cancellation(
+        db: HyperlaneRocksDB,
+        message_whitelist: Arc<MatchingList>,
+        message_blacklist: Arc<MatchingList>,
+        address_blacklist: Arc<AddressBlacklist>,
+        metrics: MessageDbLoaderMetrics,
+        send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
+        destination_ctxs: HashMap<u32, Arc<MessageContext>>,
+        metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
+        max_retries: u32,
+        cancellation: &AtomicBool,
+    ) -> Result<Self> {
         let migration_start_sequence = db.latest_sequence_number();
         let migration_complete = {
             let _timer = metrics
                 .scan_duration_seconds
                 .with_label_values(&[metrics.origin.as_str(), "all", "migration_validation"])
                 .start_timer();
-            db.pending_message_index_migration_complete()?
+            db.pending_message_index_migration_complete_with_cancellation(cancellation)?
         };
         let (migration_iterator, highest_seen_nonce) = if migration_complete {
             (None, db.retrieve_highest_seen_message_nonce()?)

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -17,7 +17,7 @@ use hyperlane_base::{
 };
 use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H256};
 use parking_lot::Mutex;
-use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
+use prometheus::{HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 use tokio::sync::mpsc::{error::TryRecvError, error::TrySendError, Receiver, Sender};
 use tracing::{debug, instrument, trace};
 
@@ -180,6 +180,7 @@ impl DestinationIndexIterator {
         if reopened_low_range {
             return self.peek(db, metrics);
         }
+        metrics.mark_initial_destination_scan_complete(self.destination_label.as_ref());
         Ok(None)
     }
 
@@ -554,6 +555,8 @@ impl MessageDbLoader {
         };
         let mut destinations: Vec<_> = send_channels.keys().copied().collect();
         destinations.sort_unstable();
+        let mut metrics = metrics;
+        metrics.bind_destinations(&destinations);
         let destination_iterators = destinations
             .into_iter()
             .map(|destination| DestinationIndexIterator::new(destination, highest_seen_nonce))
@@ -984,6 +987,7 @@ pub struct MessageDbLoaderMetricsShared {
     records_examined: IntCounterVec,
     logical_db_reads: IntCounterVec,
     destination_outcomes: IntCounterVec,
+    initial_destination_scan_complete: IntGaugeVec,
     scan_duration_seconds: HistogramVec,
     ingress_depth: IntGaugeVec,
 }
@@ -1004,8 +1008,13 @@ impl MessageDbLoaderMetricsShared {
             )?,
             destination_outcomes: metrics.new_int_counter(
                 "message_db_loader_destination_outcomes_total",
-                "Outcomes for destination-index records examined by the message DB loader",
+                "Decision outcomes for destination-index records; compare initial composition only after the matching initial scan-complete gauge is 1",
                 &["origin", "destination", "outcome"],
+            )?,
+            initial_destination_scan_complete: metrics.new_int_gauge(
+                "message_db_loader_initial_destination_scan_complete",
+                "Whether the loader reached the end of both initial destination-index ranges; outcome ratios are incomplete while 0",
+                &["origin", "destination"],
             )?,
             scan_duration_seconds: metrics.new_histogram(
                 "message_db_loader_scan_duration_seconds",
@@ -1035,6 +1044,9 @@ impl MessageDbLoaderMetricsShared {
             records_examined: self.records_examined.clone(),
             logical_db_reads: self.logical_db_reads.clone(),
             destination_outcomes: self.destination_outcomes.clone(),
+            destination_outcome_counters: HashMap::new(),
+            initial_destination_scan_complete: self.initial_destination_scan_complete.clone(),
+            initial_destination_scan_complete_gauges: HashMap::new(),
             scan_duration_seconds: self.scan_duration_seconds.clone(),
             ingress_depth: self.ingress_depth.clone(),
         }
@@ -1048,15 +1060,52 @@ pub struct MessageDbLoaderMetrics {
     records_examined: IntCounterVec,
     logical_db_reads: IntCounterVec,
     destination_outcomes: IntCounterVec,
+    destination_outcome_counters: HashMap<String, HashMap<&'static str, IntCounter>>,
+    initial_destination_scan_complete: IntGaugeVec,
+    initial_destination_scan_complete_gauges: HashMap<String, IntGauge>,
     scan_duration_seconds: HistogramVec,
     ingress_depth: IntGaugeVec,
 }
 
 impl MessageDbLoaderMetrics {
-    fn record_destination_outcome(&self, destination: &str, outcome: &str) {
-        self.destination_outcomes
-            .with_label_values(&[self.origin.as_str(), destination, outcome])
-            .inc();
+    fn bind_destinations(&mut self, destinations: &[u32]) {
+        for destination in destinations {
+            let destination = destination.to_string();
+            let scan_complete = self
+                .initial_destination_scan_complete
+                .with_label_values(&[self.origin.as_str(), destination.as_str()]);
+            scan_complete.set(0);
+            self.initial_destination_scan_complete_gauges
+                .insert(destination, scan_complete);
+        }
+    }
+
+    fn record_destination_outcome(&mut self, destination: &str, outcome: &'static str) {
+        if let Some(counter) = self
+            .destination_outcome_counters
+            .get(destination)
+            .and_then(|counters| counters.get(outcome))
+        {
+            counter.inc();
+            return;
+        }
+        let counter = self.destination_outcomes.with_label_values(&[
+            self.origin.as_str(),
+            destination,
+            outcome,
+        ]);
+        counter.inc();
+        self.destination_outcome_counters
+            .entry(destination.to_owned())
+            .or_default()
+            .insert(outcome, counter);
+    }
+
+    fn mark_initial_destination_scan_complete(&self, destination: &str) {
+        self.initial_destination_scan_complete_gauges
+            .get(destination)
+            .expect("destination scan gauge is bound")
+            .set(1);
     }
 
     fn update_ingress_depths(

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -180,7 +180,6 @@ impl DestinationIndexIterator {
         if reopened_low_range {
             return self.peek(db, metrics);
         }
-        metrics.mark_initial_destination_scan_complete(self.destination_label.as_ref());
         Ok(None)
     }
 
@@ -755,6 +754,7 @@ impl MessageDbLoader {
             self.db
                 .mark_pending_message_index_migration_complete(self.migration_start_sequence)?;
             self.migration_iterator = None;
+            self.destination_scan_pending = true;
         }
         Ok(())
     }
@@ -782,6 +782,10 @@ impl MessageDbLoader {
         let Some((direction, nonce, indexed_message_id)) =
             self.destination_iterators[iterator_index].peek(&self.db, &self.metrics)?
         else {
+            if self.migration_iterator.is_none() {
+                self.metrics
+                    .mark_initial_destination_scan_complete(destination_label.as_ref());
+            }
             return Ok(false);
         };
         self.metrics

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -28,6 +28,16 @@ use super::{
 use crate::{db_loader::DbLoaderExt, settings::matching_list::MatchingList};
 
 const LEGACY_MIGRATION_BATCH_SIZE: usize = 256;
+const DESTINATION_OUTCOME_STALE_REPAIR: &str = "stale_repair";
+const DESTINATION_OUTCOME_PROCESSED_CLEANUP: &str = "processed_cleanup";
+const DESTINATION_OUTCOME_TERMINAL_CLEANUP: &str = "terminal_cleanup";
+const DESTINATION_OUTCOME_ALREADY_LOADED: &str = "already_loaded";
+const DESTINATION_OUTCOME_NOT_WHITELISTED: &str = "not_whitelisted";
+const DESTINATION_OUTCOME_MESSAGE_BLACKLISTED: &str = "message_blacklisted";
+const DESTINATION_OUTCOME_ADDRESS_BLACKLISTED: &str = "address_blacklisted";
+const DESTINATION_OUTCOME_MISSING_CONTEXT: &str = "missing_context";
+const DESTINATION_OUTCOME_RETRY_INELIGIBLE: &str = "retry_ineligible";
+const DESTINATION_OUTCOME_QUEUED: &str = "queued";
 
 /// Finds unprocessed messages from an origin and submits them through a channel
 /// for to the appropriate destination.
@@ -792,6 +802,10 @@ impl MessageDbLoader {
         let Some(message) = message else {
             self.db
                 .delete_pending_message_index_by_nonce(destination, nonce)?;
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_STALE_REPAIR,
+            );
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         };
@@ -808,6 +822,10 @@ impl MessageDbLoader {
                 ])
                 .inc_by(2);
             self.db.reconcile_pending_message_index(&message)?;
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_STALE_REPAIR,
+            );
             if message.destination == destination {
                 return Ok(true);
             }
@@ -836,6 +854,10 @@ impl MessageDbLoader {
             .unwrap_or(false)
         {
             self.db.delete_pending_message_index(&message)?;
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_PROCESSED_CLEANUP,
+            );
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         }
@@ -852,6 +874,10 @@ impl MessageDbLoader {
         if self.db.retrieve_terminally_dropped_message(&message.id())? {
             self.db
                 .delete_pending_message_index_by_nonce(destination, nonce)?;
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_TERMINAL_CLEANUP,
+            );
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         }
@@ -863,6 +889,10 @@ impl MessageDbLoader {
                 .clone(),
             self.db.clone(),
         ) else {
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_ALREADY_LOADED,
+            );
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         };
@@ -870,17 +900,29 @@ impl MessageDbLoader {
         DirectionalNonceIterator::update_max_nonce_gauge(&message, &self.metrics);
         // Retain disqualified entries so restart or configuration changes reconsider them.
         if !self.message_whitelist.msg_matches(&message, true) {
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_NOT_WHITELISTED,
+            );
             debug!(?message, "Message not whitelisted, skipping");
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         }
         if self.message_blacklist.msg_matches(&message, false) {
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_MESSAGE_BLACKLISTED,
+            );
             debug!(?message, "Message blacklisted, skipping");
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         }
         if let Some(blacklisted_address) = self.address_blacklist.find_blacklisted_address(&message)
         {
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_ADDRESS_BLACKLISTED,
+            );
             debug!(
                 ?message,
                 blacklisted_address = hex::encode(blacklisted_address),
@@ -890,6 +932,10 @@ impl MessageDbLoader {
             return Ok(true);
         }
         let Some(destination_msg_ctx) = self.destination_ctxs.get(&destination) else {
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_MISSING_CONTEXT,
+            );
             debug!(
                 ?message,
                 "Message destined for unknown message context, skipping"
@@ -907,12 +953,20 @@ impl MessageDbLoader {
             app_context,
             self.max_retries,
         ) else {
+            self.metrics.record_destination_outcome(
+                destination_label.as_ref(),
+                DESTINATION_OUTCOME_RETRY_INELIGIBLE,
+            );
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         };
         pending_message.set_loaded_message_guard(loaded_message_guard);
         match sender.try_send(vec![Box::new(pending_message) as QueueOperation]) {
             Ok(()) => {
+                self.metrics.record_destination_outcome(
+                    destination_label.as_ref(),
+                    DESTINATION_OUTCOME_QUEUED,
+                );
                 self.destination_iterators[iterator_index].advance(direction, nonce);
                 Ok(true)
             }
@@ -929,6 +983,7 @@ impl MessageDbLoader {
 pub struct MessageDbLoaderMetricsShared {
     records_examined: IntCounterVec,
     logical_db_reads: IntCounterVec,
+    destination_outcomes: IntCounterVec,
     scan_duration_seconds: HistogramVec,
     ingress_depth: IntGaugeVec,
 }
@@ -946,6 +1001,11 @@ impl MessageDbLoaderMetricsShared {
                 "message_db_loader_logical_db_reads_total",
                 "Logical database reads performed by the message DB loader",
                 &["origin", "destination", "phase", "operation"],
+            )?,
+            destination_outcomes: metrics.new_int_counter(
+                "message_db_loader_destination_outcomes_total",
+                "Outcomes for destination-index records examined by the message DB loader",
+                &["origin", "destination", "outcome"],
             )?,
             scan_duration_seconds: metrics.new_histogram(
                 "message_db_loader_scan_duration_seconds",
@@ -974,6 +1034,7 @@ impl MessageDbLoaderMetricsShared {
             origin: origin.name().to_owned(),
             records_examined: self.records_examined.clone(),
             logical_db_reads: self.logical_db_reads.clone(),
+            destination_outcomes: self.destination_outcomes.clone(),
             scan_duration_seconds: self.scan_duration_seconds.clone(),
             ingress_depth: self.ingress_depth.clone(),
         }
@@ -986,11 +1047,18 @@ pub struct MessageDbLoaderMetrics {
     origin: String,
     records_examined: IntCounterVec,
     logical_db_reads: IntCounterVec,
+    destination_outcomes: IntCounterVec,
     scan_duration_seconds: HistogramVec,
     ingress_depth: IntGaugeVec,
 }
 
 impl MessageDbLoaderMetrics {
+    fn record_destination_outcome(&self, destination: &str, outcome: &str) {
+        self.destination_outcomes
+            .with_label_values(&[self.origin.as_str(), destination, outcome])
+            .inc();
+    }
+
     fn update_ingress_depths(
         &self,
         send_channels: &HashMap<u32, Sender<QueueOperationBatch>>,

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -233,7 +233,7 @@ struct LegacyMessageIterator {
 impl LegacyMessageIterator {
     #[instrument(skip(db), ret)]
     fn new(db: Arc<dyn HyperlaneDb>) -> Result<(Self, Option<u32>)> {
-        let high_nonce = db.retrieve_highest_seen_message_nonce()?;
+        let high_nonce = db.retrieve_highest_message_nonce()?;
         let domain = db.domain().name().to_owned();
         let high_nonce_iter = DirectionalNonceIterator::new(
             // If the high nonce is None, we start from the beginning

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -73,6 +73,16 @@ pub fn dummy_message_loader_metrics() -> MessageDbLoaderMetrics {
             &["origin", "destination", "outcome"],
         )
         .unwrap(),
+        destination_outcome_counters: HashMap::new(),
+        initial_destination_scan_complete: IntGaugeVec::new(
+            prometheus::Opts::new(
+                "dummy_db_loader_initial_destination_scan_complete",
+                "help string",
+            ),
+            &["origin", "destination"],
+        )
+        .unwrap(),
+        initial_destination_scan_complete_gauges: HashMap::new(),
         scan_duration_seconds: HistogramVec::new(
             prometheus::HistogramOpts::new("dummy_db_loader_scan_duration", "help string"),
             &["origin", "destination", "phase"],
@@ -843,15 +853,7 @@ fn destination_outcome_count(
     destination: &HyperlaneDomain,
     outcome: &str,
 ) -> u64 {
-    loader
-        .metrics
-        .destination_outcomes
-        .with_label_values(&[
-            loader.metrics.origin.as_str(),
-            destination.id().to_string().as_str(),
-            outcome,
-        ])
-        .get()
+    loader.metrics.destination_outcome_counters[&destination.id().to_string()][outcome].get()
 }
 
 fn point_destination_scan_at(loader: &mut MessageDbLoader, nonce: u32) {
@@ -993,6 +995,18 @@ async fn destination_outcomes_attribute_loader_decisions_once() {
                 ])
                 .get(),
             10,
+        );
+        assert_eq!(
+            loader.metrics.initial_destination_scan_complete_gauges[&destination.id().to_string()]
+                .get(),
+            0,
+        );
+        point_destination_scan_at(&mut loader, nonce + 1);
+        assert!(!loader.try_load_destination(0).await.unwrap());
+        assert_eq!(
+            loader.metrics.initial_destination_scan_complete_gauges[&destination.id().to_string()]
+                .get(),
+            1,
         );
     })
     .await;

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -866,6 +866,37 @@ fn point_destination_scan_at(loader: &mut MessageDbLoader, nonce: u32) {
 }
 
 #[tokio::test]
+async fn initial_destination_scan_waits_for_legacy_migration() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let message = dummy_hyperlane_message(&destination, 0);
+        add_db_entry(&db, &message, 0);
+        db.delete_pending_message_index(&message).unwrap();
+        let (mut loader, mut receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        let scan_complete = loader.metrics.initial_destination_scan_complete_gauges
+            [&destination.id().to_string()]
+            .clone();
+
+        assert!(!loader.try_load_destination(0).await.unwrap());
+        assert_eq!(scan_complete.get(), 0);
+        finish_legacy_migration(&mut loader).await;
+        assert_eq!(scan_complete.get(), 0);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        assert_eq!(
+            only_operation(receiver.try_recv().unwrap()).id(),
+            message.id()
+        );
+        assert_eq!(scan_complete.get(), 0);
+        assert!(!loader.try_load_destination(0).await.unwrap());
+        assert_eq!(scan_complete.get(), 1);
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn destination_outcomes_attribute_loader_decisions_once() {
     test_utils::run_test_db(|raw_db| async move {
         let origin = dummy_domain(0, "origin");
@@ -1398,9 +1429,16 @@ async fn processed_legacy_history_does_not_rescan_every_destination() {
             })
             .sum();
         assert!(
-            destination_index_reads <= u64::from(DESTINATION_COUNT).saturating_mul(2),
+            // Two initial range reads, then one high-range read to certify
+            // completion after migration seals. No scans between those points.
+            destination_index_reads <= u64::from(DESTINATION_COUNT).saturating_mul(3),
             "destination indexes were rescanned during legacy history migration"
         );
+        assert!(loader
+            .metrics
+            .initial_destination_scan_complete_gauges
+            .values()
+            .all(|gauge| gauge.get() == 1));
     })
     .await;
 }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -68,6 +68,11 @@ pub fn dummy_message_loader_metrics() -> MessageDbLoaderMetrics {
             &["origin", "destination", "phase", "operation"],
         )
         .unwrap(),
+        destination_outcomes: IntCounterVec::new(
+            prometheus::Opts::new("dummy_db_loader_destination_outcomes", "help string"),
+            &["origin", "destination", "outcome"],
+        )
+        .unwrap(),
         scan_duration_seconds: HistogramVec::new(
             prometheus::HistogramOpts::new("dummy_db_loader_scan_duration", "help string"),
             &["origin", "destination", "phase"],
@@ -831,6 +836,166 @@ async fn get_first_n_operations_from_db_loader(
         _ = sleep(Duration::from_millis(200)) => { panic!("No PendingMessage received from the db_loader") }
     };
     pending_messages
+}
+
+fn destination_outcome_count(
+    loader: &MessageDbLoader,
+    destination: &HyperlaneDomain,
+    outcome: &str,
+) -> u64 {
+    loader
+        .metrics
+        .destination_outcomes
+        .with_label_values(&[
+            loader.metrics.origin.as_str(),
+            destination.id().to_string().as_str(),
+            outcome,
+        ])
+        .get()
+}
+
+fn point_destination_scan_at(loader: &mut MessageDbLoader, nonce: u32) {
+    let iterator = &mut loader.destination_iterators[0];
+    iterator.high_nonce = Some(nonce);
+    iterator.low_nonce = None;
+    iterator.next_direction = IndexDirection::High;
+    iterator.reconsider_nonces.clear();
+    iterator.low_range_reopen_pending = false;
+}
+
+#[tokio::test]
+async fn destination_outcomes_attribute_loader_decisions_once() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let (mut loader, mut receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        finish_legacy_migration(&mut loader).await;
+
+        let mut nonce = 0;
+        let stale = dummy_hyperlane_message(&destination, nonce);
+        db.store_pending_message_index(&stale).unwrap();
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+
+        nonce += 1;
+        let processed = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &processed, 0);
+        db.store_message_processed(&processed).unwrap();
+        db.store_pending_message_index(&processed).unwrap();
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+
+        nonce += 1;
+        let terminal = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &terminal, 0);
+        db.store_terminally_dropped_message(&terminal.id()).unwrap();
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+
+        nonce += 1;
+        let already_loaded = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &already_loaded, 0);
+        loader.destination_iterators[0]
+            .loaded_messages
+            .lock()
+            .insert(already_loaded.id());
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        loader.destination_iterators[0]
+            .loaded_messages
+            .lock()
+            .remove(&already_loaded.id());
+        db.delete_pending_message_index(&already_loaded).unwrap();
+
+        nonce += 1;
+        let not_whitelisted = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &not_whitelisted, 0);
+        loader.message_whitelist = Arc::new(MatchingList::with_destination_domain(
+            destination.id().saturating_add(1),
+        ));
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        loader.message_whitelist = Arc::new(MatchingList::default());
+        db.delete_pending_message_index(&not_whitelisted).unwrap();
+
+        nonce += 1;
+        let message_blacklisted = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &message_blacklisted, 0);
+        loader.message_blacklist =
+            Arc::new(MatchingList::with_destination_domain(destination.id()));
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        loader.message_blacklist = Arc::new(MatchingList::default());
+        db.delete_pending_message_index(&message_blacklisted)
+            .unwrap();
+
+        nonce += 1;
+        let mut address_blacklisted = dummy_hyperlane_message(&destination, nonce);
+        address_blacklisted.body = b"blocked".to_vec();
+        add_db_entry(&db, &address_blacklisted, 0);
+        loader.address_blacklist = Arc::new(AddressBlacklist::new(vec![b"blocked".to_vec()]));
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        loader.address_blacklist = Arc::new(AddressBlacklist::default());
+        db.delete_pending_message_index(&address_blacklisted)
+            .unwrap();
+
+        nonce += 1;
+        let missing_context = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &missing_context, 0);
+        let context = loader.destination_ctxs.remove(&destination.id()).unwrap();
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        loader.destination_ctxs.insert(destination.id(), context);
+        db.delete_pending_message_index(&missing_context).unwrap();
+
+        nonce += 1;
+        let retry_ineligible = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &retry_ineligible, DEFAULT_MAX_MESSAGE_RETRIES);
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        db.delete_pending_message_index(&retry_ineligible).unwrap();
+
+        nonce += 1;
+        let queued = dummy_hyperlane_message(&destination, nonce);
+        add_db_entry(&db, &queued, 0);
+        point_destination_scan_at(&mut loader, nonce);
+        assert!(loader.try_load_destination(0).await.unwrap());
+        assert_eq!(
+            only_operation(receiver.try_recv().unwrap()).id(),
+            queued.id()
+        );
+
+        for outcome in [
+            DESTINATION_OUTCOME_STALE_REPAIR,
+            DESTINATION_OUTCOME_PROCESSED_CLEANUP,
+            DESTINATION_OUTCOME_TERMINAL_CLEANUP,
+            DESTINATION_OUTCOME_ALREADY_LOADED,
+            DESTINATION_OUTCOME_NOT_WHITELISTED,
+            DESTINATION_OUTCOME_MESSAGE_BLACKLISTED,
+            DESTINATION_OUTCOME_ADDRESS_BLACKLISTED,
+            DESTINATION_OUTCOME_MISSING_CONTEXT,
+            DESTINATION_OUTCOME_RETRY_INELIGIBLE,
+            DESTINATION_OUTCOME_QUEUED,
+        ] {
+            assert_eq!(destination_outcome_count(&loader, &destination, outcome), 1);
+        }
+        assert_eq!(
+            loader
+                .metrics
+                .records_examined
+                .with_label_values(&[
+                    loader.metrics.origin.as_str(),
+                    destination.id().to_string().as_str(),
+                    "destination_index",
+                ])
+                .get(),
+            10,
+        );
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1731,3 +1731,37 @@ async fn completed_migration_recovers_late_low_nonce_and_legacy_writes() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn standalone_cleanup_forces_restart_recovery_of_replacement() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let original = dummy_hyperlane_message(&destination, 0);
+        add_db_entry(&db, &original, 0);
+        let (mut loader, _) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        finish_legacy_migration(&mut loader).await;
+        drop(loader);
+        let mut replacement = original;
+        replacement.body = vec![1];
+        db.upsert_message(&replacement, 2)
+            .expect("atomic replacement");
+        db.delete_pending_message_index_by_nonce(destination.id(), 0)
+            .expect("stale cleanup");
+        let (mut restarted, mut receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        assert!(restarted.migration_iterator.is_some());
+        finish_legacy_migration(&mut restarted).await;
+        restarted
+            .try_load_destination(0)
+            .await
+            .expect("load replacement");
+        assert_eq!(
+            only_operation(receiver.try_recv().expect("replacement")).id(),
+            replacement.id()
+        );
+    })
+    .await;
+}

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1520,3 +1520,214 @@ async fn saturated_destination_does_not_block_legacy_migration_for_another_desti
     })
     .await;
 }
+
+fn loader_phase_counter(counter: &IntCounterVec, phase: &str) -> f64 {
+    prometheus::core::Collector::collect(counter)
+        .iter()
+        .flat_map(|family| family.get_metric())
+        .filter(|metric| {
+            metric
+                .get_label()
+                .iter()
+                .any(|label| label.name() == "phase" && label.value() == phase)
+        })
+        .map(|metric| metric.get_counter().as_ref().unwrap().value())
+        .sum()
+}
+
+// Measures migration separately from fixture creation, database reopening and
+// destination loading. OS filesystem caches remain warm across all runs.
+async fn measure_legacy_migration_restart(history_len: u32) -> (bool, f64) {
+    assert_eq!(history_len % 2, 0);
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let origin = dummy_domain(0, "migration_benchmark_origin");
+    let destination = dummy_domain(1, "migration_benchmark_destination");
+    {
+        let db = HyperlaneRocksDB::new(
+            &origin,
+            hyperlane_base::db::DB::from_path_with_rollback_wal(temp_dir.path()).unwrap(),
+        );
+        for nonce in 0..history_len {
+            let message = dummy_hyperlane_message(&destination, nonce);
+            add_db_entry(&db, &message, 0);
+            if nonce % 2 == 0 {
+                db.store_message_processed(&message).unwrap();
+            } else {
+                // Exercise upgrade from rows without the destination index.
+                db.delete_pending_message_index(&message).unwrap();
+            }
+        }
+    }
+
+    let mut restart_started_complete = false;
+    let mut restart_reads = 0.0;
+    for phase in ["initial", "restart", "restart_after_writes"] {
+        let db = HyperlaneRocksDB::new(
+            &origin,
+            hyperlane_base::db::DB::from_path_with_rollback_wal(temp_dir.path()).unwrap(),
+        );
+        let metrics = dummy_message_loader_metrics();
+        let (sender, _receiver) = mpsc::channel::<QueueOperationBatch>(1);
+        let started = Instant::now();
+        let mut loader = MessageDbLoader::new(
+            db.clone(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metrics,
+            HashMap::from([(destination.id(), sender)]),
+            HashMap::new(),
+            vec![].into(),
+            10,
+        )
+        .unwrap();
+        let started_complete = loader.migration_iterator.is_none();
+        finish_legacy_migration(&mut loader).await;
+        let elapsed = started.elapsed();
+        let reads = loader_phase_counter(&loader.metrics.logical_db_reads, "migration");
+        let records = loader_phase_counter(&loader.metrics.records_examined, "migration");
+        let destination_reads =
+            loader_phase_counter(&loader.metrics.logical_db_reads, "destination_index");
+        println!(
+            "legacy_migration_benchmark phase={phase} history={history_len} elapsed_seconds={:.6} migration_records={records} migration_logical_reads={reads} destination_logical_reads={destination_reads} started_complete={started_complete}",
+            elapsed.as_secs_f64(),
+        );
+        assert_eq!(destination_reads, 0.0);
+        if phase == "initial" {
+            assert_eq!(records, f64::from(history_len));
+            // Every present row reads message + processed; the unprocessed
+            // half additionally reads destination index + processed again.
+            assert_eq!(reads, f64::from(history_len) * 3.0);
+        } else if phase == "restart" {
+            restart_started_complete = started_complete;
+            restart_reads = reads;
+        } else {
+            assert!(started_complete);
+            assert_eq!(reads, 0.0);
+        }
+        drop(loader);
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination.id(), 0)
+                .unwrap()
+                .map(|(nonce, _)| nonce),
+            Some(1),
+        );
+        assert_eq!(
+            db.retrieve_pending_message_at_or_before(destination.id(), history_len - 1)
+                .unwrap()
+                .map(|(nonce, _)| nonce),
+            Some(history_len - 1),
+        );
+        if phase == "restart" {
+            // Include unrelated WAL history in the next startup's validation,
+            // without charging write generation to its measured duration.
+            for nonce in 0..history_len {
+                db.store_value_by_key("migration_benchmark_status_", &nonce, &nonce)
+                    .unwrap();
+            }
+        }
+    }
+    (restart_started_complete, restart_reads)
+}
+
+#[tokio::test]
+async fn completed_legacy_migration_restart_read_count() {
+    let (started_complete, reads) = measure_legacy_migration_restart(1_024).await;
+    assert!(started_complete);
+    assert_eq!(reads, 0.0);
+}
+
+#[tokio::test]
+#[ignore = "100k-row migration benchmark; run explicitly with --ignored --nocapture"]
+async fn benchmark_legacy_migration_restart() {
+    measure_legacy_migration_restart(100_000).await;
+}
+
+#[tokio::test]
+async fn interrupted_migration_restarts_and_recovers_all_destinations() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let other = dummy_domain(2, "other");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let low = dummy_hyperlane_message(&other, 0);
+        let high = dummy_hyperlane_message(&destination, 2);
+        for message in [&low, &high] {
+            add_db_entry(&db, message, 0);
+            db.delete_pending_message_index(message)
+                .expect("legacy row");
+        }
+        let (mut loader, _) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        loader
+            .migrate_legacy_batch()
+            .await
+            .expect("migrate high row");
+        assert!(loader.migration_iterator.is_some());
+        assert!(!db
+            .pending_message_index_migration_complete()
+            .expect("read seal"));
+        drop(loader);
+        let (mut restarted, _) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        assert!(restarted.migration_iterator.is_some());
+        finish_legacy_migration(&mut restarted).await;
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(other.id(), 0)
+                .expect("other destination"),
+            Some((low.nonce, low.id())),
+        );
+        assert!(db
+            .pending_message_index_migration_complete()
+            .expect("completed seal"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn completed_migration_recovers_late_low_nonce_and_legacy_writes() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let high = dummy_hyperlane_message(&destination, 10);
+        add_db_entry(&db, &high, 0);
+        let (mut loader, _) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        finish_legacy_migration(&mut loader).await;
+        drop(loader);
+        let low = dummy_hyperlane_message(&destination, 1);
+        add_db_entry(&db, &low, 0);
+        let (mut restarted, mut receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        assert!(restarted.migration_iterator.is_none());
+        let mut loaded = Vec::new();
+        for _ in 0..8 {
+            restarted
+                .try_load_destination(0)
+                .await
+                .expect("load indexed destination");
+            if let Ok(batch) = receiver.try_recv() {
+                loaded.push(only_operation(batch).id());
+            }
+        }
+        assert!(loaded.contains(&low.id()));
+        assert!(loaded.contains(&high.id()));
+        drop(restarted);
+        let legacy = dummy_hyperlane_message(&destination, 0);
+        db.store_message_by_id(&legacy.id(), &legacy)
+            .expect("legacy message");
+        db.store_message_id_by_nonce(&legacy.nonce, &legacy.id())
+            .expect("legacy nonce");
+        let (mut upgraded, _) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        assert!(upgraded.migration_iterator.is_some());
+        finish_legacy_migration(&mut upgraded).await;
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination.id(), 0)
+                .expect("recovered legacy row"),
+            Some((legacy.nonce, legacy.id())),
+        );
+    })
+    .await;
+}

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1367,6 +1367,7 @@ async fn processed_legacy_history_does_not_rescan_every_destination() {
         for destination_id in 2..=DESTINATION_COUNT {
             let (sender, receiver) = mpsc::channel::<QueueOperationBatch>(1);
             loader.send_channels.insert(destination_id, sender);
+            loader.metrics.bind_destinations(&[destination_id]);
             loader
                 .destination_iterators
                 .push(DestinationIndexIterator::new(
@@ -1662,6 +1663,7 @@ async fn saturated_destination_does_not_block_legacy_migration_for_another_desti
         loader
             .send_channels
             .insert(destination_a.id(), sender_a.clone());
+        loader.metrics.bind_destinations(&[destination_a.id()]);
         loader.destination_iterators.insert(
             0,
             DestinationIndexIterator::new(destination_a.id(), Some(2)),

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1362,7 +1362,7 @@ async fn legacy_iterator_stops_at_startup_watermark() {
         .expect_domain()
         .return_const(dummy_domain(0, "dummy_domain"));
     mock_db
-        .expect_retrieve_highest_seen_message_nonce()
+        .expect_retrieve_highest_message_nonce()
         .returning(|| Ok(Some(MOCK_HIGHEST_SEEN_NONCE)));
     mock_db
         .expect_retrieve_message_by_nonce()
@@ -1407,7 +1407,7 @@ async fn legacy_iterator_stops_at_startup_watermark() {
 fn startup_watermark_error_is_propagated() {
     let mut mock_db = MockDb::new();
     mock_db
-        .expect_retrieve_highest_seen_message_nonce()
+        .expect_retrieve_highest_message_nonce()
         .times(1)
         .returning(|| Err(DbError::Other("watermark read failed".to_owned())));
 
@@ -1644,6 +1644,41 @@ async fn benchmark_legacy_migration_restart() {
 }
 
 #[tokio::test]
+#[ignore = "multi-origin restart benchmark; run explicitly with --ignored --nocapture"]
+async fn benchmark_multi_origin_legacy_migration_restart() {
+    const ORIGIN_COUNT: u32 = 32;
+    const HISTORY_LEN: u32 = 1_024;
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let raw_db = hyperlane_base::db::DB::from_path_with_rollback_wal(temp_dir.path()).unwrap();
+    let destination = dummy_domain(10_000, "migration_benchmark_destination");
+    let origins: Vec<_> = (0..ORIGIN_COUNT)
+        .map(|id| dummy_domain(id, &format!("migration_benchmark_origin_{id}")))
+        .collect();
+
+    for origin in &origins {
+        let db = HyperlaneRocksDB::new(origin, raw_db.clone());
+        for nonce in 0..HISTORY_LEN {
+            add_db_entry(&db, &dummy_hyperlane_message(&destination, nonce), 0);
+        }
+        let (mut loader, _) =
+            dummy_message_loader(origin, &destination, &db, OptionalCache::new(None));
+        finish_legacy_migration(&mut loader).await;
+    }
+
+    let started = Instant::now();
+    for origin in &origins {
+        let db = HyperlaneRocksDB::new(origin, raw_db.clone());
+        let (loader, _) = dummy_message_loader(origin, &destination, &db, OptionalCache::new(None));
+        assert!(loader.migration_iterator.is_none());
+    }
+    println!(
+        "legacy_migration_multi_origin_benchmark origins={ORIGIN_COUNT} history_per_origin={HISTORY_LEN} elapsed_seconds={:.6}",
+        started.elapsed().as_secs_f64()
+    );
+}
+
+#[tokio::test]
 async fn interrupted_migration_restarts_and_recovers_all_destinations() {
     test_utils::run_test_db(|raw_db| async move {
         let origin = dummy_domain(0, "origin");
@@ -1680,6 +1715,38 @@ async fn interrupted_migration_restarts_and_recovers_all_destinations() {
         assert!(db
             .pending_message_index_migration_complete()
             .expect("completed seal"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn migration_uses_highest_message_id_when_watermark_is_stale() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let low = dummy_hyperlane_message(&destination, 1);
+        let high = dummy_hyperlane_message(&destination, 2);
+        add_db_entry(&db, &low, 0);
+
+        // Reproduce the legacy non-atomic write ordering: the canonical
+        // nonce-to-ID map advances, but the high watermark and destination
+        // index do not.
+        db.store_message_by_id(&high.id(), &high).unwrap();
+        db.store_message_id_by_nonce(&high.nonce, &high.id())
+            .unwrap();
+        assert_eq!(db.retrieve_highest_seen_message_nonce().unwrap(), Some(1));
+
+        let (mut loader, _) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+        finish_legacy_migration(&mut loader).await;
+
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination.id(), high.nonce)
+                .unwrap(),
+            Some((high.nonce, high.id()))
+        );
+        assert!(db.pending_message_index_migration_complete().unwrap());
     })
     .await;
 }

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -2,7 +2,10 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Formatter},
     hash::Hash,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -75,6 +78,45 @@ const CURSOR_BUILDING_ERROR: &str = "Error building cursor for origin";
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
 const MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 const ADVANCED_LOG_META: bool = false;
+
+struct CancelBlockingTaskOnDrop {
+    cancellation: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl CancelBlockingTaskOnDrop {
+    fn new(cancellation: Arc<AtomicBool>) -> Self {
+        Self {
+            cancellation,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelBlockingTaskOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cancellation.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+async fn spawn_cancellable_blocking<F, T>(work: F) -> Result<T, tokio::task::JoinError>
+where
+    F: FnOnce(&AtomicBool) -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let cancellation = Arc::new(AtomicBool::new(false));
+    let worker_cancellation = cancellation.clone();
+    let mut guard = CancelBlockingTaskOnDrop::new(cancellation);
+    let result = tokio::task::spawn_blocking(move || work(&worker_cancellation)).await;
+    guard.disarm();
+    result
+}
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 struct ContextKey {
@@ -965,8 +1007,8 @@ impl Relayer {
                     let send_channels = send_channels.clone();
                     let destination_ctxs = destination_ctxs.clone();
                     let metric_app_contexts = metric_app_contexts.clone();
-                    let result = tokio::task::spawn_blocking(move || {
-                        MessageDbLoader::new(
+                    let result = spawn_cancellable_blocking(move |cancellation| {
+                        MessageDbLoader::new_with_cancellation(
                             database,
                             message_whitelist,
                             message_blacklist,
@@ -976,6 +1018,7 @@ impl Relayer {
                             destination_ctxs,
                             metric_app_contexts,
                             max_retries,
+                            cancellation,
                         )
                     })
                     .await;

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -957,25 +957,47 @@ impl Relayer {
             async move {
                 let mut init_failed = false;
                 let mut message_db_loader = loop {
-                    match MessageDbLoader::new(
-                        database.clone(),
-                        message_whitelist.clone(),
-                        message_blacklist.clone(),
-                        address_blacklist.clone(),
-                        metrics.clone(),
-                        send_channels.clone(),
-                        destination_ctxs.clone(),
-                        metric_app_contexts.clone(),
-                        max_retries,
-                    ) {
-                        Ok(loader) => break loader,
-                        Err(err) => {
+                    let database = database.clone();
+                    let message_whitelist = message_whitelist.clone();
+                    let message_blacklist = message_blacklist.clone();
+                    let address_blacklist = address_blacklist.clone();
+                    let metrics = metrics.clone();
+                    let send_channels = send_channels.clone();
+                    let destination_ctxs = destination_ctxs.clone();
+                    let metric_app_contexts = metric_app_contexts.clone();
+                    let result = tokio::task::spawn_blocking(move || {
+                        MessageDbLoader::new(
+                            database,
+                            message_whitelist,
+                            message_blacklist,
+                            address_blacklist,
+                            metrics,
+                            send_channels,
+                            destination_ctxs,
+                            metric_app_contexts,
+                            max_retries,
+                        )
+                    })
+                    .await;
+                    match result {
+                        Ok(Ok(loader)) => break loader,
+                        Ok(Err(err)) => {
                             init_failed = true;
                             Self::record_critical_error(
                                 &origin_domain,
                                 &chain_metrics,
                                 &err,
                                 "Failed to run message db loader; retrying",
+                            );
+                            tokio::time::sleep(MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL).await;
+                        }
+                        Err(err) => {
+                            init_failed = true;
+                            Self::record_critical_error(
+                                &origin_domain,
+                                &chain_metrics,
+                                &err,
+                                "Message db loader initialization task failed; retrying",
                             );
                             tokio::time::sleep(MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL).await;
                         }

--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use ethers::utils::hex;
@@ -26,7 +29,32 @@ use lander::DispatcherMetrics;
 
 use crate::settings::{matching_list::MatchingList, RelayerSettings};
 
-use super::Relayer;
+use super::{spawn_cancellable_blocking, Relayer};
+
+#[tokio::test]
+async fn cancelled_blocking_task_is_signalled_to_stop() {
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let stopped = Arc::new(AtomicBool::new(false));
+    let worker_stopped = stopped.clone();
+    let task = tokio::spawn(spawn_cancellable_blocking(move |cancellation| {
+        started_tx.send(()).expect("signal worker started");
+        while !cancellation.load(Ordering::Relaxed) {
+            std::thread::yield_now();
+        }
+        worker_stopped.store(true, Ordering::Relaxed);
+    }));
+
+    started_rx.await.expect("worker started");
+    task.abort();
+    assert!(task.await.expect_err("task is cancelled").is_cancelled());
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !stopped.load(Ordering::Relaxed) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("blocking task observed cancellation");
+}
 
 fn generate_test_core_contract_addresses() -> CoreContractAddresses {
     CoreContractAddresses {

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -20,6 +20,9 @@ pub trait HyperlaneDb: Send + Sync {
     /// Retrieve the nonce of the highest processed message we're aware of
     fn retrieve_highest_seen_message_nonce(&self) -> DbResult<Option<u32>>;
 
+    /// Retrieve the greatest nonce with a stored message ID.
+    fn retrieve_highest_message_nonce(&self) -> DbResult<Option<u32>>;
+
     /// Retrieve a message by its nonce
     fn retrieve_message_by_nonce(&self, nonce: u32) -> DbResult<Option<HyperlaneMessage>>;
 

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -187,27 +187,43 @@ impl HyperlaneRocksDB {
         };
         // Capture before validation so concurrent writes remain covered next time.
         let sequence = self.latest_sequence_number();
-        for source in [MESSAGE_ID, NONCE_PROCESSED] {
-            match self.has_unmarked_writes_since(checkpoint, source, PENDING_MESSAGE_BY_DESTINATION)
-            {
-                Ok(false) => continue,
-                Ok(true) => debug!(
-                    checkpoint,
-                    source, "Pending message index has legacy writes; repeating migration"
-                ),
-                Err(error) => debug!(
-                    ?error,
-                    checkpoint, "Pending message index WAL unavailable; repeating migration"
-                ),
+        let validation = (|| {
+            if checkpoint > sequence {
+                return Ok(true);
             }
-            self.store_and_delete_batch(
-                std::iter::empty(),
-                [(
-                    PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE.as_bytes().to_vec(),
-                    false.to_vec(),
-                )],
-            )?;
-            return Ok(false);
+            for source in [MESSAGE_ID, NONCE_PROCESSED] {
+                if self.has_unmarked_writes_since(
+                    checkpoint,
+                    source,
+                    PENDING_MESSAGE_BY_DESTINATION,
+                )? {
+                    return Ok(true);
+                }
+            }
+            // Standalone cleanup can race a replacement or crash before repair.
+            // Only canonical upsert/processed batches prove that deletion is safe.
+            self.has_unmarked_deletions_since(
+                checkpoint,
+                PENDING_MESSAGE_BY_DESTINATION,
+                &[MESSAGE_ID.as_bytes(), NONCE_PROCESSED.as_bytes()],
+            )
+        })();
+        match validation {
+            Ok(false) => {}
+            result => {
+                debug!(
+                    ?result,
+                    checkpoint, "Pending message index cannot be certified; repeating migration"
+                );
+                self.store_and_delete_batch(
+                    std::iter::empty(),
+                    [(
+                        PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE.as_bytes().to_vec(),
+                        false.to_vec(),
+                    )],
+                )?;
+                return Ok(false);
+            }
         }
         self.mark_pending_message_index_migration_complete(sequence)?;
         Ok(true)
@@ -531,6 +547,37 @@ mod pending_index_tests {
             recipient: H256::zero(),
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn migration_seal_rejects_standalone_cleanup_after_replacement() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            for cleanup_during_migration in [false, true] {
+                let original = message(2, 10);
+                db.upsert_message(&original, 1).expect("original");
+                let sequence = db.latest_sequence_number();
+                if !cleanup_during_migration {
+                    db.mark_pending_message_index_migration_complete(sequence)
+                        .expect("seal");
+                }
+                // A loader's old terminal/missing-row observation can precede
+                // an atomic replacement, then delete that replacement's entry.
+                let mut replacement = original.clone();
+                replacement.body = vec![1];
+                db.upsert_message(&replacement, 2).expect("replacement");
+                db.delete_pending_message_index_by_nonce(10, 2)
+                    .expect("stale cleanup");
+                if cleanup_during_migration {
+                    db.mark_pending_message_index_migration_complete(sequence)
+                        .expect("seal");
+                }
+                assert!(!db
+                    .pending_message_index_migration_complete()
+                    .expect("validate"));
+            }
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -1,4 +1,7 @@
-use std::ops::Add;
+use std::{
+    ops::Add,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use async_trait::async_trait;
 use eyre::{bail, Result};
@@ -180,6 +183,14 @@ impl HyperlaneRocksDB {
     /// Check that migration finished and subsequent writes maintained the index.
     /// Older binaries do not maintain this index; missing WAL also requires a rescan.
     pub fn pending_message_index_migration_complete(&self) -> DbResult<bool> {
+        self.pending_message_index_migration_complete_with_cancellation(&AtomicBool::new(false))
+    }
+
+    /// Check migration completion while allowing a blocking WAL scan to stop on shutdown.
+    pub fn pending_message_index_migration_complete_with_cancellation(
+        &self,
+        cancellation: &AtomicBool,
+    ) -> DbResult<bool> {
         let Some(checkpoint) =
             self.retrieve_value_by_key::<_, u64>(PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE, &false)?
         else {
@@ -198,8 +209,14 @@ impl HyperlaneRocksDB {
                 checkpoint,
                 &[MESSAGE_ID.as_bytes(), NONCE_PROCESSED.as_bytes()],
                 PENDING_MESSAGE_BY_DESTINATION.as_bytes(),
+                cancellation,
             )
         })();
+        if cancellation.load(Ordering::Relaxed) {
+            return Err(DbError::Other(
+                "Pending message index migration validation cancelled".to_string(),
+            ));
+        }
         match validation {
             Ok(false) => {}
             result => {
@@ -538,6 +555,8 @@ impl HyperlaneRocksDB {
 
 #[cfg(test)]
 mod pending_index_tests {
+    use std::sync::atomic::AtomicBool;
+
     use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, H256};
 
     use super::*;
@@ -592,6 +611,22 @@ mod pending_index_tests {
             db.store_value_by_key(PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE, &false, &true)
                 .expect("write malformed seal");
             assert!(db.pending_message_index_migration_complete().is_err());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_migration_validation_preserves_seal() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
+                .expect("seal");
+
+            let cancellation = AtomicBool::new(true);
+            assert!(db
+                .pending_message_index_migration_complete_with_cancellation(&cancellation)
+                .is_err());
+            assert!(db.pending_message_index_migration_complete().unwrap());
         })
         .await;
     }

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -39,6 +39,8 @@ const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
 const PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID: &str =
     "pending_message_retry_state_for_message_id_v1_";
 const PENDING_MESSAGE_BY_DESTINATION: &str = "pending_message_by_destination_v1_";
+const PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE: &str =
+    "pending_message_index_migration_complete_v1_";
 const TERMINALLY_DROPPED_MESSAGE_BY_ID: &str = "terminally_dropped_message_by_id_v1_";
 const MERKLE_TREE_INSERTION: &str = "merkle_tree_insertion_";
 const MERKLE_LEAF_INDEX_BY_MESSAGE_ID: &str = "merkle_leaf_index_by_message_id_";
@@ -173,6 +175,48 @@ impl HyperlaneRocksDB {
             .chain(destination.to_be_bytes().iter())
             .copied()
             .collect()
+    }
+
+    /// Check that migration finished and subsequent writes maintained the index.
+    /// Older binaries do not maintain this index; missing WAL also requires a rescan.
+    pub fn pending_message_index_migration_complete(&self) -> DbResult<bool> {
+        let Some(checkpoint) =
+            self.retrieve_value_by_key::<_, u64>(PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE, &false)?
+        else {
+            return Ok(false);
+        };
+        // Capture before validation so concurrent writes remain covered next time.
+        let sequence = self.latest_sequence_number();
+        for source in [MESSAGE_ID, NONCE_PROCESSED] {
+            match self.has_unmarked_writes_since(checkpoint, source, PENDING_MESSAGE_BY_DESTINATION)
+            {
+                Ok(false) => continue,
+                Ok(true) => debug!(
+                    checkpoint,
+                    source, "Pending message index has legacy writes; repeating migration"
+                ),
+                Err(error) => debug!(
+                    ?error,
+                    checkpoint, "Pending message index WAL unavailable; repeating migration"
+                ),
+            }
+            self.store_and_delete_batch(
+                std::iter::empty(),
+                [(
+                    PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE.as_bytes().to_vec(),
+                    false.to_vec(),
+                )],
+            )?;
+            return Ok(false);
+        }
+        self.mark_pending_message_index_migration_complete(sequence)?;
+        Ok(true)
+    }
+
+    /// Seal a finished migration using the sequence captured before it started.
+    /// Keeping that conservative boundary also detects legacy writes during migration.
+    pub fn mark_pending_message_index_migration_complete(&self, sequence: u64) -> DbResult<()> {
+        self.store_value_by_key(PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE, &false, &sequence)
     }
 
     /// Add an unprocessed message to its destination range.
@@ -487,6 +531,144 @@ mod pending_index_tests {
             recipient: H256::zero(),
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn migration_seal_decode_error_is_propagated() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            db.store_value_by_key(PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE, &false, &true)
+                .expect("write malformed seal");
+            assert!(db.pending_message_index_migration_complete().is_err());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn migration_seal_accepts_atomic_writes_and_refreshes() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            assert!(!db.pending_message_index_migration_complete().unwrap());
+            db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
+                .unwrap();
+            db.store_message(&message(100, 10), 1).unwrap();
+            db.store_message(&message(2, 10), 1).unwrap();
+            db.upsert_message(&message(2, 11), 2).unwrap();
+            db.store_message_processed(&message(2, 11)).unwrap();
+            db.store_dispatched_block_number_by_nonce(&100, &3).unwrap();
+            db.store_dispatched_tx_hash_by_message_id(&message(100, 10).id(), &H512::zero())
+                .unwrap();
+            let sequence = db.latest_sequence_number();
+            assert!(db.pending_message_index_migration_complete().unwrap());
+            assert_eq!(
+                db.retrieve_value_by_key::<_, u64>(
+                    PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE,
+                    &false
+                )
+                .unwrap(),
+                Some(sequence)
+            );
+            assert!(db.pending_message_index_migration_complete().unwrap());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn migration_seal_rejects_legacy_low_nonce_insert_and_replacement() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            db.store_message(&message(100, 10), 1).unwrap();
+            for legacy in [message(2, 10), message(2, 11)] {
+                db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
+                    .unwrap();
+                // Reproduce the older writer's separate message and nonce-map writes.
+                db.store_message_by_id(&legacy.id(), &legacy).unwrap();
+                db.store_message_id_by_nonce(&legacy.nonce, &legacy.id())
+                    .unwrap();
+                assert_eq!(db.retrieve_highest_seen_message_nonce().unwrap(), Some(100));
+                assert!(!db.pending_message_index_migration_complete().unwrap());
+                assert!(db
+                    .retrieve_value_by_key::<_, u64>(
+                        PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE,
+                        &false,
+                    )
+                    .unwrap()
+                    .is_none());
+                assert!(!db.pending_message_index_migration_complete().unwrap());
+            }
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn migration_seal_rejects_legacy_processed_reset() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            let message = message(2, 10);
+            db.store_message(&message, 1).unwrap();
+            db.store_message_processed(&message).unwrap();
+            db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
+                .unwrap();
+            db.store_processed_by_nonce(&message.nonce, &false).unwrap();
+            assert!(!db.pending_message_index_migration_complete().unwrap());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn migration_seal_keeps_writes_during_migration_visible() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            let sequence = db.latest_sequence_number();
+            db.store_message_id_by_nonce(&0, &message(0, 10).id())
+                .unwrap();
+            db.mark_pending_message_index_migration_complete(sequence)
+                .unwrap();
+            assert!(!db.pending_message_index_migration_complete().unwrap());
+        })
+        .await;
+    }
+
+    #[test]
+    fn migration_seal_survives_reopen_with_retained_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let domain = HyperlaneDomain::new_test_domain("origin");
+        {
+            let db = HyperlaneRocksDB::new(
+                &domain,
+                DB::from_path_with_rollback_wal(dir.path()).unwrap(),
+            );
+            db.store_message(&message(0, 10), 1).unwrap();
+            db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
+                .unwrap();
+        }
+        let db = HyperlaneRocksDB::new(
+            &domain,
+            DB::from_path_with_rollback_wal(dir.path()).unwrap(),
+        );
+        assert!(db.pending_message_index_migration_complete().unwrap());
+    }
+
+    #[test]
+    fn migration_seal_rejects_missing_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let domain = HyperlaneDomain::new_test_domain("origin");
+        let mut options = rocksdb::Options::default();
+        options.create_if_missing(true);
+        {
+            let rocks = std::sync::Arc::new(rocksdb::DB::open(&options, dir.path()).unwrap());
+            let db = HyperlaneRocksDB::new(&domain, DB(rocks.clone()));
+            db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
+                .unwrap();
+            db.store_message(&message(0, 10), 1).unwrap();
+            rocks.flush().unwrap();
+            db.store_message(&message(1, 10), 1).unwrap();
+        }
+        let db = HyperlaneRocksDB::new(
+            &domain,
+            rocksdb::DB::open(&options, dir.path()).unwrap().into(),
+        );
+        assert!(!db.pending_message_index_migration_complete().unwrap());
     }
 
     #[tokio::test]

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -191,21 +191,13 @@ impl HyperlaneRocksDB {
             if checkpoint > sequence {
                 return Ok(true);
             }
-            for source in [MESSAGE_ID, NONCE_PROCESSED] {
-                if self.has_unmarked_writes_since(
-                    checkpoint,
-                    source,
-                    PENDING_MESSAGE_BY_DESTINATION,
-                )? {
-                    return Ok(true);
-                }
-            }
             // Standalone cleanup can race a replacement or crash before repair.
-            // Only canonical upsert/processed batches prove that deletion is safe.
-            self.has_unmarked_deletions_since(
+            // One WAL pass detects both legacy source writes and derived-index
+            // deletions not paired with a canonical upsert/processed batch.
+            self.has_unmarked_pending_index_updates_since(
                 checkpoint,
-                PENDING_MESSAGE_BY_DESTINATION,
                 &[MESSAGE_ID.as_bytes(), NONCE_PROCESSED.as_bytes()],
+                PENDING_MESSAGE_BY_DESTINATION.as_bytes(),
             )
         })();
         match validation {
@@ -353,6 +345,19 @@ impl HyperlaneRocksDB {
             None => Ok(None),
             Some(id) => self.retrieve_message_by_id(&id),
         }
+    }
+
+    /// Retrieve the greatest nonce represented by the canonical nonce-to-ID map.
+    pub fn retrieve_highest_message_nonce(&self) -> DbResult<Option<u32>> {
+        let Some((nonce, _)) =
+            self.retrieve_by_prefix_at_or_before::<H256>(MESSAGE_ID, u32::MAX.to_be_bytes())?
+        else {
+            return Ok(None);
+        };
+        let nonce: [u8; 4] = nonce.try_into().map_err(|nonce: Vec<u8>| {
+            DbError::Other(format!("Invalid message ID index key: {nonce:?}"))
+        })?;
+        Ok(Some(u32::from_be_bytes(nonce)))
     }
 
     /// Update the nonce of the highest processed message we're aware of
@@ -955,6 +960,10 @@ impl HyperlaneWatermarkedLogStore<MerkleTreeInsertion> for HyperlaneRocksDB {
 impl HyperlaneDb for HyperlaneRocksDB {
     fn retrieve_highest_seen_message_nonce(&self) -> DbResult<Option<u32>> {
         self.retrieve_highest_seen_message_nonce_number()
+    }
+
+    fn retrieve_highest_message_nonce(&self) -> DbResult<Option<u32>> {
+        self.retrieve_highest_message_nonce()
     }
 
     fn retrieve_message_by_nonce(&self, nonce: u32) -> DbResult<Option<HyperlaneMessage>> {

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -85,25 +85,30 @@ pub struct DbBatch {
 
 struct PrefixWriteDetector<'a> {
     source_prefix: &'a [u8],
-    marker_prefix: &'a [u8],
+    marker_prefixes: &'a [&'a [u8]],
+    deletions_only: bool,
     source_written: bool,
     marker_written: bool,
 }
 
 impl PrefixWriteDetector<'_> {
-    fn record(&mut self, key: &[u8]) {
-        self.source_written |= key.starts_with(self.source_prefix);
-        self.marker_written |= key.starts_with(self.marker_prefix);
+    fn record(&mut self, key: &[u8], deletion: bool) {
+        self.source_written |=
+            (!self.deletions_only || deletion) && key.starts_with(self.source_prefix);
+        self.marker_written |= self
+            .marker_prefixes
+            .iter()
+            .any(|prefix| key.starts_with(prefix));
     }
 }
 
 impl WriteBatchIterator for PrefixWriteDetector<'_> {
     fn put(&mut self, key: &[u8], _value: &[u8]) {
-        self.record(key);
+        self.record(key, false);
     }
 
     fn delete(&mut self, key: &[u8]) {
-        self.record(key);
+        self.record(key, true);
     }
 }
 
@@ -255,6 +260,26 @@ impl DB {
         source_prefix: &[u8],
         marker_prefix: &[u8],
     ) -> Result<bool> {
+        self.has_unmarked_updates_since(sequence, source_prefix, &[marker_prefix], false)
+    }
+
+    /// Detect source deletions without any of the supplied atomic markers.
+    pub fn has_unmarked_deletions_since(
+        &self,
+        sequence: u64,
+        source_prefix: &[u8],
+        marker_prefixes: &[&[u8]],
+    ) -> Result<bool> {
+        self.has_unmarked_updates_since(sequence, source_prefix, marker_prefixes, true)
+    }
+
+    fn has_unmarked_updates_since(
+        &self,
+        sequence: u64,
+        source_prefix: &[u8],
+        marker_prefixes: &[&[u8]],
+        deletions_only: bool,
+    ) -> Result<bool> {
         let latest_sequence = self.0.latest_sequence_number();
         let mut expected_sequence = sequence
             .checked_add(1)
@@ -272,7 +297,8 @@ impl DB {
                 .ok_or_else(|| DbError::Other("RocksDB sequence number overflowed".to_string()))?;
             let mut detector = PrefixWriteDetector {
                 source_prefix,
-                marker_prefix,
+                marker_prefixes,
+                deletions_only,
                 source_written: false,
                 marker_written: false,
             };

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -91,6 +91,14 @@ struct PrefixWriteDetector<'a> {
     marker_written: bool,
 }
 
+struct PendingIndexWriteDetector<'a> {
+    source_prefixes: &'a [&'a [u8]],
+    marker_prefix: &'a [u8],
+    source_written: bool,
+    marker_written: bool,
+    marker_deleted: bool,
+}
+
 impl PrefixWriteDetector<'_> {
     fn record(&mut self, key: &[u8], deletion: bool) {
         self.source_written |=
@@ -103,6 +111,29 @@ impl PrefixWriteDetector<'_> {
 }
 
 impl WriteBatchIterator for PrefixWriteDetector<'_> {
+    fn put(&mut self, key: &[u8], _value: &[u8]) {
+        self.record(key, false);
+    }
+
+    fn delete(&mut self, key: &[u8]) {
+        self.record(key, true);
+    }
+}
+
+impl PendingIndexWriteDetector<'_> {
+    fn record(&mut self, key: &[u8], deletion: bool) {
+        self.source_written |= self
+            .source_prefixes
+            .iter()
+            .any(|prefix| key.starts_with(prefix));
+        if key.starts_with(self.marker_prefix) {
+            self.marker_written = true;
+            self.marker_deleted |= deletion;
+        }
+    }
+}
+
+impl WriteBatchIterator for PendingIndexWriteDetector<'_> {
     fn put(&mut self, key: &[u8], _value: &[u8]) {
         self.record(key, false);
     }
@@ -273,12 +304,51 @@ impl DB {
         self.has_unmarked_updates_since(sequence, source_prefix, marker_prefixes, true)
     }
 
+    /// Detect legacy source writes or standalone derived-index deletions in one WAL pass.
+    pub fn has_unmarked_pending_index_updates_since(
+        &self,
+        sequence: u64,
+        source_prefixes: &[&[u8]],
+        marker_prefix: &[u8],
+    ) -> Result<bool> {
+        self.has_matching_updates_since(sequence, |batch| {
+            let mut detector = PendingIndexWriteDetector {
+                source_prefixes,
+                marker_prefix,
+                source_written: false,
+                marker_written: false,
+                marker_deleted: false,
+            };
+            batch.iterate(&mut detector);
+            (detector.source_written && !detector.marker_written)
+                || (detector.marker_deleted && !detector.source_written)
+        })
+    }
+
     fn has_unmarked_updates_since(
         &self,
         sequence: u64,
         source_prefix: &[u8],
         marker_prefixes: &[&[u8]],
         deletions_only: bool,
+    ) -> Result<bool> {
+        self.has_matching_updates_since(sequence, |batch| {
+            let mut detector = PrefixWriteDetector {
+                source_prefix,
+                marker_prefixes,
+                deletions_only,
+                source_written: false,
+                marker_written: false,
+            };
+            batch.iterate(&mut detector);
+            detector.source_written && !detector.marker_written
+        })
+    }
+
+    fn has_matching_updates_since(
+        &self,
+        sequence: u64,
+        mut matches: impl FnMut(&WriteBatch) -> bool,
     ) -> Result<bool> {
         let latest_sequence = self.0.latest_sequence_number();
         let mut expected_sequence = sequence
@@ -295,15 +365,7 @@ impl DB {
             expected_sequence = batch_sequence
                 .checked_add(batch.len() as u64)
                 .ok_or_else(|| DbError::Other("RocksDB sequence number overflowed".to_string()))?;
-            let mut detector = PrefixWriteDetector {
-                source_prefix,
-                marker_prefixes,
-                deletions_only,
-                source_written: false,
-                marker_written: false,
-            };
-            batch.iterate(&mut detector);
-            if detector.source_written && !detector.marker_written {
+            if matches(&batch) {
                 return Ok(true);
             }
         }

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -1,4 +1,12 @@
-use std::{fs, io::ErrorKind, path::Path, sync::Arc};
+use std::{
+    fs,
+    io::ErrorKind,
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use super::error::DbError;
 use rocksdb::{Direction, IteratorMode, Options, WriteBatch, WriteBatchIterator, DB as Rocks};
@@ -310,8 +318,9 @@ impl DB {
         sequence: u64,
         source_prefixes: &[&[u8]],
         marker_prefix: &[u8],
+        cancellation: &AtomicBool,
     ) -> Result<bool> {
-        self.has_matching_updates_since(sequence, |batch| {
+        self.has_matching_updates_since(sequence, Some(cancellation), |batch| {
             let mut detector = PendingIndexWriteDetector {
                 source_prefixes,
                 marker_prefix,
@@ -332,7 +341,7 @@ impl DB {
         marker_prefixes: &[&[u8]],
         deletions_only: bool,
     ) -> Result<bool> {
-        self.has_matching_updates_since(sequence, |batch| {
+        self.has_matching_updates_since(sequence, None, |batch| {
             let mut detector = PrefixWriteDetector {
                 source_prefix,
                 marker_prefixes,
@@ -348,6 +357,7 @@ impl DB {
     fn has_matching_updates_since(
         &self,
         sequence: u64,
+        cancellation: Option<&AtomicBool>,
         mut matches: impl FnMut(&WriteBatch) -> bool,
     ) -> Result<bool> {
         let latest_sequence = self.0.latest_sequence_number();
@@ -356,6 +366,11 @@ impl DB {
             .ok_or_else(|| DbError::Other("RocksDB sequence number overflowed".to_string()))?;
 
         for update in self.0.get_updates_since(sequence)? {
+            if cancellation.is_some_and(|cancelled| cancelled.load(Ordering::Relaxed)) {
+                return Err(DbError::Other(
+                    "RocksDB WAL validation cancelled".to_string(),
+                ));
+            }
             let (batch_sequence, batch) = update?;
             if batch_sequence != expected_sequence {
                 return Err(DbError::Other(format!(

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -210,6 +210,25 @@ impl TypedDB {
         )
     }
 
+    /// Detect unmarked pending-index updates in a single domain-scoped WAL pass.
+    pub fn has_unmarked_pending_index_updates_since(
+        &self,
+        sequence: u64,
+        source_prefixes: &[&[u8]],
+        marker_prefix: &[u8],
+    ) -> Result<bool> {
+        let source_prefixes: Vec<_> = source_prefixes
+            .iter()
+            .map(|prefix| self.prefixed_key(prefix, &[]))
+            .collect();
+        let source_prefix_refs: Vec<_> = source_prefixes.iter().map(Vec::as_slice).collect();
+        self.db.has_unmarked_pending_index_updates_since(
+            sequence,
+            &source_prefix_refs,
+            &self.prefixed_key(marker_prefix, &[]),
+        )
+    }
+
     /// Start an atomic write batch scoped to this domain.
     pub fn batch(&self) -> TypedDbBatch {
         TypedDbBatch {

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicBool;
+
 use hyperlane_core::{Decode, Encode, HyperlaneDomain};
 
 use crate::db::{error::DbError, DbBatch, DB};
@@ -216,6 +218,7 @@ impl TypedDB {
         sequence: u64,
         source_prefixes: &[&[u8]],
         marker_prefix: &[u8],
+        cancellation: &AtomicBool,
     ) -> Result<bool> {
         let source_prefixes: Vec<_> = source_prefixes
             .iter()
@@ -226,6 +229,7 @@ impl TypedDB {
             sequence,
             &source_prefix_refs,
             &self.prefixed_key(marker_prefix, &[]),
+            cancellation,
         )
     }
 

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -191,6 +191,25 @@ impl TypedDB {
         )
     }
 
+    /// Detect domain-scoped deletions without an atomic source-state marker.
+    pub fn has_unmarked_deletions_since(
+        &self,
+        sequence: u64,
+        source_prefix: impl AsRef<[u8]>,
+        marker_prefixes: &[&[u8]],
+    ) -> Result<bool> {
+        let markers: Vec<_> = marker_prefixes
+            .iter()
+            .map(|prefix| self.prefixed_key(prefix, &[]))
+            .collect();
+        let markers: Vec<_> = markers.iter().map(Vec::as_slice).collect();
+        self.db.has_unmarked_deletions_since(
+            sequence,
+            &self.prefixed_key(source_prefix.as_ref(), &[]),
+            &markers,
+        )
+    }
+
     /// Start an atomic write batch scoped to this domain.
     pub fn batch(&self) -> TypedDbBatch {
         TypedDbBatch {

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -24,6 +24,7 @@ mockall::mock! {
 
     impl HyperlaneDb for HyperlaneDb {
         fn retrieve_highest_seen_message_nonce(&self) -> DbResult<Option<u32>>;
+        fn retrieve_highest_message_nonce(&self) -> DbResult<Option<u32>>;
         fn retrieve_message_by_nonce(&self, nonce: u32) -> DbResult<Option<HyperlaneMessage>>;
         fn retrieve_processed_by_nonce(&self, nonce: &u32) -> DbResult<Option<bool>>;
         fn domain(&self) -> &HyperlaneDomain;


### PR DESCRIPTION
## Problem

The #9549 production canary removed the completed legacy migration on restart, but the relayer still rebuilt its destination queues from about 997,450 indexed records and 6,144,414 logical DB reads. That bounded catch-up briefly reached about 6.3 CPU cores.

Those rows are not uniformly waste: eligible messages must be re-enqueued after a crash, while policy-rejected and retry-ineligible rows deliberately remain indexed for later reconsideration. Existing metrics cannot distinguish the outcomes, so persisting a skip cursor would risk losing work.

## Solution

- count each completed destination-index decision by bounded origin, destination, and outcome
- distinguish queued work, policy rejections, retry-ineligible/already-loaded entries, and stale/processed/terminal cleanup
- leave loader scheduling, retry, database, and recovery behavior unchanged

This stacks on #9549.

## Performance evidence

Supplied production baseline from the fastpath #9549 canary:

- destination-index records examined: about 997,450
- destination-index logical DB reads: about 6,144,414
- brief restart CPU peak: about 6.3 cores
- legacy migration after the #9549 restart: 0 records and 0 logical reads

No reduction is claimed here. The new counter determines whether a safe follow-up is worthwhile. If policy rejects dominate, their distribution can justify a policy-bound, WAL-validated skip design; if queued/retry/cleanup outcomes dominate, the restart scan is required recovery work.

## Correctness

- metrics are recorded only after the corresponding decision or cleanup succeeds
- errors retain existing behavior and do not become successful outcomes
- label values are a fixed set; no message IDs or unbounded values are exported
- no queue, persistence, filtering, retry, or delivery semantics change

## Validation

- cargo fmt --all -- --check
- git diff --check
- focused outcome-attribution test added
- focused build/test delegated to CI after local compilation was timeboxed
