### PR TITLE
fix(sealevel): configure v1 JSON reads per chain

### DIFF
--- a/.changeset/quiet-solana-json-reads.md
+++ b/.changeset/quiet-solana-json-reads.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Added per-chain transaction-version configuration for Sealevel agent JSON reads so Solana v1 activation can be enabled independently of other SVM chains.

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -1,0 +1,24 @@
+# Solana v1 readiness
+
+Agent JSON reads accept `maxSupportedTransactionVersion: 0 | 1` per chain.
+The default is `0`; mainnet3 agent configuration enables `1` only for
+`solanamainnet`. Environment overrides use
+`HYP_CHAINS_SOLANAMAINNET_MAXSUPPORTEDTRANSACTIONVERSION=1`.
+Other SVMs must be configured independently of Solana feature activation.
+
+This change only enables JSON/JSON-parsed reads. The indexer consumes account
+keys, instructions and execution metadata; it does not decode raw transaction
+bytes or reconstruct v1 messages. Agave's additional `transactionConfig` JSON
+field is unused; fee accounting reads `meta.fee`. Tests exercise v1 JSON through
+the pinned client. Binary transaction decoding and v1 sending require separate
+SDK updates and validation.
+
+Before rollout, validate a mixed legacy/v0/v1 block and a v1 dispatch/gas payment
+on a v1-enabled test validator, then verify the deployed agent image and chain
+configuration. Unit fixtures are not live-cluster evidence. Existing legacy/v0
+sending stays unchanged.
+
+References:
+
+- https://www.helius.dev/blog/agave-4-2-migration-checklist
+- https://solana.com/upgrades/agave-4-2-release-overview

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -10,8 +10,11 @@ This change only enables JSON/JSON-parsed reads. The indexer consumes account
 keys, instructions and execution metadata; it does not decode raw transaction
 bytes or reconstruct v1 messages. Agave's additional `transactionConfig` JSON
 field is unused; fee accounting reads `meta.fee`. Tests exercise v1 JSON through
-the pinned client. Binary transaction decoding and v1 sending require separate
-SDK updates and validation.
+the pinned client, assert outgoing version/encoding parameters for default and
+opted-in chains, and pass mixed legacy/v0/v1 responses through dispatch and gas
+payment log metadata extraction. The v1 fixtures adapt existing transactions to
+Agave's JSON schema; they are not captured v1 executions. Binary transaction
+decoding and v1 sending require separate SDK updates and validation.
 
 Before rollout, validate a mixed legacy/v0/v1 block and a v1 dispatch/gas payment
 on a v1-enabled test validator, then verify the deployed agent image and chain

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -2,7 +2,8 @@
 
 Agent JSON reads accept `maxSupportedTransactionVersion: 0 | 1` per chain.
 The default is `0`; mainnet3 agent configuration enables `1` only for
-`solanamainnet`. Environment overrides use
+`solanamainnet`, and testnet4 enables `1` for `solanadevnet` and
+`solanatestnet`, where v1 transactions are already active. Environment overrides use
 `HYP_CHAINS_SOLANAMAINNET_MAXSUPPORTEDTRANSACTIONVERSION=1`.
 Other SVMs must be configured independently of Solana feature activation.
 
@@ -12,7 +13,9 @@ bytes or reconstruct v1 messages. Agave's additional `transactionConfig` JSON
 field is unused; fee accounting reads `meta.fee`. Tests exercise v1 JSON through
 the pinned client, assert outgoing version/encoding parameters for default and
 opted-in chains, and pass mixed legacy/v0/v1 responses through dispatch and gas
-payment log metadata extraction. The v1 fixtures adapt existing transactions to
+payment log metadata extraction. Generated agent configuration tests cover all
+three Solana clusters across configured roles and contexts, while asserting that
+other SVMs retain version `0`. The v1 fixtures adapt existing transactions to
 Agave's JSON schema; they are not captured v1 executions. Binary transaction
 decoding and v1 sending require separate SDK updates and validation.
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -35,7 +35,10 @@ use crate::tx_type::SealevelTxType;
 
 /// Wrapper struct around Solana's RpcClient
 #[derive(Clone)]
