### PR TITLE
chore(infra): deploy websocket indexing to validators

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -46,9 +46,9 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: 'be18813-20260908-054007',
   relayerRC: 'be18813-20260908-054007',
   relayerFastPath: 'be18813-20260908-054007',
-  validator: 'be18813-20260908-054007',
+  validator: 'cb7237c-20260908-141540',
   validatorRC: 'be18813-20260908-054007',
-  validatorFastPath: 'be18813-20260908-054007',
+  validatorFastPath: 'cb7237c-20260908-141540',
   scraper: 'be18813-20260908-054007',
   // monorepo services
   checkWarpDeploy: 'main',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -66,9 +66,9 @@ export const testnetDockerTags: BaseDockerTags = {
   relayer: 'be18813-20260908-054007',
   relayerRC: 'be18813-20260908-054007',
   relayerFastPath: 'be18813-20260908-054007',
-  validator: 'be18813-20260908-054007',
+  validator: 'cb7237c-20260908-141540',
   validatorRC: 'be18813-20260908-054007',
-  validatorFastPath: 'be18813-20260908-054007',
+  validatorFastPath: 'cb7237c-20260908-141540',
   scraper: 'be18813-20260908-054007',
   // standalone services
   keyFunder: '757150f-20260908-042619',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: '757150f-20260908-042619',
   warpMonitor: '757150f-20260908-042619',
   rebalancer: '757150f-20260908-042619',
-  scraperProxy: '757150f-20260908-042619',
+  scraperProxy: 'cb7237c-20260908-145436',
   feeQuoting: '12d899d-20260325-184337',
 };
 


### PR DESCRIPTION
## Summary
- pin testnet4 and mainnet3 Hyperlane and fastpath validators to the agent image built from `main@cb7237c332`
- pin the mainnet3 scraper proxy to the matching node-services image so the configured 200-agent WebSocket cap is enforced
- leave release-candidate validators unchanged/scaled down

## Validation
- agent build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34237072488
- node-services build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34241275216
- `pnpm turbo build`
- focused infra tests: 19 passing
- testnet4: all 16 active validator pods use `cb7237c-20260908-141540`; 14 WebSocket-active, 2 safely using RPC fallback
- testnet4 fastpath validators announced on Base Sepolia, Arbitrum Sepolia, and Sepolia
- mainnet3 GCP fleet: 80/80 Hyperlane + fastpath validator pods Ready on `cb7237c-20260908-141540`
- mainnet3 legacy AWS/S3 fleet: 77/77 validator pods Ready on the same image with the scraper WebSocket configured
- mainnet3 proxy: Ready on `cb7237c-20260908-145436`; 153\/200 agent connections, zero connection-limit rejections or send failures
- both mainnet fleets have zero restarts and zero critical errors after rollout
- live Helm values use the environment-local `/agents` scraper WebSocket URL