### PR TITLE
feat(infra): deploy testnet scraper proxy

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-cloudflared-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-cloudflared-external-secret.yaml
@@ -1,5 +1,5 @@
 # Pre-deploy: GCP secret {context}-{runEnv}-scraper-proxy-cloudflared-tunnel-token must exist.
-{{- if .Values.hyperlane.scraperProxy.enabled }}
+{{- if and .Values.hyperlane.scraperProxy.enabled .Values.hyperlane.scraperProxy.tunnel.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
@@ -16,7 +16,9 @@ spec:
     metadata:
       annotations:
         checksum/scraper-proxy-external-secret: {{ include (print $.Template.BasePath "/scraper-proxy-external-secret.yaml") . | sha256sum }}
+        {{- if .Values.hyperlane.scraperProxy.tunnel.enabled }}
         checksum/scraper-proxy-cloudflared-external-secret: {{ include (print $.Template.BasePath "/scraper-proxy-cloudflared-external-secret.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "agent-common.labels" . | nindent 8 }}
         app.kubernetes.io/component: scraper-proxy
@@ -63,6 +65,7 @@ spec:
           periodSeconds: 10
         resources:
           {{- toYaml .Values.hyperlane.scraperProxy.resources | nindent 10 }}
+      {{- if .Values.hyperlane.scraperProxy.tunnel.enabled }}
       - name: cloudflared
         image: {{ .Values.hyperlane.scraperProxy.tunnel.image }}
         args: ["tunnel", "--no-autoupdate", "run"]
@@ -73,6 +76,7 @@ spec:
           requests:
             cpu: 50m
             memory: 64Mi
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -164,6 +164,7 @@ hyperlane:
     port: 8383
     replicas: 1
     tunnel:
+      enabled: true
       image: cloudflare/cloudflared:2026.8.2
     resources:
       requests:

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -30,6 +30,7 @@ interface AgentDockerTags {
 
 interface BaseDockerTags extends AgentDockerTags {
   keyFunder: string;
+  scraperProxy: string;
 }
 
 interface MainnetDockerTags extends BaseDockerTags {
@@ -37,7 +38,6 @@ interface MainnetDockerTags extends BaseDockerTags {
   validatorMonitor: string;
   warpMonitor: string;
   rebalancer: string;
-  scraperProxy: string;
   feeQuoting: string;
 }
 
@@ -72,4 +72,5 @@ export const testnetDockerTags: BaseDockerTags = {
   scraper: '337825e-20260907-130516',
   // standalone services
   keyFunder: '5dc6aa4-20260714-184449',
+  scraperProxy: 'b3619ad-20260901-171710',
 };

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -276,6 +276,19 @@ const hyperlane: RootAgentConfig = {
     },
     resources: scraperResources,
   },
+  scraperProxy: {
+    docker: {
+      repo: DockerImageRepos.NODE_SERVICES,
+      tag: testnetDockerTags.scraperProxy,
+    },
+    enabled: true,
+    port: 8383,
+    replicas: 1,
+    tunnel: { enabled: false },
+    resources: {
+      requests: { cpu: '500m', memory: '1Gi' },
+    },
+  },
 };
 
 const releaseCandidate: RootAgentConfig = {

--- a/typescript/infra/src/config/agent/scraper-proxy.ts
+++ b/typescript/infra/src/config/agent/scraper-proxy.ts
@@ -1,12 +1,16 @@
 import type { DockerConfig, KubernetesResources } from './agent.js';
 
+type ScraperProxyTunnelConfig =
+  | { enabled: false; image?: never }
+  | { enabled: true; image: string };
+
 export interface ScraperProxyConfig {
   docker: DockerConfig;
   enabled: boolean;
   port?: number;
   replicas?: number;
   resources?: KubernetesResources;
-  tunnel?: { enabled?: boolean; image?: string };
+  tunnel?: ScraperProxyTunnelConfig;
 }
 
 export type HelmScraperProxyValues = Omit<ScraperProxyConfig, 'docker'>;

--- a/typescript/infra/src/config/agent/scraper-proxy.ts
+++ b/typescript/infra/src/config/agent/scraper-proxy.ts
@@ -6,7 +6,7 @@ export interface ScraperProxyConfig {
   port?: number;
   replicas?: number;
   resources?: KubernetesResources;
-  tunnel?: { image: string };
+  tunnel?: { enabled?: boolean; image?: string };
 }
 
 export type HelmScraperProxyValues = Omit<ScraperProxyConfig, 'docker'>;

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -5,6 +5,7 @@ import { ProtocolType } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts, RELEASE_CANDIDATE_INDEX_FROM } from '../config/contexts.js';
+import { DockerImageRepos, testnetDockerTags } from '../config/docker.js';
 import {
   agents as mainnet3Agents,
   hyperlaneContextAgentChainConfig as mainnet3AgentChainConfig,
@@ -78,6 +79,27 @@ function agentConfigHelper(
 }
 
 describe('Agent configs', () => {
+  it('configures one shared testnet4 scraper proxy', () => {
+    const enabledProxies = Object.values(testnet4Agents).filter(
+      (config) => config.scraperProxy?.enabled,
+    );
+
+    expect(enabledProxies).to.have.length(1);
+    expect(enabledProxies[0].scraperProxy).to.deep.equal({
+      docker: {
+        repo: DockerImageRepos.NODE_SERVICES,
+        tag: testnetDockerTags.scraperProxy,
+      },
+      enabled: true,
+      port: 8383,
+      replicas: 1,
+      tunnel: { enabled: false },
+      resources: {
+        requests: { cpu: '500m', memory: '1Gi' },
+      },
+    });
+  });
+
   it('renders fallback hedging only for EVM relayers and scrapers', async () => {
     let sawEthereum = false;
     let sawNonEthereum = false;


### PR DESCRIPTION
## Summary

- provision one scraper proxy for testnet4, shared by every testnet agent context
- use the existing scraper read-only database credentials and cluster-local scraper-proxy.testnet4.svc.cluster.local:8383 service
- make the Cloudflare tunnel optional and disable it for testnet4; mainnet keeps its current default-on tunnel

This only provisions the proxy. It does not make the stream authoritative or point agents at it: #9324 owns validator consumer wiring and #9397 owns relayer shadow wiring.

## Validation

- focused agent config and scraper-proxy Helm manager tests (11 passing)
- Helm chart lint
- Helm render: testnet4 emits no cloudflared container or tunnel ExternalSecret
- Helm render: default/mainnet path still emits both
- git diff --check

Infra typecheck still hits the two existing fallbackHedge fields in test/agent-configs.test.ts; this diff does not change that code.