-pub struct SealevelRpcClient(Arc<RpcClient>);
+pub struct SealevelRpcClient {
+    client: Arc<RpcClient>,
+    max_supported_transaction_version: u8,
+}
 
 impl SealevelRpcClient {
     async fn get_signature_statuses_with_config(
@@ -53,7 +56,7 @@ impl SealevelRpcClient {
             json!([signatures])
         };
         let mut response: Value = self
-            .0
+            .client
             .send(RpcRequest::GetSignatureStatuses, params)
             .await
             .map_err(ChainCommunicationError::from_other)?;
@@ -84,12 +87,22 @@ impl SealevelRpcClient {
 
     /// constructor with an rpc client
     pub fn from_rpc_client(rpc_client: Arc<RpcClient>) -> Self {
-        Self(rpc_client)
+        Self {
+            client: rpc_client,
+            max_supported_transaction_version: 0,
+        }
+    }
+
+    /// Select the highest transaction version accepted by this chain's JSON readers.
+    /// This does not change the format used to submit transactions.
+    pub fn with_max_supported_transaction_version(mut self, version: u8) -> Self {
+        self.max_supported_transaction_version = version;
+        self
     }
 
     /// Get Url
     pub fn url(&self) -> String {
-        self.0.url()
+        self.client.url()
     }
 
     /// confirm transaction with given commitment
@@ -98,7 +111,7 @@ impl SealevelRpcClient {
         signature: &Signature,
         commitment: CommitmentConfig,
     ) -> ChainResult<bool> {
-        self.0
+        self.client
             .confirm_transaction_with_commitment(signature, commitment)
             .await
             .map(|ctx| ctx.value)
@@ -133,7 +146,7 @@ impl SealevelRpcClient {
         commitment: CommitmentConfig,
     ) -> ChainResult<Option<Account>> {
         let account = self
-            .0
+            .client
             .get_account_with_commitment(pubkey, commitment)
             .await
             .map_err(ChainCommunicationError::from_other)?
@@ -144,7 +157,7 @@ impl SealevelRpcClient {
     /// get balance
     pub async fn get_balance(&self, pubkey: &Pubkey) -> ChainResult<U256> {
         let balance = self
-            .0
+            .client
             .get_balance(pubkey)
             .await
             .map_err(Box::new)
@@ -160,8 +173,11 @@ impl SealevelRpcClient {
         slot: u64,
         commitment: CommitmentConfig,
     ) -> ChainResult<UiConfirmedBlock> {
-        self.0
-            .get_block_with_config(slot, block_config(commitment))
+        self.client
+            .get_block_with_config(
+                slot,
+                block_config(commitment, self.max_supported_transaction_version),
+            )
             .await
             .map_err(Box::new)
             .map_err(HyperlaneSealevelError::ClientError)
@@ -176,7 +192,7 @@ impl SealevelRpcClient {
 
     /// Get block metadata without downloading transactions.
     pub async fn get_block_info(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
-        self.0
+        self.client
             .get_block_with_config(slot, block_info_config(CommitmentConfig::finalized()))
             .await
             .map_err(Box::new)
@@ -186,7 +202,7 @@ impl SealevelRpcClient {
 
     /// get block_height
     pub async fn get_block_height(&self) -> ChainResult<u64> {
-        self.0
+        self.client
             .get_block_height()
             .await
             .map_err(Box::new)
@@ -196,7 +212,7 @@ impl SealevelRpcClient {
 
     /// get minimum balance for rent exemption
     pub async fn get_minimum_balance_for_rent_exemption(&self, len: usize) -> ChainResult<u64> {
-        self.0
+        self.client
             .get_minimum_balance_for_rent_exemption(len)
             .await
             .map_err(ChainCommunicationError::from_other)
@@ -208,7 +224,7 @@ impl SealevelRpcClient {
         pubkeys: &[Pubkey],
     ) -> ChainResult<Vec<Option<Account>>> {
         let accounts = self
-            .0
+            .client
             .get_multiple_accounts_with_commitment(pubkeys, CommitmentConfig::finalized())
             .await
             .map_err(ChainCommunicationError::from_other)?
@@ -222,7 +238,7 @@ impl SealevelRpcClient {
         &self,
         commitment: CommitmentConfig,
     ) -> ChainResult<Hash> {
-        self.0
+        self.client
             .get_latest_blockhash_with_commitment(commitment)
             .await
             .map_err(ChainCommunicationError::from_other)
@@ -235,7 +251,7 @@ impl SealevelRpcClient {
         pubkey: &Pubkey,
         config: RpcProgramAccountsConfig,
     ) -> ChainResult<Vec<(Pubkey, Account)>> {
-        self.0
+        self.client
             .get_program_accounts_with_config(pubkey, config)
             .await
             .map_err(ChainCommunicationError::from_other)
@@ -252,7 +268,7 @@ impl SealevelRpcClient {
             limit: Some(limit),
             ..Default::default()
         };
-        self.0
+        self.client
             .get_signatures_for_address_with_config(address, config)
             .await
             .map_err(ChainCommunicationError::from_other)
@@ -289,7 +305,7 @@ impl SealevelRpcClient {
 
     /// get slot
     pub async fn get_slot_raw(&self) -> ChainResult<Slot> {
-        self.0
+        self.client
             .get_slot_with_commitment(CommitmentConfig::finalized())
             .await
             .map_err(ChainCommunicationError::from_other)
@@ -304,9 +320,9 @@ impl SealevelRpcClient {
         let config = RpcTransactionConfig {
             encoding: Some(UiTransactionEncoding::JsonParsed),
             commitment: Some(commitment),
-            max_supported_transaction_version: Some(0),
+            max_supported_transaction_version: Some(self.max_supported_transaction_version),
         };
-        self.0
+        self.client
             .get_transaction_with_config(signature, config)
             .await
             .map_err(Box::new)
@@ -325,7 +341,7 @@ impl SealevelRpcClient {
 
     /// check if block hash is valid
     pub async fn is_blockhash_valid(&self, hash: &Hash) -> ChainResult<bool> {
-        self.0
+        self.client
             .is_blockhash_valid(hash, CommitmentConfig::processed())
             .await
             .map_err(ChainCommunicationError::from_other)
@@ -337,7 +353,7 @@ impl SealevelRpcClient {
         transaction: &Transaction,
         skip_preflight: bool,
     ) -> ChainResult<Signature> {
-        self.0
+        self.client
             .send_transaction_with_config(
                 transaction,
                 RpcSendTransactionConfig {
@@ -355,7 +371,7 @@ impl SealevelRpcClient {
         transaction: &VersionedTransaction,
         skip_preflight: bool,
     ) -> ChainResult<Signature> {
-        self.0
+        self.client
             .send_transaction_with_config(
                 transaction,
                 RpcSendTransactionConfig {
@@ -390,7 +406,7 @@ impl SealevelRpcClient {
         transaction: &impl SerializableTransaction,
     ) -> ChainResult<RpcSimulateTransactionResult> {
         let result = self
-            .0
+            .client
             .simulate_transaction_with_config(
                 transaction,
                 RpcSimulateTransactionConfig {
@@ -434,7 +450,7 @@ impl SealevelRpcClient {
 
 impl std::fmt::Debug for SealevelRpcClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RpcClient {{ url: {} }}", self.0.url())
+        write!(f, "RpcClient {{ url: {} }}", self.client.url())
     }
 }
 
@@ -451,10 +467,13 @@ impl BlockNumberGetter for SealevelRpcClient {
 /// carries a reward_type our pinned solana crates don't know (e.g.
 /// `DeactivatedStake`), and because SerdeJson errors aren't classified as
 /// skippable this permanently stalls the sequence-aware cursor.
-fn block_config(commitment: CommitmentConfig) -> RpcBlockConfig {
+fn block_config(commitment: CommitmentConfig, max_version: u8) -> RpcBlockConfig {
     RpcBlockConfig {
         commitment: Some(commitment),
-        max_supported_transaction_version: Some(0),
+        // JSON exposes the accounts/instructions we index for legacy, v0 and v1.
+        // Never request binary: the sending SDK does not decode v1 wire messages.
+        encoding: Some(UiTransactionEncoding::Json),
+        max_supported_transaction_version: Some(max_version),
         rewards: Some(false),
         ..Default::default()
     }
@@ -463,7 +482,7 @@ fn block_config(commitment: CommitmentConfig) -> RpcBlockConfig {
 fn block_info_config(commitment: CommitmentConfig) -> RpcBlockConfig {
     RpcBlockConfig {
         transaction_details: Some(TransactionDetails::None),
-        ..block_config(commitment)
+        ..block_config(commitment, 0)
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -46,7 +46,7 @@ async fn _test_get_block() {
 /// disabled. See ENG-4405.
 #[test]
 fn get_block_config_disables_rewards() {
-    let config = block_config(CommitmentConfig::finalized());
+    let config = block_config(CommitmentConfig::finalized(), 0);
 
     assert_eq!(config.rewards, Some(false));
     assert_eq!(config.max_supported_transaction_version, Some(0));
@@ -109,4 +109,79 @@ async fn signature_statuses_reject_nonempty_invalid_api_version() {
         .await;
 
     assert!(result.is_err());
+}
+
+#[test]
+fn v1_block_reads_use_json() {
+    let config = block_config(CommitmentConfig::finalized(), 1);
+    assert_eq!(config.max_supported_transaction_version, Some(1));
+    assert_eq!(
+        config.encoding,
+        Some(solana_transaction_status::UiTransactionEncoding::Json)
+    );
+}
+
+#[tokio::test]
+async fn reads_mixed_version_json_blocks() {
+    // The read path consumes JSON fields, never the v1 binary layout.
+    let legacy: serde_json::Value = serde_json::from_str(include_str!(
+        "../../log_meta_composer/dispatch_message_txn.json"
+    ))
+    .unwrap();
+    let mut v1 = legacy.clone();
+    v1["version"] = serde_json::json!(1);
+    v1["transaction"]["message"]["transactionConfig"] = serde_json::json!({
+        "computeUnitLimit": 200000,
+        "priorityFee": 50000,
+        "heapSize": null,
+        "loadedAccountsDataSizeLimit": null
+    });
+    let block = serde_json::json!({
+        "blockhash": "blockhash",
+        "previousBlockhash": "previous",
+        "parentSlot": 41,
+        "transactions": [legacy, v1],
+        "rewards": [],
+        "blockTime": 1729865514,
+        "blockHeight": 42
+    });
+    let client = SealevelRpcClient::from_rpc_client(Arc::new(RpcClient::new_mock_with_mocks(
+        "succeeds".to_owned(),
+        HashMap::from([(RpcRequest::GetBlock, block)]),
+    )))
+    .with_max_supported_transaction_version(1);
+    let result = client.get_block(42).await.unwrap();
+    let transactions = result.transactions.unwrap();
+    assert_eq!(transactions.len(), 2);
+    assert_eq!(
+        serde_json::to_value(&transactions[1]).unwrap()["version"],
+        1
+    );
+}
+
+#[tokio::test]
+async fn reads_v1_parsed_transaction_metadata() {
+    let mut tx: serde_json::Value = serde_json::from_str(include_str!(
+        "../../log_meta_composer/dispatch_message_txn.json"
+    ))
+    .unwrap();
+    tx["version"] = serde_json::json!(1);
+    let message = tx["transaction"]["message"].as_object_mut().unwrap();
+    let keys = message["accountKeys"].as_array().unwrap().iter().enumerate().map(|(index, key)| {
+        serde_json::json!({"pubkey": key, "signer": index == 0, "writable": true, "source": "transaction"})
+    }).collect::<Vec<_>>();
+    message.insert("accountKeys".into(), serde_json::json!(keys));
+    message.remove("header");
+    message.insert(
+        "transactionConfig".into(),
+        serde_json::json!({"computeUnitLimit": 200000, "priorityFee": 50000}),
+    );
+    let expected_fee = tx["meta"]["fee"].as_u64().unwrap();
+    let client = SealevelRpcClient::from_rpc_client(Arc::new(RpcClient::new_mock_with_mocks(
+        "succeeds".to_owned(),
+        HashMap::from([(RpcRequest::GetTransaction, tx)]),
+    )))
+    .with_max_supported_transaction_version(1);
+    let result = client.get_transaction(&Signature::default()).await.unwrap();
+    assert_eq!(result.transaction.meta.unwrap().fee, expected_fee);
 }

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -1,14 +1,58 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
+use hyperlane_core::U256;
+use serde_json::{json, Value};
+use solana_client::{
+    client_error::ClientError, nonblocking::rpc_client::RpcClient, rpc_client::RpcClientConfig,
+    rpc_request::RpcRequest,
+};
 use solana_commitment_config::CommitmentConfig;
+use solana_rpc_client::rpc_sender::{RpcSender, RpcTransportStats};
 use solana_sdk::signature::Signature;
 use solana_transaction_status::TransactionDetails;
 
 use super::{block_config, block_info_config};
 use crate::client::SealevelRpcClient;
+use crate::log_meta_composer::{
+    is_interchain_payment_instruction, is_message_dispatch_instruction, LogMetaComposer,
+};
+use crate::utils::{decode_h512, decode_pubkey};
+
+// Assert the actual serialized requests, not just the config helper.
+struct ReadSender {
+    request: RpcRequest,
+    params: Value,
+    response: Value,
+}
+
+#[async_trait::async_trait]
+impl RpcSender for ReadSender {
+    async fn send(&self, request: RpcRequest, params: Value) -> Result<Value, ClientError> {
+        assert_eq!(request, self.request);
+        assert_eq!(params, self.params);
+        Ok(self.response.clone())
+    }
+
+    fn get_transport_stats(&self) -> RpcTransportStats {
+        RpcTransportStats::default()
+    }
+
+    fn url(&self) -> String {
+        "http://localhost:8899".to_owned()
+    }
+}
+
+fn read_client(request: RpcRequest, params: Value, response: Value) -> SealevelRpcClient {
+    SealevelRpcClient::from_rpc_client(Arc::new(RpcClient::new_sender(
+        ReadSender {
+            request,
+            params,
+            response,
+        },
+        RpcClientConfig::default(),
+    )))
+}
 
 fn signature_status_client(api_version: serde_json::Value) -> SealevelRpcClient {
     let response = serde_json::json!({
@@ -128,6 +172,10 @@ async fn reads_mixed_version_json_blocks() {
         "../../log_meta_composer/dispatch_message_txn.json"
     ))
     .unwrap();
+    let v0: Value = serde_json::from_str(include_str!(
+        "../../log_meta_composer/dispatch_message_versioned_txn.json"
+    ))
+    .unwrap();
     let mut v1 = legacy.clone();
     v1["version"] = serde_json::json!(1);
     v1["transaction"]["message"]["transactionConfig"] = serde_json::json!({
@@ -137,26 +185,64 @@ async fn reads_mixed_version_json_blocks() {
         "loadedAccountsDataSizeLimit": null
     });
     let block = serde_json::json!({
-        "blockhash": "blockhash",
+        "blockhash": "11111111111111111111111111111111",
         "previousBlockhash": "previous",
         "parentSlot": 41,
-        "transactions": [legacy, v1],
+        "transactions": [v0, v1],
         "rewards": [],
         "blockTime": 1729865514,
         "blockHeight": 42
     });
-    let client = SealevelRpcClient::from_rpc_client(Arc::new(RpcClient::new_mock_with_mocks(
-        "succeeds".to_owned(),
-        HashMap::from([(RpcRequest::GetBlock, block)]),
-    )))
-    .with_max_supported_transaction_version(1);
+    // Include legacy without creating a second matching dispatch for the same PDA.
+    let mut unrelated_legacy = legacy;
+    unrelated_legacy["version"] = json!("legacy");
+    unrelated_legacy["transaction"]["message"]["instructions"] = json!([]);
+    unrelated_legacy["meta"]["innerInstructions"] = json!([]);
+    let mut block = block;
+    block["transactions"]
+        .as_array_mut()
+        .unwrap()
+        .insert(0, unrelated_legacy);
+    let expected_signature = decode_h512(
+        block["transactions"][2]["transaction"]["signatures"][0]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    let client = read_client(
+        RpcRequest::GetBlock,
+        json!([42, {"encoding":"json", "commitment":"finalized", "maxSupportedTransactionVersion":1, "rewards":false, "transactionDetails":null}]),
+        block,
+    ).with_max_supported_transaction_version(1);
     let result = client.get_block(42).await.unwrap();
-    let transactions = result.transactions.unwrap();
-    assert_eq!(transactions.len(), 2);
+    let transactions = result.transactions.as_ref().unwrap();
+    assert_eq!(transactions.len(), 3);
     assert_eq!(
-        serde_json::to_value(&transactions[1]).unwrap()["version"],
+        serde_json::to_value(&transactions[2]).unwrap()["version"],
         1
     );
+    let program = decode_pubkey("E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi").unwrap();
+    let pda = decode_pubkey("6eG8PheL41qLFFUtPjSYMtsp4aoAQsMgcsYwkGCB8kwT").unwrap();
+    let meta = LogMetaComposer::new(
+        program,
+        "dispatch".to_owned(),
+        is_message_dispatch_instruction,
+    )
+    .log_meta(result.clone(), U256::zero(), &pda, &42)
+    .unwrap();
+    assert_eq!(meta.transaction_index, 2);
+    assert_eq!(meta.transaction_id, expected_signature);
+    let program = decode_pubkey("BhNcatUDC2D5JTyeaqrdSukiVFsEHK7e3hVmKMztwefv").unwrap();
+    let pda = decode_pubkey("9yMwrDqHsbmmvYPS9h4MLPbe2biEykcL51W7qJSDL5hF").unwrap();
+    let payment = LogMetaComposer::new(
+        program,
+        "gas payment".to_owned(),
+        is_interchain_payment_instruction,
+    )
+    .log_meta(result, U256::zero(), &pda, &42)
+    .unwrap();
+    assert_eq!(payment.transaction_index, 2);
+    assert_eq!(payment.transaction_id, expected_signature);
 }
 
 #[tokio::test]
@@ -166,22 +252,87 @@ async fn reads_v1_parsed_transaction_metadata() {
     ))
     .unwrap();
     tx["version"] = serde_json::json!(1);
+    let account_keys = tx["transaction"]["message"]["accountKeys"]
+        .as_array()
+        .unwrap()
+        .clone();
+    let partially_decode = |instruction: &Value| {
+        json!({
+            "programId": account_keys[instruction["programIdIndex"].as_u64().unwrap() as usize],
+            "accounts": instruction["accounts"].as_array().unwrap().iter().map(|index| &account_keys[index.as_u64().unwrap() as usize]).collect::<Vec<_>>(),
+            "data": instruction["data"],
+            "stackHeight": instruction["stackHeight"],
+        })
+    };
     let message = tx["transaction"]["message"].as_object_mut().unwrap();
-    let keys = message["accountKeys"].as_array().unwrap().iter().enumerate().map(|(index, key)| {
-        serde_json::json!({"pubkey": key, "signer": index == 0, "writable": true, "source": "transaction"})
-    }).collect::<Vec<_>>();
-    message.insert("accountKeys".into(), serde_json::json!(keys));
+    let header = &message["header"];
+    let signers = header["numRequiredSignatures"].as_u64().unwrap() as usize;
+    let readonly_signed = header["numReadonlySignedAccounts"].as_u64().unwrap() as usize;
+    let readonly_unsigned = header["numReadonlyUnsignedAccounts"].as_u64().unwrap() as usize;
+    let keys = account_keys
+        .iter()
+        .enumerate()
+        .map(|(index, key)| {
+            let signer = index < signers;
+            let writable = if signer {
+                index < signers - readonly_signed
+            } else {
+                index < account_keys.len() - readonly_unsigned
+            };
+            json!({"pubkey": key, "signer": signer, "writable": writable, "source": "transaction"})
+        })
+        .collect::<Vec<_>>();
+    let instructions = message["instructions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(&partially_decode)
+        .collect::<Vec<_>>();
+    message.insert("instructions".into(), json!(instructions));
+    message.insert("accountKeys".into(), json!(keys));
     message.remove("header");
     message.insert(
         "transactionConfig".into(),
-        serde_json::json!({"computeUnitLimit": 200000, "priorityFee": 50000}),
+        json!({"computeUnitLimit": 200000, "priorityFee": 50000, "heapSize":null, "loadedAccountsDataSizeLimit":null}),
     );
+    for inner in tx["meta"]["innerInstructions"].as_array_mut().unwrap() {
+        let instructions = inner["instructions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(&partially_decode)
+            .collect::<Vec<_>>();
+        inner["instructions"] = json!(instructions);
+    }
+    tx["meta"]
+        .as_object_mut()
+        .unwrap()
+        .remove("loadedAddresses");
     let expected_fee = tx["meta"]["fee"].as_u64().unwrap();
-    let client = SealevelRpcClient::from_rpc_client(Arc::new(RpcClient::new_mock_with_mocks(
-        "succeeds".to_owned(),
-        HashMap::from([(RpcRequest::GetTransaction, tx)]),
-    )))
-    .with_max_supported_transaction_version(1);
+    let client = read_client(
+        RpcRequest::GetTransaction,
+        json!([Signature::default().to_string(), {"encoding":"jsonParsed", "commitment":"finalized", "maxSupportedTransactionVersion":1}]),
+        tx,
+    ).with_max_supported_transaction_version(1);
     let result = client.get_transaction(&Signature::default()).await.unwrap();
     assert_eq!(result.transaction.meta.unwrap().fee, expected_fee);
+}
+
+#[tokio::test]
+async fn default_chain_reads_keep_version_zero() {
+    let client = read_client(
+        RpcRequest::GetBlock,
+        json!([42, {"encoding":"json", "commitment":"finalized", "maxSupportedTransactionVersion":0, "rewards":false, "transactionDetails":null}]),
+        json!({"blockhash":"hash", "previousBlockhash":"previous", "parentSlot":41, "blockTime":null, "blockHeight":42}),
+    );
+    client.get_block(42).await.unwrap();
+    let client = read_client(
+        RpcRequest::GetTransaction,
+        json!([Signature::default().to_string(), {"encoding":"jsonParsed", "commitment":"finalized", "maxSupportedTransactionVersion":0}]),
+        serde_json::from_str(include_str!(
+            "../../log_meta_composer/dispatch_message_txn.json"
+        ))
+        .unwrap(),
+    );
+    client.get_transaction(&Signature::default()).await.unwrap();
 }

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
@@ -242,6 +242,7 @@ impl SealevelFallbackRpcClient {
         chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
         urls: Vec<Url>,
         metrics: PrometheusClientMetrics,
+        max_supported_transaction_version: u8,
     ) -> Self {
         let clients: Vec<_> = urls
             .into_iter()
@@ -249,6 +250,7 @@ impl SealevelFallbackRpcClient {
                 SealevelRpcClientBuilder::new(rpc_url)
                     .with_prometheus_metrics(metrics.clone(), chain.clone())
                     .build()
+                    .with_max_supported_transaction_version(max_supported_transaction_version)
             })
             .collect();
 

--- a/rust/main/chains/hyperlane-sealevel/src/trait_builder.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/trait_builder.rs
@@ -27,6 +27,8 @@ pub struct ProcessAltOverride {
 pub struct ConnectionConf {
     /// A list of urls to connect to
     pub urls: Vec<Url>,
+    /// Highest transaction version accepted by JSON RPC reads (0 by default).
+    pub max_supported_transaction_version: u8,
     /// Operation batching configuration
     pub op_submission_config: OpSubmissionConfig,
     /// Native token and its denomination

--- a/rust/main/chains/hyperlane-sealevel/src/tx_submitter/config.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/tx_submitter/config.rs
@@ -53,7 +53,12 @@ impl TransactionSubmitterConfig {
             TransactionSubmitterConfig::Rpc { urls } => {
                 let urls: Vec<_> = urls.iter().filter_map(|url| Url::parse(url).ok()).collect();
 
-                let rpc_client = SealevelFallbackRpcClient::from_urls(chain, urls, metrics);
+                let rpc_client = SealevelFallbackRpcClient::from_urls(
+                    chain,
+                    urls,
+                    metrics,
+                    conf.max_supported_transaction_version,
+                );
                 let provider = SealevelProvider::new(rpc_client, domain, &[], conf);
                 Arc::new(RpcTransactionSubmitter::new(Arc::new(provider)))
             }
@@ -70,7 +75,12 @@ impl TransactionSubmitterConfig {
 
                 let urls: Vec<_> = urls.iter().filter_map(|url| Url::parse(url).ok()).collect();
 
-                let rpc_client = SealevelFallbackRpcClient::from_urls(chain, urls, metrics);
+                let rpc_client = SealevelFallbackRpcClient::from_urls(
+                    chain,
+                    urls,
+                    metrics,
+                    conf.max_supported_transaction_version,
+                );
                 let submit_provider = SealevelProvider::new(rpc_client, domain, &[], conf);
                 Arc::new(JitoTransactionSubmitter::new(
                     provider.clone(),

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1622,7 +1622,12 @@ fn build_sealevel_provider(
 
     let chain = middleware_metrics.chain.clone();
     let urls = conf.urls.clone();
-    let rpc_client = SealevelFallbackRpcClient::from_urls(chain, urls, client_metrics);
+    let rpc_client = SealevelFallbackRpcClient::from_urls(
+        chain,
+        urls,
+        client_metrics,
+        conf.max_supported_transaction_version,
+    );
     SealevelProvider::new(rpc_client, locator.domain.clone(), contract_addresses, conf)
 }
 

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -338,6 +338,24 @@ fn build_sealevel_connection_conf(
 ) -> Option<ChainConnectionConf> {
     let mut local_err = ConfigParsingError::default();
 
+    let max_supported_transaction_version = chain
+        .chain(&mut local_err)
+        .get_opt_key("maxSupportedTransactionVersion")
+        .parse_u64()
+        .end()
+        .unwrap_or(0);
+    let max_supported_transaction_version = match max_supported_transaction_version {
+        0 => 0,
+        1 => 1,
+        _ => {
+            local_err.push(
+                (&chain.cwp).add("maxsupportedtransactionversion"),
+                eyre!("maxSupportedTransactionVersion must be 0 or 1"),
+            );
+            0
+        }
+    };
+
     let native_token = parse_native_token(chain, err, 9);
     let priority_fee_oracle = parse_sealevel_priority_fee_oracle_config(chain, &mut local_err);
     let transaction_submitter = parse_transaction_submitter_config(chain, &mut local_err);
@@ -358,6 +376,7 @@ fn build_sealevel_connection_conf(
         native_token,
         priority_fee_oracle,
         transaction_submitter,
+        max_supported_transaction_version,
         mailbox_process_alt,
         process_alt_overrides,
         ur_reveal,
@@ -941,6 +960,34 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn sealevel_read_version_is_opt_in_and_validated() {
+        for (value, expected) in [
+            (json!({}), Some(0)),
+            (json!({"maxsupportedtransactionversion": 0}), Some(0)),
+            (json!({"maxsupportedtransactionversion": 1}), Some(1)),
+            (json!({"maxsupportedtransactionversion": 2}), None),
+            (json!({"maxsupportedtransactionversion": "bad"}), None),
+        ] {
+            let chain = ValueParser::new(ConfigPath::default(), &value);
+            let mut errors = ConfigParsingError::default();
+            let result = build_sealevel_connection_conf(
+                &[Url::parse("http://localhost:8899").unwrap()],
+                &chain,
+                &mut errors,
+                OpSubmissionConfig::default(),
+            );
+            let version = result.map(|conf| {
+                let ChainConnectionConf::Sealevel(conf) = conf else {
+                    panic!("expected sealevel")
+                };
+                conf.max_supported_transaction_version
+            });
+            assert_eq!(version, expected);
+            assert_eq!(errors.is_ok(), expected.is_some());
+        }
+    }
 
     fn parse_ethereum_hedge(value: serde_json::Value) -> (ChainConnectionConf, ConfigParsingError) {
         let chain = ValueParser::new(ConfigPath::default(), &value);

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
@@ -97,6 +97,7 @@ impl SealevelAdapter {
             chain_info.clone(),
             urls.clone(),
             client_metrics.clone(),
+            connection_conf.max_supported_transaction_version,
         );
 
         let provider = SealevelProvider::new(

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_config.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_config.rs
@@ -27,6 +27,7 @@ fn test_configuration_fields() {
         reorg_period: expected_reorg_period.clone(),
         addresses: Default::default(),
         connection: ChainConnectionConf::Sealevel(hyperlane_sealevel::ConnectionConf {
+            max_supported_transaction_version: 0,
             urls: vec![],
             op_submission_config: OpSubmissionConfig {
                 batch_contract_address: None,

--- a/rust/main/lander/src/adapter/chains/sealevel/conf.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/conf.rs
@@ -73,6 +73,7 @@ mod tests {
             reorg_period: ReorgPeriod::None,
             addresses: Default::default(),
             connection: ChainConnectionConf::Sealevel(hyperlane_sealevel::ConnectionConf {
+                max_supported_transaction_version: 0,
                 urls: vec![],
                 op_submission_config: OpSubmissionConfig::default(),
                 native_token: Default::default(),

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -397,6 +397,8 @@ const contextBase = {
     location: 'us-east1',
   },
   sealevel: {
+    maxSupportedTransactionVersionGetter: (chain: ChainName): 0 | 1 =>
+      chain === 'solanamainnet' ? 1 : 0,
     priorityFeeOracleConfigGetter: sealevelPriorityFeeOracleConfigGetter,
     transactionSubmitterConfigGetter: sealevelTransactionSubmitterConfigGetter,
     urRevealConfigGetter: sealevelUrRevealConfigGetter,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -1,4 +1,5 @@
 import {
+  ChainName,
   GasPaymentEnforcement,
   GasPaymentEnforcementPolicyType,
   IsmCacheConfig,
@@ -103,6 +104,10 @@ const contextBase = {
   gcp: {
     project: 'abacus-labs-dev',
     location: 'us-east1',
+  },
+  sealevel: {
+    maxSupportedTransactionVersionGetter: (chain: ChainName): 0 | 1 =>
+      chain === 'solanadevnet' || chain === 'solanatestnet' ? 1 : 0,
   },
 } as const;
 

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -156,6 +156,14 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
             fallbackHedgeConfig
               ? fallbackHedgeConfig
               : {}),
+            ...(metadata.protocol === ProtocolType.Sealevel
+              ? {
+                  maxSupportedTransactionVersion:
+                    this.config.rawConfig.sealevel?.maxSupportedTransactionVersionGetter?.(
+                      chain,
+                    ) ?? 0,
+                }
+              : {}),
             protocol: metadata.protocol,
             blocks: { reorgPeriod },
             maxBatchSize: batchConfig.maxBatchSize,

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -112,6 +112,7 @@ export interface AgentContextConfig extends AgentEnvConfig {
 }
 
 export interface SealevelAgentConfig {
+  maxSupportedTransactionVersionGetter?: (chain: ChainName) => 0 | 1;
   priorityFeeOracleConfigGetter?: (
     chain: ChainName,
   ) => AgentSealevelPriorityFeeOracle;

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -97,6 +97,48 @@ function agentConfigHelper(
 }
 
 describe('Agent configs', () => {
+  it('renders v1 reads for Solana clusters and preserves other SVM defaults', async () => {
+    const solanaChains = new Set([
+      'solanamainnet',
+      'solanadevnet',
+      'solanatestnet',
+    ]);
+    const seenSolanaChains = new Set<string>();
+    let sawOtherSvm = false;
+
+    for (const agentConfigs of [mainnet3Agents, testnet4Agents]) {
+      for (const config of Object.values(agentConfigs)) {
+        for (const role of [
+          Role.Relayer,
+          Role.Scraper,
+          Role.Validator,
+        ] as const) {
+          if (!(role === Role.Validator ? config.validators : config[role]))
+            continue;
+          const manager = new TestAgentHelmManager(
+            agentConfigHelper(config, role),
+            role,
+          );
+          const values = await manager.helmValues();
+          for (const chain of values.hyperlane.chains) {
+            const isSolana = solanaChains.has(chain.name);
+            const isSvm =
+              getChain(chain.name).protocol === ProtocolType.Sealevel;
+            expect(
+              chain.maxSupportedTransactionVersion,
+              `${config.runEnv}/${config.context}/${role}/${chain.name}`,
+            ).to.equal(isSolana ? 1 : isSvm ? 0 : undefined);
+            if (isSolana) seenSolanaChains.add(chain.name);
+            if (isSvm && !isSolana) sawOtherSvm = true;
+          }
+        }
+      }
+    }
+
+    expect([...seenSolanaChains]).to.have.members([...solanaChains]);
+    expect(sawOtherSvm).to.equal(true);
+  });
+
   it('configures one shared testnet4 scraper proxy', () => {
     const enabledProxies = Object.values(testnet4Agents).filter(
       (config) => config.scraperProxy?.enabled,

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -177,6 +177,9 @@ export type AgentCosmosGasPrice = z.infer<
 >['gasPrice'];
 
 const AgentSealevelChainMetadataSchema = z.object({
+  maxSupportedTransactionVersion: z
+    .union([z.literal(0), z.literal(1)])
+    .optional(),
   priorityFeeOracle: z
     .union([
       z.object({


### PR DESCRIPTION
Solana blocks containing v1 transactions fail agent RPC reads capped at v0. Added per-chain `maxSupportedTransactionVersion` (0/1), defaulting to 0 and enabling 1 for Solana mainnet agent configuration. Threaded the setting through fallback providers, submitter clients and Lander.

Reads explicitly use JSON/JSON-parsed fields, which the existing indexer consumes without binary decoding; v1 header config is unused and fee accounting continues to use execution metadata. Sending format is unchanged. Dependency updates and v1 sending are separate followups.

Validation: 60 Sealevel library tests passed, including v1 block/receipt fixtures; configuration default/override/rejection test passed; SDK and infra builds passed; lint and commit hooks passed. Source clippy passed for Sealevel, hyperlane-base and Lander. The Rust reader also fetched a real v1 transaction and block from a local Agave 4.2.0 validator. Hyperlane v1 dispatch/payment execution and production rollout remain unverified.

