### PR TITLE
fix(relayer): ignore overlapping keys in highest nonce lookup

### DIFF
--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -391,15 +391,11 @@ impl HyperlaneRocksDB {
 
     /// Retrieve the greatest nonce represented by the canonical nonce-to-ID map.
     pub fn retrieve_highest_message_nonce(&self) -> DbResult<Option<u32>> {
-        let Some((nonce, _)) =
-            self.retrieve_by_prefix_at_or_before::<H256>(MESSAGE_ID, u32::MAX.to_be_bytes())?
-        else {
-            return Ok(None);
-        };
-        let nonce: [u8; 4] = nonce.try_into().map_err(|nonce: Vec<u8>| {
-            DbError::Other(format!("Invalid message ID index key: {nonce:?}"))
-        })?;
-        Ok(Some(u32::from_be_bytes(nonce)))
+        // A message hash beginning with `id_` also matches MESSAGE_ID, but has
+        // a 29-byte suffix instead of a four-byte nonce. Filter before decoding.
+        Ok(self
+            .retrieve_last_key_by_prefix(MESSAGE_ID)?
+            .map(u32::from_be_bytes))
     }
 
     /// Update the nonce of the highest processed message we're aware of
@@ -586,6 +582,55 @@ mod pending_index_tests {
 
     use super::*;
     use crate::db::rocks::test_utils::run_test_db;
+
+    #[tokio::test]
+    async fn highest_message_nonce_ignores_overlapping_message_keys() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            assert_eq!(db.retrieve_highest_message_nonce().unwrap(), None);
+
+            // A valid row in the message table whose hash shares the nonce-map prefix.
+            let mut hash = [0xfe; 32];
+            hash[..3].copy_from_slice(b"id_");
+            let hash = H256::from(hash);
+            db.store_message_by_id(&hash, &message(7, 10)).unwrap();
+            assert_eq!(db.retrieve_highest_message_nonce().unwrap(), None);
+
+            // These sort below the overlapping row; the watermark must still be exact.
+            for nonce in [0, 256, 2] {
+                db.store_message_id_by_nonce(&nonce, &H256::zero()).unwrap();
+            }
+            assert_eq!(db.retrieve_highest_message_nonce().unwrap(), Some(256));
+            assert!(db.retrieve_message_by_id(&hash).unwrap().is_some());
+
+            db.store_message_id_by_nonce(&u32::MAX, &H256::zero())
+                .unwrap();
+            assert_eq!(db.retrieve_highest_message_nonce().unwrap(), Some(u32::MAX));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn highest_message_nonce_filters_key_width_before_value_decode() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            let other = HyperlaneRocksDB::new(
+                &HyperlaneDomain::new_test_domain("other"),
+                AsRef::<DB>::as_ref(&db).clone(),
+            );
+            other
+                .store_message_id_by_nonce(&u32::MAX, &H256::zero())
+                .unwrap();
+            // Non-nonce keys may also have values that cannot decode as an H256.
+            for key in [vec![0xfe], vec![0xfe; 29]] {
+                db.store_encodable(MESSAGE_ID, key, &true).unwrap();
+            }
+            assert_eq!(db.retrieve_highest_message_nonce().unwrap(), None);
+            db.store_message_id_by_nonce(&0, &H256::zero()).unwrap();
+            assert_eq!(db.retrieve_highest_message_nonce().unwrap(), Some(0));
+        })
+        .await;
+    }
 
     fn message(nonce: u32, destination: u32) -> HyperlaneMessage {
         HyperlaneMessage {

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -291,6 +291,28 @@ impl DB {
             .map(|(key, value)| (key.to_vec(), value.to_vec())))
     }
 
+    /// Retrieve the greatest fixed-width key under a prefix, without decoding its value.
+    pub(crate) fn retrieve_last_key_by_prefix<const N: usize>(
+        &self,
+        prefix: &[u8],
+    ) -> Result<Option<[u8; N]>> {
+        let mut start = prefix.to_vec();
+        start.extend_from_slice(&[u8::MAX; N]);
+        let mut iterator = self.0.raw_iterator();
+        iterator.seek_for_prev(&start);
+        loop {
+            iterator.status()?;
+            let Some(suffix) = iterator.key().and_then(|key| key.strip_prefix(prefix)) else {
+                return Ok(None);
+            };
+            // Other tables can overlap this prefix through their binary keys.
+            if let Ok(key) = suffix.try_into() {
+                return Ok(Some(key));
+            }
+            iterator.prev();
+        }
+    }
+
     /// Retrieve a value from the DB
     pub fn retrieve(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -92,6 +92,14 @@ impl TypedDB {
         self.retrieve_by_prefix_from(prefix.as_ref(), key.as_ref(), false)
     }
 
+    pub(crate) fn retrieve_last_key_by_prefix<const N: usize>(
+        &self,
+        prefix: impl AsRef<[u8]>,
+    ) -> Result<Option<[u8; N]>> {
+        self.db
+            .retrieve_last_key_by_prefix(&self.prefixed_key(prefix.as_ref(), &[]))
+    }
+
     fn retrieve_by_prefix_from<V: Decode>(
         &self,
         prefix: &[u8],


### PR DESCRIPTION
The Linea origin loader repeatedly fails with `Invalid message ID index key` after #9549. A `message_<H256>` key whose hash begins with `id_` also matches the `message_id_` nonce-map prefix, leaving a 29-byte suffix where the new highest-nonce lookup expects four bytes. This can happen with ordinary stored message rows; it does not establish database corruption.

1. Reverse-scan the nonce prefix for an exact four-byte key before reading values. Preserve the actual greatest stored nonce, including zero and `u32::MAX`, without changing or deleting database entries.
2. Add regression coverage for the overlapping message row, non-nonce keys with undecodable values, empty maps, numeric ordering, and domain isolation.
3. Validation: `cargo test -p hyperlane-base highest_message_nonce_ --lib` passed (2 tests); `cargo test -p hyperlane-base pending_index_tests --lib` passed (13 tests). Mandatory commit hooks passed, including main/sealevel formatting and secret scanning; `git diff --check` passed. Full CI tests/clippy pending. Draft for urgent review; no deployment or database repair performed.
