### PR TITLE
fix(agents): suppress OAuth token debug logs

### DIFF
--- a/rust/main/hyperlane-base/src/settings/trace/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/trace/mod.rs
@@ -61,6 +61,23 @@ impl TracingConfig {
     /// Attempt to instantiate and register a tracing subscriber setup from
     /// settings.
     pub fn start_tracing(&self, metrics: &CoreMetrics) -> Result<console_subscriber::Server> {
+        let target_layer = self.targets();
+        let fmt_layer: LogOutputLayer<_> = self.fmt.into();
+        let err_layer = tracing_error::ErrorLayer::default();
+
+        let (tokio_layer, tokio_server) = console_subscriber::ConsoleLayer::new();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tokio_layer)
+            .with(target_layer)
+            .with(TimeSpanLifetime::new(metrics))
+            .with(fmt_layer)
+            .with(err_layer);
+
+        subscriber.try_init()?;
+        Ok(tokio_server)
+    }
+
+    fn targets(&self) -> Targets {
         let mut target_layer = Targets::new().with_default(self.level);
 
         if self.level < Level::DependencyTrace {
@@ -91,18 +108,42 @@ impl TracingConfig {
                 .with_target("sqlx::query", Level::Warn)
                 .with_target("hyper::", Level::Warn);
         }
-        let fmt_layer: LogOutputLayer<_> = self.fmt.into();
-        let err_layer = tracing_error::ErrorLayer::default();
+        // OAuth debug logs include cached bearer tokens. Keep this cap even in
+        // dependencyTrace mode, and never raise a quieter configured level.
+        target_layer.with_target("yup_oauth2", self.level.min(Level::Info))
+    }
+}
 
-        let (tokio_layer, tokio_server) = console_subscriber::ConsoleLayer::new();
-        let subscriber = tracing_subscriber::Registry::default()
-            .with(tokio_layer)
-            .with(target_layer)
-            .with(TimeSpanLifetime::new(metrics))
-            .with(fmt_layer)
-            .with(err_layer);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        subscriber.try_init()?;
-        Ok(tokio_server)
+    #[test]
+    fn oauth_logs_never_enable_debug_even_with_dependency_trace() {
+        for level in [
+            Level::Off,
+            Level::Error,
+            Level::Warn,
+            Level::Info,
+            Level::Debug,
+            Level::Trace,
+            Level::DependencyTrace,
+        ] {
+            let targets = TracingConfig {
+                level,
+                ..Default::default()
+            }
+            .targets();
+            assert!(!targets.would_enable("yup_oauth2::authenticator", &tracing::Level::DEBUG));
+            assert!(!targets.would_enable("yup_oauth2::authenticator", &tracing::Level::TRACE));
+            assert_eq!(
+                targets.would_enable("yup_oauth2::authenticator", &tracing::Level::INFO),
+                level >= Level::Info
+            );
+            assert_eq!(
+                targets.would_enable("validator", &tracing::Level::DEBUG),
+                level >= Level::Debug
+            );
+        }
     }
 }


### PR DESCRIPTION
During validator checkpoint backfill, `yup_oauth2` emits cached bearer tokens at DEBUG on checkpoint storage reads. Agent DEBUG logging currently includes these events, adding repeated log output during replay.

Cap this dependency at INFO for every agent log mode, including `dependencyTrace`, while preserving quieter Off/Error/Warn settings and application DEBUG logs. A regression test covers all seven modes. No checkpoint, signing, resource-request, or alert-threshold behavior changes.

Validation: pre-commit secret scan and both Rust workspace format checks passed. `cargo test -p hyperlane-base oauth_logs_never_enable_debug_even_with_dependency_trace --lib` passed (1 test, covering all seven logging modes). `cargo clippy -p hyperlane-base --lib -- -D warnings` passed. The additional `--tests` Clippy run encountered existing test-only unwrap/panic lint failures (for example, `settings/loader/arguments.rs:300`); the new test introduces neither pattern.

<details>
<summary>CPU alert investigation, 2026-09-08 05:37–05:45 UTC</summary>

Both `mainnet3` and `validator-mainnet3` contain the named Arbitrum/Base/BSC validator pods. All inspected pods were Ready with zero restarts and no CPU limits. Arbitrum/Base had `hyperlane_backfill_complete=0` and were checking historical checkpoints; current observed and processed checkpoints matched. BSC had completed backfill and returned to roughly 2–10m CPU. Before the rollout, the inspected validator-mainnet3 series were roughly 2–8m.

The elevated CPU is consistent with restart backfill, so this PR does not increase requests. Suppressing OAuth DEBUG output removes unnecessary repeated logging, but no CPU reduction is claimed without post-deployment measurement. The alert's missing deployment/namespace context is a separate monitoring-label issue; its definition was not found in this repository.
</details>
