### PR TITLE
fix(infra): restore oUSDT rebalancer secret provisioning

### DIFF
--- a/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
@@ -21,6 +21,9 @@ spec:
           update-on-redeploy: "{{ now }}"
       data:
         COINGECKO_API_KEY: {{ printf "'{{ .%s_coingecko_api_key | toString }}'" .Values.hyperlane.runEnv }}
+        {{- if has "swapsxyz" (.Values.hyperlane.externalBridgeProviders | default list) }}
+        SWAPSXYZ_API_KEY: {{ print "'{{ .swapsxyz_api_key | toString }}'" }}
+        {{- end }}
         # Extract only the privateKey field from the JSON
         HYP_REBALANCER_KEY: {{ print "'{{ $json := .rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
         HYP_INVENTORY_KEY: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
@@ -39,6 +42,11 @@ spec:
   - secretKey: {{ printf "%s_coingecko_api_key" .Values.hyperlane.runEnv }}
     remoteRef:
       key: {{ printf "%s-coingecko-api-key" .Values.hyperlane.runEnv }}
+  {{- if has "swapsxyz" (.Values.hyperlane.externalBridgeProviders | default list) }}
+  - secretKey: swapsxyz_api_key
+    remoteRef:
+      key: {{ printf "%s-swapsxyz-api-key" .Values.hyperlane.runEnv }}
+  {{- end }}
   - secretKey: rebalancer_key
     remoteRef:
       key: {{ printf "hyperlane-%s-key-rebalancer" .Values.hyperlane.runEnv }}

--- a/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
@@ -25,6 +25,10 @@ spec:
         HYP_REBALANCER_KEY: {{ print "'{{ $json := .rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
         HYP_INVENTORY_KEY: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
         HYP_INVENTORY_KEY_ETHEREUM: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
+        {{- if has "tron" .Values.hyperlane.inventorySignerProtocols }}
+        # Tron and Ethereum share the EVM inventory key.
+        HYP_INVENTORY_KEY_TRON: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
+        {{- end }}
         {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
         HYP_INVENTORY_KEY_SEALEVEL: {{ print "'{{ $json := .inventory_rebalancer_key_sealevel | fromJson }}{{ $json.privateKey }}'" }}
         {{- end }}


### PR DESCRIPTION
The production oUSDT rebalancer lost required environment variables when ExternalSecret reconciled. Startup first failed on missing `HYP_INVENTORY_KEY_TRON`; restoring it exposed missing `SWAPSXYZ_API_KEY`.

Conditionally render the Tron inventory key from the existing EVM inventory secret and the Swaps.xyz API key from the environment-specific Secret Manager entry. Both credentials already exist; no key rotation is needed.

Validation: Helm lint, 15 protocol/provider render combinations, formatting and secret-scanning commit hooks. The production manifest diff contains only the added secret mappings and refresh timestamp.

Deployed to `mainnet3/hyperlane-rebalancer-ousdt-production` as Helm revision 5 using the existing chart and identical release values, retaining image `db28a86-20260826-203943`, registry pin and reduced targets. The replacement pod started at 15:40:22Z with zero restarts. Both signers initialized, and polls completed at 15:40:50Z and 15:41:44Z with `No rebalancing needed`. Existing extra-lockbox metrics errors remain; the same errors were present in pre-incident logs at 15:18Z.
