### PR TITLE
fix(radix): widen e2e transaction epoch window

### DIFF
--- a/rust/main/utils/run-locally/src/radix/cli.rs
+++ b/rust/main/utils/run-locally/src/radix/cli.rs
@@ -31,6 +31,10 @@ use crate::{
     },
 };
 
+// Localnet epochs can advance between the gateway status read and submission.
+// Keep E2E transactions valid across that boundary without changing production policy.
+const TRANSACTION_EPOCH_VALIDITY_RANGE: u64 = 10;
+
 impl Deref for RadixCli {
     type Target = RadixProvider;
 
@@ -108,7 +112,7 @@ impl RadixCli {
             notary_is_signatory: true,
             network_id: self.network.id,
             start_epoch_inclusive: Epoch::of(epoch),
-            end_epoch_exclusive: Epoch::of(epoch.saturating_add(2)), // ~5 minutes per epoch -> 10min timeout
+            end_epoch_exclusive: Epoch::of(epoch.saturating_add(TRANSACTION_EPOCH_VALIDITY_RANGE)),
             nonce: rand::random::<u32>(),
             tip_percentage: 0,
         });


### PR DESCRIPTION
## Problem

Radix E2E transactions were valid for only two epochs. In the [linked failure](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34175890522/job/101905084257?pr=9556), the gateway status read and submission crossed the validity boundary, so every fallback provider rejected the same expired faucet transaction.

## Solution

Increase only the local E2E helper validity window from 2 to 10 epochs, matching the existing Radix TypeScript safeguard. Production Radix provider and Lander policy remain unchanged.

## Validation

- Exact Radix CI command: 1 passed, 0 failed (487.85s)
- cargo fmt -p run-locally -- --check
- Full pre-commit hook (gitleaks, lint-staged, Rust formatting)
- git diff --check
