### PR TITLE
chore(infra): update agent and node service images

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,34 +43,34 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '337825e-20260907-130516',
-  relayerRC: '337825e-20260907-130516',
-  relayerFastPath: '337825e-20260907-130516',
-  validator: '337825e-20260907-130516',
-  validatorRC: '337825e-20260907-130516',
-  validatorFastPath: '337825e-20260907-130516',
-  scraper: '337825e-20260907-130516',
+  relayer: '757150f-20260908-042606',
+  relayerRC: '757150f-20260908-042606',
+  relayerFastPath: '757150f-20260908-042606',
+  validator: '757150f-20260908-042606',
+  validatorRC: '757150f-20260908-042606',
+  validatorFastPath: '757150f-20260908-042606',
+  scraper: '757150f-20260908-042606',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
-  keyFunder: 'b0c3c5d-20260804-175736',
-  warpMonitor: '744b3bb-20260521-215958',
-  rebalancer: 'da26d9a-20260703-122943',
-  scraperProxy: 'b3619ad-20260901-171710',
+  keyFunder: '757150f-20260908-042619',
+  warpMonitor: '757150f-20260908-042619',
+  rebalancer: '757150f-20260908-042619',
+  scraperProxy: '757150f-20260908-042619',
   feeQuoting: '12d899d-20260325-184337',
 };
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '337825e-20260907-130516',
-  relayerRC: '337825e-20260907-130516',
-  relayerFastPath: '337825e-20260907-130516',
-  validator: '337825e-20260907-130516',
-  validatorRC: '337825e-20260907-130516',
-  validatorFastPath: '337825e-20260907-130516',
-  scraper: '337825e-20260907-130516',
+  relayer: '757150f-20260908-042606',
+  relayerRC: '757150f-20260908-042606',
+  relayerFastPath: '757150f-20260908-042606',
+  validator: '757150f-20260908-042606',
+  validatorRC: '757150f-20260908-042606',
+  validatorFastPath: '757150f-20260908-042606',
+  scraper: '757150f-20260908-042606',
   // standalone services
-  keyFunder: '5dc6aa4-20260714-184449',
-  scraperProxy: 'b3619ad-20260901-171710',
+  keyFunder: '757150f-20260908-042619',
+  scraperProxy: '757150f-20260908-042619',
 };

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '757150f-20260908-042606',
-  relayerRC: '757150f-20260908-042606',
-  relayerFastPath: '757150f-20260908-042606',
-  validator: '757150f-20260908-042606',
-  validatorRC: '757150f-20260908-042606',
-  validatorFastPath: '757150f-20260908-042606',
-  scraper: '757150f-20260908-042606',
+  relayer: 'be18813-20260908-054007',
+  relayerRC: 'be18813-20260908-054007',
+  relayerFastPath: 'be18813-20260908-054007',
+  validator: 'be18813-20260908-054007',
+  validatorRC: 'be18813-20260908-054007',
+  validatorFastPath: 'be18813-20260908-054007',
+  scraper: 'be18813-20260908-054007',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '757150f-20260908-042606',
-  relayerRC: '757150f-20260908-042606',
-  relayerFastPath: '757150f-20260908-042606',
-  validator: '757150f-20260908-042606',
-  validatorRC: '757150f-20260908-042606',
-  validatorFastPath: '757150f-20260908-042606',
-  scraper: '757150f-20260908-042606',
+  relayer: 'be18813-20260908-054007',
+  relayerRC: 'be18813-20260908-054007',
+  relayerFastPath: 'be18813-20260908-054007',
+  validator: 'be18813-20260908-054007',
+  validatorRC: 'be18813-20260908-054007',
+  validatorFastPath: 'be18813-20260908-054007',
+  scraper: 'be18813-20260908-054007',
   // standalone services
   keyFunder: '757150f-20260908-042619',
   scraperProxy: '757150f-20260908-042619',


### PR DESCRIPTION
## Summary

1. Pin all mainnet3 and testnet4 Rust agent roles to `757150f-20260908-042606`.
2. Pin configured mainnet3 and testnet4 node-service roles to `757150f-20260908-042619`, including RC/fastpath and services outside the immediate rollout list.
3. Leave `checkWarpDeploy`, `validatorMonitor`, and `feeQuoting` unchanged because the supplied builds did not publish tags to their configured image repositories.

## Build evidence

- [Agent image](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34186962683): success at `757150fedb6682211a6f9a6bc9ed97f17e55fbe0`
- [Node services image](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34186964286): success at the same SHA
- Both immutable GHCR manifests resolve.

## Validation

- `pnpm -C typescript/infra check`
- `pnpm exec prettier --check typescript/infra/config/docker.ts`
- Commit hooks: gitleaks, oxlint, oxfmt
- Focused `agent-configs.test.ts` could not start because the current frozen install resolves `core-js@3.50.0` without `proposals/json-parse-with-source.js`, imported by `@provablehq/sdk@0.11.3`.