### PR TITLE
chore(infra): deploy relayer WebSocket indexing

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -348,6 +348,7 @@ impl BaseAgent for Relayer {
                 )
                 .with_broadcaster(origin.message_sync.get_broadcaster())
                 .with_freshness_indexer(origin.message_sequence_indexer.clone())
+                .with_merkle_freshness_indexer(origin.merkle_sequence_indexer.clone())
             })
             .collect();
         let scraper_websocket_monitor = settings

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -156,7 +156,7 @@ pub struct Relayer {
     chain_metrics: ChainMetrics,
     runtime_metrics: RuntimeMetrics,
     scraper_websocket_monitor: Option<ScraperWebSocketMonitor>,
-    scraper_websocket_authority: Option<ScraperAuthorityReceiver>,
+    scraper_websocket_authority: HashMap<u32, ScraperAuthorityReceiver>,
     /// Tokio console server
     pub tokio_console_server: Option<console_subscriber::Server>,
 
@@ -362,9 +362,15 @@ impl BaseAgent for Relayer {
                 )
             })
             .transpose()?;
-        let scraper_websocket_authority = scraper_websocket_monitor
-            .as_ref()
-            .and_then(ScraperWebSocketMonitor::authority_receiver);
+        let scraper_websocket_authority = origins
+            .keys()
+            .filter_map(|domain| {
+                scraper_websocket_monitor
+                    .as_ref()
+                    .and_then(|monitor| monitor.authority_receiver(domain.id()))
+                    .map(|authority| (domain.id(), authority))
+            })
+            .collect();
 
         debug!(elapsed = ?start.elapsed(), event = "fully initialized", "Relayer startup duration measurement");
 
@@ -541,7 +547,10 @@ impl BaseAgent for Relayer {
             .expect("Creating message DB loader metrics is infallible");
         for (origin_domain, origin) in self.origins.iter() {
             let maybe_broadcaster = origin.message_sync.get_broadcaster();
-            let scraper_authority = self.scraper_websocket_authority.clone();
+            let scraper_authority = self
+                .scraper_websocket_authority
+                .get(&origin_domain.id())
+                .cloned();
             if let Some(authority) = scraper_authority.clone() {
                 tasks.push(self.run_rpc_sync_supervisor(
                     origin,

--- a/rust/main/agents/relayer/src/relayer/origin.rs
+++ b/rust/main/agents/relayer/src/relayer/origin.rs
@@ -43,6 +43,7 @@ pub struct Origin {
     /// `tx_id_indexer_task` has stored it.
     pub igp_indexer: Option<Arc<dyn Indexer<InterchainGasPayment>>>,
     pub merkle_tree_hook_sync: MerkleTreeHookSync,
+    pub merkle_sequence_indexer: SequenceIndexer<MerkleTreeInsertion>,
 }
 
 impl std::fmt::Debug for Origin {
@@ -165,7 +166,7 @@ impl Factory for OriginFactory {
             (None, None)
         };
 
-        let merkle_tree_hook_sync = {
+        let (merkle_tree_hook_sync, merkle_sequence_indexer) = {
             let start_entity_init = Instant::now();
             let res = self
                 .init_merkle_tree_hook_sync(&domain, chain_conf, hyperlane_db.clone())
@@ -191,6 +192,7 @@ impl Factory for OriginFactory {
             interchain_gas_payment_sync,
             igp_indexer,
             merkle_tree_hook_sync,
+            merkle_sequence_indexer,
         };
         Ok(origin)
     }
@@ -335,7 +337,7 @@ impl OriginFactory {
         domain: &HyperlaneDomain,
         chain_conf: &ChainConf,
         db: Arc<HyperlaneRocksDB>,
-    ) -> Result<MerkleTreeHookSync, FactoryError> {
+    ) -> Result<(MerkleTreeHookSync, SequenceIndexer<MerkleTreeInsertion>), FactoryError> {
         match MerkleTreeInsertion::indexing_cursor(domain.domain_protocol()) {
             CursorType::SequenceAware => Self::build_sequenced_contract_sync(
                 domain,
@@ -347,7 +349,7 @@ impl OriginFactory {
                 false,
             )
             .await
-            .map(|(r, _)| r as Arc<dyn ContractSyncer<_>>)
+            .map(|(r, i)| (r as Arc<dyn ContractSyncer<_>>, i))
             .map_err(|err| FactoryError::MerkleTreeHookSync(domain.to_string(), err.to_string())),
             CursorType::RateLimited => Self::build_watermark_contract_sync(
                 domain,
@@ -359,7 +361,7 @@ impl OriginFactory {
                 false,
             )
             .await
-            .map(|(r, _)| r as Arc<dyn ContractSyncer<_>>)
+            .map(|(r, i)| (r as Arc<dyn ContractSyncer<_>>, i))
             .map_err(|err| FactoryError::MerkleTreeHookSync(domain.to_string(), err.to_string())),
         }
     }

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -2869,17 +2869,15 @@ impl ScraperWebSocketMonitor {
                         false
                     });
                     if !readiness_still_valid || !is_fresh {
-                        if !is_fresh {
-                            if should_warn(&self.freshness_warned_at) {
-                                warn!(
-                                    %chain,
-                                    ?dispatch_canonical_count,
-                                    ?merkle_canonical_count,
-                                    ?dispatch_cursor,
-                                    ?merkle_cursor,
-                                    "Scraper sequenced cursors are not canonically fresh"
-                                );
-                            }
+                        if !is_fresh && should_warn(&self.freshness_warned_at) {
+                            warn!(
+                                %chain,
+                                ?dispatch_canonical_count,
+                                ?merkle_canonical_count,
+                                ?dispatch_cursor,
+                                ?merkle_cursor,
+                                "Scraper sequenced cursors are not canonically fresh"
+                            );
                         }
                         self.deactivate_source_authority(domain);
                     } else {

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -72,7 +72,11 @@ const GAS_PAYMENT_CURSOR_V2_PREFIX: &[u8] = b"scraper_websocket_gas_payment_stre
 const GAS_PAYMENT_CURSOR_PREFIX: &[u8] = b"scraper_websocket_gas_payment_stream_cursor_v3";
 const GAS_PAYMENT_DEGRADED_PREFIX: &[u8] = b"scraper_websocket_gas_payment_degraded_v3";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
-const PARITY_UNHEALTHY_PREFIX: &[u8] = b"scraper_websocket_parity_unhealthy";
+// V1 poison keys are intentionally retained in RocksDB. V2 starts a clean
+// parity epoch after fixing the first deployment's known false failures.
+const PARITY_UNHEALTHY_PREFIX: &[u8] = b"scraper_websocket_parity_unhealthy_v2";
+#[cfg(test)]
+const PARITY_UNHEALTHY_V1_PREFIX: &[u8] = b"scraper_websocket_parity_unhealthy";
 
 #[cfg_attr(test, mockall::automock)]
 trait ParityDatabase: Send + Sync {
@@ -652,9 +656,14 @@ impl ParityInput {
                 let local_transaction_id = database
                     .retrieve_dispatched_tx_hash_by_message_id(&message.id())
                     .context("Reading RPC-indexed dispatch transaction ID")?;
+                // Sealevel's basic log metadata stores zero when the relayer's
+                // advanced transaction lookup is disabled. Keep requiring the
+                // entry, but only compare transaction IDs when one is known.
+                let transaction_id_conflicts = local_transaction_id
+                    .is_some_and(|local| local != H512::zero() && local != *transaction_id);
                 if local_message.as_ref().is_some_and(|local| local != message)
                     || local_block_number.is_some_and(|local| local != *block_number)
-                    || local_transaction_id.is_some_and(|local| local != *transaction_id)
+                    || transaction_id_conflicts
                 {
                     return Ok(ParityResult::Conflict);
                 }
@@ -4234,6 +4243,32 @@ mod tests {
             .expect("store dispatch transaction");
     }
 
+    fn dispatch_parity_result(local_transaction_id: Option<H512>) -> ParityResult {
+        let message = dispatch_message(7, b"payload");
+        let local_message = message.clone();
+        let mut database = MockParityDatabase::new();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(1)
+            .return_once(move |_| Ok(Some(local_message)));
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(1)
+            .return_once(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(1)
+            .return_once(move |_| Ok(local_transaction_id));
+
+        ParityInput::Dispatch {
+            block_number: 100,
+            message,
+            transaction_id: dispatch_transaction_id(),
+        }
+        .compare(&database)
+        .expect("compare dispatch parity")
+    }
+
     fn sequence(validated: ValidatedEvent) -> (EventKind, SequenceResult) {
         (validated.kind, validated.sequence_result)
     }
@@ -4991,6 +5026,27 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_parity_accepts_unknown_local_transaction_id() {
+        assert_eq!(
+            dispatch_parity_result(Some(H512::zero())),
+            ParityResult::Match
+        );
+    }
+
+    #[test]
+    fn dispatch_parity_rejects_known_transaction_id_mismatch() {
+        assert_eq!(
+            dispatch_parity_result(Some(bytes_to_h512(&[7_u8; 32]))),
+            ParityResult::Conflict
+        );
+    }
+
+    #[test]
+    fn dispatch_parity_requires_local_transaction_id_entry() {
+        assert_eq!(dispatch_parity_result(None), ParityResult::Missing);
+    }
+
+    #[test]
     fn dispatch_parity_survives_database_restart() {
         let temp_dir = tempfile::tempdir().expect("temp DB directory");
         let message = dispatch_message(7, b"payload");
@@ -5654,6 +5710,13 @@ mod tests {
         assert!(source
             .parity_unhealthy(EventKind::Dispatch)
             .expect("health read"));
+        assert_eq!(
+            source
+                .cursor_db
+                .retrieve_value_by_key(PARITY_UNHEALTHY_PREFIX, &source.mailbox)
+                .expect("read v2 parity poison"),
+            Some(true)
+        );
 
         let metrics = CoreMetrics::new("scraper-parity-restart", 9090, Registry::new())
             .expect("create restart metrics");
@@ -5673,6 +5736,27 @@ mod tests {
                 .with_label_values(&["test", DISPATCH_EVENT_TYPE])
                 .get(),
             0
+        );
+    }
+
+    #[test]
+    fn retained_v1_parity_poison_does_not_poison_v2_epoch() {
+        let fixture = fixture();
+        let source = &fixture.sources[&5];
+        source
+            .cursor_db
+            .store_value_by_key(PARITY_UNHEALTHY_V1_PREFIX, &source.mailbox, &true)
+            .expect("store retained v1 parity poison");
+
+        assert!(!source
+            .parity_unhealthy(EventKind::Dispatch)
+            .expect("read clean v2 parity epoch"));
+        assert_eq!(
+            source
+                .cursor_db
+                .retrieve_value_by_key(PARITY_UNHEALTHY_V1_PREFIX, &source.mailbox)
+                .expect("read retained v1 parity poison"),
+            Some(true)
         );
     }
 

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -63,14 +63,12 @@ const PARITY_RETRY_DELAY: Duration = Duration::from_millis(10);
 const PARITY_RETRY_ATTEMPTS: usize = 60;
 const PARITY_WARN_INTERVAL: Duration = Duration::from_secs(60);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
-const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
 const GAS_PAYMENT_CURSOR_V1_PREFIX: &[u8] = b"scraper_websocket_gas_payment_stream_cursor_v1";
 const GAS_PAYMENT_CURSOR_V2_PREFIX: &[u8] = b"scraper_websocket_gas_payment_stream_cursor_v2";
 const GAS_PAYMENT_CURSOR_PREFIX: &[u8] = b"scraper_websocket_gas_payment_stream_cursor_v3";
 const GAS_PAYMENT_DEGRADED_PREFIX: &[u8] = b"scraper_websocket_gas_payment_degraded_v3";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
-const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor";
 const PARITY_UNHEALTHY_PREFIX: &[u8] = b"scraper_websocket_parity_unhealthy";
 
 #[cfg_attr(test, mockall::automock)]
@@ -133,6 +131,7 @@ pub(crate) struct ScraperSource {
     merkle_tree_hook: H256,
     database: Arc<dyn ParityDatabase>,
     freshness_indexer: Option<SequenceIndexer<HyperlaneMessage>>,
+    merkle_freshness_indexer: Option<SequenceIndexer<MerkleTreeInsertion>>,
 }
 
 impl ScraperSource {
@@ -154,6 +153,7 @@ impl ScraperSource {
             merkle_tree_hook,
             database: Arc::new(database),
             freshness_indexer: None,
+            merkle_freshness_indexer: None,
         }
     }
 
@@ -170,6 +170,14 @@ impl ScraperSource {
         indexer: SequenceIndexer<HyperlaneMessage>,
     ) -> Self {
         self.freshness_indexer = Some(indexer);
+        self
+    }
+
+    pub(crate) fn with_merkle_freshness_indexer(
+        mut self,
+        indexer: SequenceIndexer<MerkleTreeInsertion>,
+    ) -> Self {
+        self.merkle_freshness_indexer = Some(indexer);
         self
     }
 
@@ -199,6 +207,7 @@ impl ScraperSource {
             merkle_tree_hook,
             database,
             freshness_indexer: None,
+            merkle_freshness_indexer: None,
         }
     }
 
@@ -214,35 +223,6 @@ impl ScraperSource {
         self.cursor_db
             .retrieve_value_by_key(kind.cursor_prefix(), &self.address(kind))
             .context("Reading durable scraper WebSocket cursor")
-    }
-
-    fn correlation_cursor_key(&self) -> H512 {
-        let mut key = [0_u8; 64];
-        key[..32].copy_from_slice(self.mailbox.as_ref());
-        key[32..].copy_from_slice(self.merkle_tree_hook.as_ref());
-        H512::from_slice(&key)
-    }
-
-    fn correlation_cursor(&self) -> Result<Option<u32>> {
-        self.cursor_db
-            .retrieve_value_by_key(CORRELATION_CURSOR_PREFIX, &self.correlation_cursor_key())
-            .context("Reading durable scraper correlation cursor")
-    }
-
-    fn store_correlation_cursor(&self, sequence: u32) -> Result<()> {
-        if self
-            .correlation_cursor()?
-            .is_some_and(|stored| stored >= sequence)
-        {
-            return Ok(());
-        }
-        self.cursor_db
-            .store_value_by_key(
-                CORRELATION_CURSOR_PREFIX,
-                &self.correlation_cursor_key(),
-                &sequence,
-            )
-            .context("Storing durable scraper correlation cursor")
     }
 
     fn store_cursor(&self, kind: EventKind, sequence: u32) -> Result<()> {
@@ -464,8 +444,18 @@ impl EventKind {
 
 #[derive(Clone, Copy, Debug)]
 struct SequencedReplaySource {
-    correlation_next: Option<u32>,
-    floor: Option<u32>,
+    dispatch_floor: Option<u32>,
+    merkle_floor: Option<u32>,
+}
+
+impl SequencedReplaySource {
+    fn floor(self, kind: EventKind) -> Option<u32> {
+        match kind {
+            EventKind::Dispatch => self.dispatch_floor,
+            EventKind::GasPayment => None,
+            EventKind::MerkleTreeInsertion => self.merkle_floor,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -477,21 +467,13 @@ impl SequencedReplayPlan {
     fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
         let mut plan = Self::default();
         for source in sources.values() {
-            let dispatch = source.cursor(EventKind::Dispatch)?;
-            let merkle = source.cursor(EventKind::MerkleTreeInsertion)?;
-            let correlation = source.correlation_cursor()?;
-            let floor = [dispatch, merkle, correlation].into_iter().flatten().min();
-            let correlation_next = correlation.or(floor);
-            if correlation.is_none() {
-                if let Some(sequence) = correlation_next {
-                    source.store_correlation_cursor(sequence)?;
-                }
-            }
+            let dispatch_floor = source.cursor(EventKind::Dispatch)?;
+            let merkle_floor = source.cursor(EventKind::MerkleTreeInsertion)?;
             plan.sources.insert(
                 source.domain,
                 SequencedReplaySource {
-                    correlation_next,
-                    floor,
+                    dispatch_floor,
+                    merkle_floor,
                 },
             );
         }
@@ -504,50 +486,12 @@ impl SequencedReplayPlan {
             .copied()
             .context("Scraper replay plan omitted configured source")
     }
-
-    fn correlation_required(&self, domain: u32) -> Result<bool> {
-        Ok(self.source(domain)?.floor.is_some())
-    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
 enum SequenceResult {
     Accepted,
     Duplicate,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct ProtocolProjection {
-    block_number: u64,
-    message_id: H256,
-}
-
-#[derive(Debug, Default)]
-struct CrossStreamPair {
-    dispatch: Option<ProtocolProjection>,
-    merkle: Option<ProtocolProjection>,
-}
-
-impl CrossStreamPair {
-    fn complete(&self) -> bool {
-        self.dispatch.is_some() && self.merkle.is_some()
-    }
-
-    fn get(&self, kind: EventKind) -> Option<ProtocolProjection> {
-        match kind {
-            EventKind::Dispatch => self.dispatch,
-            EventKind::GasPayment => None,
-            EventKind::MerkleTreeInsertion => self.merkle,
-        }
-    }
-
-    fn get_mut(&mut self, kind: EventKind) -> &mut Option<ProtocolProjection> {
-        match kind {
-            EventKind::Dispatch => &mut self.dispatch,
-            EventKind::GasPayment => unreachable!("gas payments are not cross-stream events"),
-            EventKind::MerkleTreeInsertion => &mut self.merkle,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -564,79 +508,6 @@ impl ParityResult {
             Self::Missing => "missing",
             Self::Conflict => "conflict",
         }
-    }
-}
-
-#[derive(Debug, Default)]
-struct CrossStreamState {
-    entries: HashMap<u32, BTreeMap<u32, CrossStreamPair>>,
-}
-
-impl CrossStreamState {
-    fn complete(&self, domain: u32, sequence: u32) -> bool {
-        self.entries
-            .get(&domain)
-            .and_then(|entries| entries.get(&sequence))
-            .is_some_and(CrossStreamPair::complete)
-    }
-
-    fn validate(
-        &mut self,
-        domain: u32,
-        sequence: u32,
-        kind: EventKind,
-        projection: ProtocolProjection,
-    ) -> Result<()> {
-        let entries = self.entries.entry(domain).or_default();
-
-        let mismatch = if let Some(pair) = entries.get(&sequence) {
-            if let Some(previous) = pair.get(kind) {
-                if previous != projection {
-                    bail!("Conflicting scraper projection at sequence {sequence}");
-                }
-            }
-            if let Some(counterpart) = pair.get(match kind {
-                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
-                EventKind::GasPayment => {
-                    unreachable!("gas payments are not cross-stream events")
-                }
-                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
-            }) {
-                if counterpart.message_id != projection.message_id {
-                    Some(format!(
-                        "Dispatch and Merkle message IDs differ at sequence {sequence}"
-                    ))
-                } else if counterpart.block_number != projection.block_number {
-                    Some(format!(
-                        "Dispatch and Merkle block numbers differ at sequence {sequence}"
-                    ))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        if let Some(mismatch) = mismatch {
-            bail!(mismatch);
-        }
-        if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
-            let oldest_complete = entries
-                .first_key_value()
-                .is_some_and(|(_, pair)| pair.complete());
-            if !oldest_complete {
-                bail!("Scraper cross-stream skew exceeds {CROSS_STREAM_WINDOW} sequences");
-            }
-        }
-
-        if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
-            entries.pop_first();
-        }
-        let pair = entries.entry(sequence).or_default();
-        *pair.get_mut(kind) = Some(projection);
-        Ok(())
     }
 }
 
@@ -694,17 +565,30 @@ impl StagedParity {
         if !self.events.contains_key(&domain) {
             return Ok(VecDeque::new());
         }
-        let Some(frontier) = sequenced_persistence_frontier(plan, caught_up, state, domain)? else {
-            return Ok(VecDeque::new());
-        };
+        let readiness = self
+            .events
+            .get(&domain)
+            .expect("checked staged parity domain exists")
+            .iter()
+            .map(|event| {
+                sequenced_persistence_ready(
+                    plan,
+                    caught_up,
+                    state,
+                    domain,
+                    event.kind,
+                    event.sequence,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
         let events = self
             .events
             .remove(&domain)
             .expect("checked staged parity domain exists");
         let mut ready = VecDeque::new();
         let mut retained = VecDeque::new();
-        for event in events {
-            if event.sequence <= frontier {
+        for (event, ready_for_persistence) in events.into_iter().zip(readiness) {
+            if ready_for_persistence {
                 ready.push_back(event);
             } else {
                 retained.push_back(event);
@@ -899,8 +783,6 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
-    correlation_next: HashMap<u32, u32>,
-    cross_stream: CrossStreamState,
     cursors: HashMap<(u32, EventKind), StreamCursor>,
     gas_payment_degraded: HashSet<u32>,
     gas_payment_v1_rows: HashMap<u32, LegacyDurableGasPaymentCursor>,
@@ -1003,20 +885,15 @@ impl StreamState {
     }
 
     fn reset_sequenced(&mut self, plan: &SequencedReplayPlan) {
-        self.correlation_next.clear();
-        self.cross_stream = CrossStreamState::default();
         self.cursors.clear();
         for (domain, source) in &plan.sources {
-            if let Some(sequence) = source.floor {
-                for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                if let Some(sequence) = source.floor(kind) {
                     self.cursors.insert(
                         (*domain, kind),
                         StreamCursor::from_durable_sequence(sequence),
                     );
                 }
-            }
-            if let Some(sequence) = source.correlation_next {
-                self.correlation_next.insert(*domain, sequence);
             }
         }
     }
@@ -1037,31 +914,6 @@ impl StreamState {
             })
     }
 
-    fn advance_correlation(&mut self, domain: u32) -> Result<Option<u32>> {
-        let Some(initial) = self.correlation_next.get(&domain).copied() else {
-            return Ok(None);
-        };
-        let mut next = initial;
-        while self.cross_stream.complete(domain, next) {
-            next = next
-                .checked_add(1)
-                .context("Scraper correlation cursor exhausted")?;
-        }
-        if next == initial {
-            return Ok(None);
-        }
-        self.correlation_next.insert(domain, next);
-        Ok(Some(next))
-    }
-
-    fn initialize_correlation(&mut self, domain: u32, sequence: u32) -> Option<u32> {
-        if self.correlation_next.contains_key(&domain) {
-            return None;
-        }
-        self.correlation_next.insert(domain, sequence);
-        Some(sequence)
-    }
-
     fn set_baseline(&mut self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
         if self.cursors.contains_key(&(domain, kind)) || sequence < 0 {
             return Ok(());
@@ -1075,9 +927,6 @@ impl StreamState {
     }
 
     fn validate_fresh_baseline(&self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
-        if sequence < 0 {
-            return Ok(());
-        }
         let Some(first) = self
             .cursors
             .get(&(domain, kind))
@@ -1085,15 +934,14 @@ impl StreamState {
         else {
             return Ok(());
         };
-        let baseline: u32 = sequence
+        let expected: u32 = sequence
+            .checked_add(1)
+            .context("Scraper caught-up sequence exhausted")?
             .try_into()
             .context("Scraper caught-up sequence exceeds u32")?;
-        let expected = baseline
-            .checked_add(1)
-            .context("Scraper caught-up sequence exhausted")?;
         if first != expected {
             bail!(
-                "Fresh {} scraper stream started at sequence {first}, expected {expected} after caught-up baseline {baseline}",
+                "Fresh {} scraper stream started at sequence {first}, expected {expected} after caught-up baseline {sequence}",
                 kind.label()
             );
         }
@@ -1106,11 +954,6 @@ impl StreamState {
             .get(&(domain, kind))
             .context("Validated scraper stream has no cursor")?
             .latest_sequence()
-    }
-
-    #[cfg(test)]
-    fn has_cursor(&self, domain: u32, kind: EventKind) -> bool {
-        self.cursors.contains_key(&(domain, kind))
     }
 
     fn validate(
@@ -1134,7 +977,7 @@ impl StreamState {
             .parse::<u32>()
             .context("Invalid scraper event sequence")?;
 
-        let (kind, fingerprint, projection, parity) = match event.event_type.as_str() {
+        let (kind, fingerprint, parity) = match event.event_type.as_str() {
             DISPATCH_EVENT_TYPE => {
                 let data: DispatchEventData =
                     serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
@@ -1189,10 +1032,6 @@ impl StreamState {
                 (
                     EventKind::Dispatch,
                     fingerprint,
-                    ProtocolProjection {
-                        block_number: origin_block_height,
-                        message_id,
-                    },
                     ParityInput::Dispatch {
                         block_number: origin_block_height,
                         message,
@@ -1225,10 +1064,6 @@ impl StreamState {
                         merkle_tree_hook.as_ref(),
                         message_id.as_ref(),
                     ]),
-                    ProtocolProjection {
-                        block_number,
-                        message_id,
-                    },
                     ParityInput::MerkleTreeInsertion {
                         block_number,
                         insertion: MerkleTreeInsertion::new(leaf_index, message_id),
@@ -1248,8 +1083,6 @@ impl StreamState {
             Some(cursor) => cursor.check(sequence, fingerprint)?,
             None => SequenceResult::Accepted,
         };
-        self.cross_stream
-            .validate(event.domain, sequence, kind, projection)?;
         if result == SequenceResult::Accepted {
             match self.cursors.get_mut(&key) {
                 Some(cursor) => cursor.accept(sequence, fingerprint)?,
@@ -1629,7 +1462,6 @@ impl HandshakeState {
 }
 
 struct ParityJob {
-    generation: u64,
     input: ParityInput,
     queue_permit: OwnedSemaphorePermit,
     sequence: u32,
@@ -1639,56 +1471,6 @@ struct ParityJob {
 struct ParityQueue {
     jobs: VecDeque<ParityJob>,
     worker_running: bool,
-}
-
-#[derive(Debug, Default)]
-struct CorrelationGateSource {
-    cross_next: Option<u32>,
-    dispatch_match: Option<u32>,
-    durable_next: Option<u32>,
-    failed: bool,
-    merkle_match: Option<u32>,
-}
-
-impl CorrelationGateSource {
-    fn anchored(next: Option<u32>) -> Self {
-        Self {
-            cross_next: next,
-            dispatch_match: None,
-            durable_next: next,
-            failed: false,
-            merkle_match: None,
-        }
-    }
-
-    fn matched_mut(&mut self, kind: EventKind) -> &mut Option<u32> {
-        match kind {
-            EventKind::Dispatch => &mut self.dispatch_match,
-            EventKind::GasPayment => unreachable!("gas payments do not enter parity correlation"),
-            EventKind::MerkleTreeInsertion => &mut self.merkle_match,
-        }
-    }
-
-    fn candidate(&self) -> Result<Option<u32>> {
-        let (Some(cross_next), Some(dispatch_match), Some(merkle_match)) =
-            (self.cross_next, self.dispatch_match, self.merkle_match)
-        else {
-            return Ok(None);
-        };
-        let dispatch_next = dispatch_match
-            .checked_add(1)
-            .context("Dispatch parity frontier exhausted")?;
-        let merkle_next = merkle_match
-            .checked_add(1)
-            .context("Merkle parity frontier exhausted")?;
-        Ok(Some(cross_next.min(dispatch_next).min(merkle_next)))
-    }
-}
-
-#[derive(Debug, Default)]
-struct CorrelationGate {
-    generation: u64,
-    sources: HashMap<u32, CorrelationGateSource>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1807,7 +1589,6 @@ pub(crate) struct ScraperWebSocketMonitor {
     degraded: IntGaugeVec,
     fresh: IntGaugeVec,
     freshness_warned_at: Arc<parking_lot::Mutex<Option<Instant>>>,
-    correlation_gate: parking_lot::Mutex<CorrelationGate>,
     events: IntCounterVec,
     parity: IntCounterVec,
     parity_pending: IntGaugeVec,
@@ -1866,7 +1647,7 @@ impl ScraperWebSocketMonitor {
         )?;
         let fresh = metrics.new_int_gauge(
             "relayer_scraper_websocket_fresh",
-            "Whether the durable scraper dispatch cursor matches the canonical finalized count",
+            "Whether the durable scraper sequenced cursors match their canonical finalized counts",
             &["chain"],
         )?;
         let parity = metrics.new_int_counter(
@@ -1937,7 +1718,6 @@ impl ScraperWebSocketMonitor {
             degraded,
             fresh,
             freshness_warned_at: Arc::new(parking_lot::Mutex::new(None)),
-            correlation_gate: parking_lot::Mutex::new(CorrelationGate::default()),
             events,
             parity,
             parity_pending,
@@ -1969,7 +1749,6 @@ impl ScraperWebSocketMonitor {
                 freshness_monitor.run_authority_freshness().await;
             });
         }
-        let mut generation = 0_u64;
         let mut state = loop {
             match StreamState::load_gas_payment(&monitor.sources) {
                 Ok(state) => break state,
@@ -1992,19 +1771,13 @@ impl ScraperWebSocketMonitor {
                     }
                 }
             };
-            let Some(next_generation) = generation.checked_add(1) else {
-                warn!("Scraper WebSocket connection generation exhausted; stopping monitor");
-                return;
-            };
-            generation = next_generation;
             state.reset_sequenced(&plan);
-            monitor.reset_correlation_gate(generation, &plan);
             monitor.deactivate_authority();
             monitor.set_active(false);
             monitor.set_caught_up(false);
             let gas_payment_cursors = monitor.gas_payment_cursors(&state);
             match monitor
-                .stream(&mut state, &plan, &gas_payment_cursors, generation)
+                .stream(&mut state, &plan, &gas_payment_cursors)
                 .await
             {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
@@ -2018,115 +1791,6 @@ impl ScraperWebSocketMonitor {
             monitor.deactivate_authority();
             sleep(RETRY_DELAY).await;
         }
-    }
-
-    fn reset_correlation_gate(&self, generation: u64, plan: &SequencedReplayPlan) {
-        let sources = plan
-            .sources
-            .iter()
-            .map(|(domain, source)| {
-                (
-                    *domain,
-                    CorrelationGateSource::anchored(source.correlation_next),
-                )
-            })
-            .collect();
-        *self.correlation_gate.lock() = CorrelationGate {
-            generation,
-            sources,
-        };
-    }
-
-    fn anchor_correlation_gate(&self, generation: u64, domain: u32, sequence: u32) {
-        let mut gate = self.correlation_gate.lock();
-        if gate.generation != generation {
-            return;
-        }
-        gate.sources
-            .entry(domain)
-            .and_modify(|source| {
-                if source.durable_next.is_none() {
-                    *source = CorrelationGateSource::anchored(Some(sequence));
-                }
-            })
-            .or_insert_with(|| CorrelationGateSource::anchored(Some(sequence)));
-    }
-
-    fn note_cross_stream_next(&self, generation: u64, domain: u32, next: u32) {
-        let mut gate = self.correlation_gate.lock();
-        if gate.generation != generation {
-            return;
-        }
-        if let Some(source) = gate.sources.get_mut(&domain) {
-            source.cross_next = Some(source.cross_next.map_or(next, |current| current.max(next)));
-        }
-    }
-
-    fn finish_parity_correlation(
-        &self,
-        generation: u64,
-        domain: u32,
-        kind: EventKind,
-        sequence: u32,
-        terminal: &'static str,
-    ) -> Result<()> {
-        let source = self
-            .sources
-            .get(&domain)
-            .context("Validated scraper source is missing")?;
-        let mut gate = self.correlation_gate.lock();
-        if generation == 0 {
-            return Ok(());
-        }
-        if gate.generation != generation {
-            return Ok(());
-        }
-        let state = gate
-            .sources
-            .get_mut(&domain)
-            .context("Correlation gate omitted configured source")?;
-        if state.failed {
-            return Ok(());
-        }
-        if terminal != ParityResult::Match.label() {
-            state.failed = true;
-            return Ok(());
-        }
-
-        let durable_next = state
-            .durable_next
-            .context("Correlation parity frontier is not anchored")?;
-        let matched = state.matched_mut(kind);
-        let expected = match *matched {
-            Some(latest) => latest
-                .checked_add(1)
-                .context("Scraper parity frontier exhausted")?,
-            None => durable_next,
-        };
-        if sequence < expected {
-            return Ok(());
-        }
-        if sequence > expected {
-            state.failed = true;
-            bail!("Scraper parity frontier gap: expected sequence {expected}, received {sequence}");
-        }
-        *matched = Some(sequence);
-
-        let Some(candidate) = state.candidate()? else {
-            return Ok(());
-        };
-        if state
-            .durable_next
-            .is_some_and(|durable| durable >= candidate)
-        {
-            return Ok(());
-        }
-        if let Err(err) = source.store_correlation_cursor(candidate) {
-            state.failed = true;
-            return Err(err);
-        }
-        state.durable_next = Some(candidate);
-        Ok(())
     }
 
     #[cfg(test)]
@@ -2313,7 +1977,6 @@ impl ScraperWebSocketMonitor {
         parity_input: ParityInput,
         sequence: u32,
     ) -> bool {
-        let generation = self.correlation_gate.lock().generation;
         if self.parity_read_disabled.load(Ordering::Acquire) {
             return false;
         }
@@ -2334,7 +1997,6 @@ impl ScraperWebSocketMonitor {
         let start_worker = {
             let mut queue = queue.lock();
             queue.jobs.push_back(ParityJob {
-                generation,
                 input: parity_input,
                 queue_permit,
                 sequence,
@@ -2375,22 +2037,9 @@ impl ScraperWebSocketMonitor {
 
     async fn admit_parity(
         self: &Arc<Self>,
-        state: &mut StreamState,
-        generation: u64,
         domain: u32,
         validated: StagedParityEvent,
     ) -> Result<()> {
-        if let Some(sequence) = state.initialize_correlation(domain, validated.sequence) {
-            let source = self
-                .sources
-                .get(&domain)
-                .context("Validated scraper source is missing")?;
-            source.store_correlation_cursor(sequence)?;
-            self.anchor_correlation_gate(generation, domain, sequence);
-        }
-        if let Some(next) = state.advance_correlation(domain)? {
-            self.note_cross_stream_next(generation, domain, next);
-        }
         if !self
             .enqueue_accounted_parity(domain, validated.kind, validated.parity, validated.sequence)
             .await
@@ -2405,17 +2054,13 @@ impl ScraperWebSocketMonitor {
         state: &mut StreamState,
         plan: &SequencedReplayPlan,
         caught_up: &HashMap<(u32, EventKind), i64>,
-        generation: u64,
         domain: u32,
         staged: &mut StagedParity,
     ) -> Result<()> {
         let mut ready = staged.drain_ready(plan, caught_up, state, domain)?;
         while let Some(validated) = ready.pop_front() {
             let kind = validated.kind;
-            if let Err(err) = self
-                .admit_parity(state, generation, domain, validated)
-                .await
-            {
+            if let Err(err) = self.admit_parity(domain, validated).await {
                 self.cancel_parity_pending(domain, kind);
                 for pending in ready {
                     self.cancel_parity_pending(domain, pending.kind);
@@ -2476,18 +2121,6 @@ impl ScraperWebSocketMonitor {
                 self.abandon_parity_queue(domain, kind, &queue);
                 return;
             }
-            if let Err(err) =
-                self.finish_parity_correlation(job.generation, domain, kind, job.sequence, terminal)
-            {
-                warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper correlation cursor failed; disabling parity work");
-                self.disable_parity_reads(
-                    source.chain.as_str(),
-                    kind.label(),
-                    "durable correlation cursor could not be persisted",
-                );
-                self.abandon_parity_queue(domain, kind, &queue);
-                return;
-            }
             drop(job.queue_permit);
         }
     }
@@ -2519,10 +2152,9 @@ impl ScraperWebSocketMonitor {
         let plan = SequencedReplayPlan::load(&self.sources)?;
         state.reset_sequenced(&plan);
         let gas_payment_cursors = self.gas_payment_cursors(state);
-        self.reset_correlation_gate(1, &plan);
         self.set_active(false);
         self.set_caught_up(false);
-        let result = self.stream(state, &plan, &gas_payment_cursors, 1).await;
+        let result = self.stream(state, &plan, &gas_payment_cursors).await;
         self.set_active(false);
         self.set_caught_up(false);
         result
@@ -2533,17 +2165,10 @@ impl ScraperWebSocketMonitor {
         state: &mut StreamState,
         plan: &SequencedReplayPlan,
         gas_payment_cursors: &[SubscribedCursor],
-        generation: u64,
     ) -> Result<()> {
         let mut staged_parity = StagedParity::default();
         let result = self
-            .stream_inner(
-                state,
-                plan,
-                gas_payment_cursors,
-                generation,
-                &mut staged_parity,
-            )
+            .stream_inner(state, plan, gas_payment_cursors, &mut staged_parity)
             .await;
         self.abandon_staged_parity(&mut staged_parity);
         result
@@ -2554,7 +2179,6 @@ impl ScraperWebSocketMonitor {
         state: &mut StreamState,
         plan: &SequencedReplayPlan,
         gas_payment_cursors: &[SubscribedCursor],
-        generation: u64,
         staged_parity: &mut StagedParity,
     ) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
@@ -2645,7 +2269,6 @@ impl ScraperWebSocketMonitor {
                                             state,
                                             plan,
                                             &caught_up,
-                                            generation,
                                             domain,
                                             staged_parity,
                                         )
@@ -2752,44 +2375,33 @@ impl ScraperWebSocketMonitor {
                             if sequence < -1 {
                                 bail!("Invalid negative scraper caught-up sequence {sequence}");
                             }
-                            validate_caught_up_floor(plan, domain, sequence)?;
-                            if !plan.correlation_required(domain)? {
+                            validate_caught_up_floor(plan, domain, kind, sequence)?;
+                            if plan.source(domain)?.floor(kind).is_none() {
                                 state.validate_fresh_baseline(domain, kind, sequence)?;
                             }
                             state.set_baseline(domain, kind, sequence)?;
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            if !plan.correlation_required(domain)?
-                                && !state.correlation_next.contains_key(&domain)
+                            if plan.source(domain)?.floor(kind).is_none()
+                                && sequence >= 0
+                                && self
+                                    .parity_pending
+                                    .with_label_values(&[source.chain.as_str(), kind.label()])
+                                    .get()
+                                    == 0
                             {
-                                let parity_pending =
-                                    [EventKind::Dispatch, EventKind::MerkleTreeInsertion]
-                                        .into_iter()
-                                        .map(|kind| {
-                                            self.parity_pending
-                                                .with_label_values(&[
-                                                    source.chain.as_str(),
-                                                    kind.label(),
-                                                ])
-                                                .get()
-                                        })
-                                        .sum::<i64>();
-                                if parity_pending == 0 {
-                                    if let Some(baselines) =
-                                        fresh_baseline_write_order(&caught_up, domain)?
-                                    {
-                                        for (kind, sequence) in baselines {
-                                            source.store_cursor(kind, sequence)?;
-                                        }
-                                    }
-                                }
+                                source.store_cursor(
+                                    kind,
+                                    sequence
+                                        .try_into()
+                                        .context("Scraper caught-up sequence exceeds u32")?,
+                                )?;
                             }
                             self.flush_staged_parity(
                                 state,
                                 plan,
                                 &caught_up,
-                                generation,
                                 domain,
                                 staged_parity,
                             )
@@ -3076,12 +2688,22 @@ impl ScraperWebSocketMonitor {
                     .freshness_indexer
                     .clone()
                     .context("Missing canonical dispatch freshness indexer")?;
-                let (canonical_count, _) = timeout(
+                let merkle_indexer = source
+                    .merkle_freshness_indexer
+                    .clone()
+                    .context("Missing canonical Merkle freshness indexer")?;
+                let (dispatch_canonical_count, _) = timeout(
                     AUTHORITY_FRESHNESS_TIMEOUT,
                     indexer.latest_sequence_count_and_tip(),
                 )
                 .await
                 .context("Canonical dispatch freshness probe timed out")??;
+                let (merkle_canonical_count, _) = timeout(
+                    AUTHORITY_FRESHNESS_TIMEOUT,
+                    merkle_indexer.latest_sequence_count_and_tip(),
+                )
+                .await
+                .context("Canonical Merkle freshness probe timed out")??;
                 let cursor_source = source.clone();
                 let cursor_read = async {
                     let permit = self
@@ -3098,13 +2720,12 @@ impl ScraperWebSocketMonitor {
                         Ok((
                             cursor_source.cursor(EventKind::Dispatch)?,
                             cursor_source.cursor(EventKind::MerkleTreeInsertion)?,
-                            cursor_source.correlation_cursor()?,
                         ))
                     })
                     .await
                     .context("Canonical scraper freshness cursor task failed")?
                 };
-                let (dispatch_cursor, merkle_cursor, correlation_cursor) =
+                let (dispatch_cursor, merkle_cursor) =
                     match timeout(PARITY_READ_TIMEOUT, cursor_read).await {
                         Ok(result) => result?,
                         Err(_) => {
@@ -3119,15 +2740,15 @@ impl ScraperWebSocketMonitor {
                 Ok::<_, eyre::Report>((
                     chain,
                     canonical_cursors_are_fresh(
-                        canonical_count,
+                        dispatch_canonical_count,
                         dispatch_cursor,
+                        merkle_canonical_count,
                         merkle_cursor,
-                        correlation_cursor,
                     )?,
-                    canonical_count,
+                    dispatch_canonical_count,
+                    merkle_canonical_count,
                     dispatch_cursor,
                     merkle_cursor,
-                    correlation_cursor,
                 ))
             })
             .buffer_unordered(AUTHORITY_FRESHNESS_CONCURRENCY)
@@ -3145,10 +2766,10 @@ impl ScraperWebSocketMonitor {
                     Ok((
                         chain,
                         is_fresh,
-                        canonical_count,
+                        dispatch_canonical_count,
+                        merkle_canonical_count,
                         dispatch_cursor,
                         merkle_cursor,
-                        correlation_cursor,
                     )) => {
                         self.fresh
                             .with_label_values(&[chain.as_str()])
@@ -3158,10 +2779,10 @@ impl ScraperWebSocketMonitor {
                             if should_warn(&self.freshness_warned_at) {
                                 warn!(
                                     %chain,
-                                    ?canonical_count,
+                                    ?dispatch_canonical_count,
+                                    ?merkle_canonical_count,
                                     ?dispatch_cursor,
                                     ?merkle_cursor,
-                                    ?correlation_cursor,
                                     "Scraper sequenced cursors are not canonically fresh"
                                 );
                             }
@@ -3205,11 +2826,11 @@ impl ScraperWebSocketMonitor {
     async fn update_source_caught_up(
         &self,
         state: &StreamState,
-        plan: &SequencedReplayPlan,
+        _plan: &SequencedReplayPlan,
         caught_up: &HashMap<(u32, EventKind), i64>,
         domain: u32,
     ) -> Result<()> {
-        if !source_caught_up(plan.correlation_required(domain)?, caught_up, state, domain)? {
+        if !source_caught_up(caught_up, state, domain)? {
             return Ok(());
         }
         let source = self
@@ -3250,10 +2871,10 @@ fn should_warn(warned_at: &parking_lot::Mutex<Option<Instant>>) -> bool {
 }
 
 fn canonical_cursors_are_fresh(
-    canonical_count: Option<u32>,
+    dispatch_canonical_count: Option<u32>,
     dispatch_cursor: Option<u32>,
+    merkle_canonical_count: Option<u32>,
     merkle_cursor: Option<u32>,
-    correlation_cursor: Option<u32>,
 ) -> Result<bool> {
     let cursor_count = |cursor: Option<u32>, label: &str| {
         cursor
@@ -3265,43 +2886,12 @@ fn canonical_cursors_are_fresh(
             .transpose()
             .map(|count| count.unwrap_or(0))
     };
-    let canonical_count = canonical_count.unwrap_or(0);
+    let dispatch_canonical_count = dispatch_canonical_count.unwrap_or(0);
+    let merkle_canonical_count = merkle_canonical_count.unwrap_or(0);
     Ok(
-        cursor_count(dispatch_cursor, "Dispatch")? == canonical_count
-            && cursor_count(merkle_cursor, "Merkle")? == canonical_count
-            && correlation_cursor.unwrap_or(0) == canonical_count,
+        cursor_count(dispatch_cursor, "Dispatch")? == dispatch_canonical_count
+            && cursor_count(merkle_cursor, "Merkle")? == merkle_canonical_count,
     )
-}
-
-#[cfg(test)]
-fn fresh_baseline_allowed(
-    correlation_required: bool,
-    replay_seen: bool,
-    parity_pending: i64,
-) -> bool {
-    !correlation_required && !replay_seen && parity_pending == 0
-}
-
-#[cfg(test)]
-fn store_fresh_caught_up_baseline(
-    source: &ScraperSource,
-    kind: EventKind,
-    sequence: i64,
-    replay_floor: Option<u32>,
-    correlation_required: bool,
-    replay_seen: bool,
-    parity_pending: i64,
-) -> Result<()> {
-    if replay_floor.is_none()
-        && sequence >= 0
-        && fresh_baseline_allowed(correlation_required, replay_seen, parity_pending)
-    {
-        let durable: u32 = sequence
-            .try_into()
-            .context("Scraper caught-up sequence exceeds u32")?;
-        source.store_cursor(kind, durable)?;
-    }
-    Ok(())
 }
 
 fn subscription(
@@ -3379,7 +2969,10 @@ fn sequence_cursor(
     Ok(SequenceCursor {
         address: scraper_address(source.address(kind)),
         allow_replay: Some(true),
-        after_sequence: plan.source(source.domain)?.floor.map(replay_after_sequence),
+        after_sequence: plan
+            .source(source.domain)?
+            .floor(kind)
+            .map(replay_after_sequence),
         domain: source.domain,
     })
 }
@@ -3410,30 +3003,18 @@ fn sequenced_subscription_cursors(
         .collect()
 }
 
-fn validate_caught_up_floor(plan: &SequencedReplayPlan, domain: u32, sequence: i64) -> Result<()> {
-    if let Some(floor) = plan.source(domain)?.floor {
+fn validate_caught_up_floor(
+    plan: &SequencedReplayPlan,
+    domain: u32,
+    kind: EventKind,
+    sequence: i64,
+) -> Result<()> {
+    if let Some(floor) = plan.source(domain)?.floor(kind) {
         if sequence < i64::from(floor) {
             bail!("Scraper caught-up sequence {sequence} is behind replay floor {floor}");
         }
     }
     Ok(())
-}
-
-fn correlation_ready(
-    required: bool,
-    state: &StreamState,
-    domain: u32,
-    sequence: i64,
-) -> Result<bool> {
-    if sequence < 0 || !required {
-        return Ok(true);
-    }
-    Ok(state.cross_stream.complete(
-        domain,
-        sequence
-            .try_into()
-            .context("Caught-up sequence exceeds u32")?,
-    ))
 }
 
 fn caught_up_baselines(
@@ -3446,112 +3027,28 @@ fn caught_up_baselines(
     ))
 }
 
-fn validate_fresh_empty_stream_starts(state: &StreamState, domain: u32) -> Result<()> {
-    for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
-        let Some(cursor) = state.cursors.get(&(domain, kind)) else {
-            continue;
-        };
-        let first = cursor
-            .first_sequence
-            .context("Fresh scraper stream cursor omitted its first fingerprint")?;
-        if first != 0 {
-            bail!(
-                "Fresh empty {} scraper stream started at sequence {first}, expected 0",
-                kind.label()
-            );
-        }
-    }
-    Ok(())
-}
-
-fn sequenced_persistence_frontier(
-    plan: &SequencedReplayPlan,
-    caught_up: &HashMap<(u32, EventKind), i64>,
-    state: &StreamState,
-    domain: u32,
-) -> Result<Option<u32>> {
-    if plan.correlation_required(domain)? {
-        return Ok(Some(u32::MAX));
-    }
-    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
-        return Ok(None);
-    };
-    if dispatch != merkle {
-        return Ok(None);
-    }
-    if dispatch >= 0 {
-        return Ok(Some(u32::MAX));
-    }
-    validate_fresh_empty_stream_starts(state, domain)?;
-    let mut sequence = state.correlation_next.get(&domain).copied().unwrap_or(0);
-    let mut frontier = None;
-    while state.cross_stream.complete(domain, sequence) {
-        frontier = Some(sequence);
-        let Some(next) = sequence.checked_add(1) else {
-            break;
-        };
-        sequence = next;
-    }
-    Ok(frontier)
-}
-
-#[cfg(test)]
 fn sequenced_persistence_ready(
     plan: &SequencedReplayPlan,
     caught_up: &HashMap<(u32, EventKind), i64>,
     state: &StreamState,
     domain: u32,
+    kind: EventKind,
     sequence: u32,
 ) -> Result<bool> {
-    Ok(
-        sequenced_persistence_frontier(plan, caught_up, state, domain)?
-            .is_some_and(|frontier| sequence <= frontier),
-    )
-}
-
-fn cursor_write_order(dispatch: u32, merkle: u32) -> [(EventKind, u32); 2] {
-    if dispatch <= merkle {
-        [
-            (EventKind::Dispatch, dispatch),
-            (EventKind::MerkleTreeInsertion, merkle),
-        ]
-    } else {
-        [
-            (EventKind::MerkleTreeInsertion, merkle),
-            (EventKind::Dispatch, dispatch),
-        ]
+    if plan.source(domain)?.floor(kind).is_some() {
+        return Ok(true);
     }
-}
-
-#[cfg(test)]
-fn sequenced_cursor_write_order(state: &StreamState, domain: u32) -> Result<[(EventKind, u32); 2]> {
-    Ok(cursor_write_order(
-        state.latest_sequence(domain, EventKind::Dispatch)?,
-        state.latest_sequence(domain, EventKind::MerkleTreeInsertion)?,
-    ))
-}
-
-fn fresh_baseline_write_order(
-    caught_up: &HashMap<(u32, EventKind), i64>,
-    domain: u32,
-) -> Result<Option<[(EventKind, u32); 2]>> {
-    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
-        return Ok(None);
+    let Some(baseline) = caught_up.get(&(domain, kind)).copied() else {
+        return Ok(false);
     };
-    if dispatch < 0 || merkle < 0 {
-        return Ok(None);
-    }
-    let dispatch: u32 = dispatch
-        .try_into()
-        .context("Scraper caught-up sequence exceeds u32")?;
-    let merkle: u32 = merkle
-        .try_into()
-        .context("Scraper caught-up sequence exceeds u32")?;
-    Ok(Some(cursor_write_order(dispatch, merkle)))
+    state.validate_fresh_baseline(domain, kind, baseline)?;
+    let expected = baseline
+        .checked_add(1)
+        .context("Scraper caught-up sequence exhausted")?;
+    Ok(i64::from(sequence) >= expected)
 }
 
 fn source_caught_up(
-    correlation_required: bool,
     caught_up: &HashMap<(u32, EventKind), i64>,
     state: &StreamState,
     domain: u32,
@@ -3559,38 +3056,22 @@ fn source_caught_up(
     let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
         return Ok(false);
     };
-    if !correlation_required {
-        if dispatch != merkle {
-            bail!("Fresh scraper caught-up baselines differ: dispatch {dispatch}, Merkle {merkle}");
+    for (kind, target) in [
+        (EventKind::Dispatch, dispatch),
+        (EventKind::MerkleTreeInsertion, merkle),
+    ] {
+        if target < 0 {
+            state.validate_fresh_baseline(domain, kind, target)?;
+            continue;
         }
-        if dispatch < 0 {
-            validate_fresh_empty_stream_starts(state, domain)?;
-        }
-        return Ok(true);
-    }
-    let target = dispatch.max(merkle);
-    if target < 0 {
-        return Ok(true);
-    }
-    let target: u32 = target
-        .try_into()
-        .context("Caught-up sequence exceeds u32")?;
-    for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
         let Some(cursor) = state.cursors.get(&(domain, kind)) else {
             return Ok(false);
         };
-        if cursor.latest_sequence()? < target {
+        if i64::from(cursor.latest_sequence()?) < target {
             return Ok(false);
         }
     }
-    if state
-        .correlation_next
-        .get(&domain)
-        .is_none_or(|next| *next <= target)
-    {
-        return Ok(false);
-    }
-    correlation_ready(true, state, domain, i64::from(target))
+    Ok(true)
 }
 
 fn validate_subscription(
@@ -3781,6 +3262,27 @@ mod tests {
 
     #[async_trait]
     impl SequenceAwareIndexer<HyperlaneMessage> for FixedSequenceIndexer {
+        async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
+            Ok((Some(self.0), 0))
+        }
+    }
+
+    #[async_trait]
+    impl Indexer<MerkleTreeInsertion> for FixedSequenceIndexer {
+        async fn fetch_logs_in_range(
+            &self,
+            _range: RangeInclusive<u32>,
+        ) -> ChainResult<Vec<(Indexed<MerkleTreeInsertion>, LogMeta)>> {
+            unreachable!("freshness tests only query the sequence count")
+        }
+
+        async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+            unreachable!("freshness tests only query the sequence count")
+        }
+    }
+
+    #[async_trait]
+    impl SequenceAwareIndexer<MerkleTreeInsertion> for FixedSequenceIndexer {
         async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
             Ok((Some(self.0), 0))
         }
@@ -4040,23 +3542,19 @@ mod tests {
     }
 
     #[test]
-    fn canonical_freshness_requires_complete_correlated_frontier() {
+    fn canonical_freshness_compares_each_stream_to_its_own_count() {
         assert!(canonical_cursors_are_fresh(None, None, None, None).expect("empty chain is fresh"));
         assert!(
-            canonical_cursors_are_fresh(Some(10), Some(9), Some(9), Some(10))
-                .expect("matching cursors are fresh")
+            canonical_cursors_are_fresh(Some(111), Some(110), Some(101), Some(100))
+                .expect("each stream cursor matches its canonical count")
         );
         assert!(
-            !canonical_cursors_are_fresh(Some(10), Some(9), Some(8), Some(10))
+            !canonical_cursors_are_fresh(Some(111), Some(110), Some(101), Some(99))
                 .expect("lagging Merkle cursor is stale")
         );
         assert!(
-            !canonical_cursors_are_fresh(Some(10), Some(9), Some(9), Some(9))
-                .expect("lagging correlation cursor is stale")
-        );
-        assert!(
-            !canonical_cursors_are_fresh(Some(11), Some(9), Some(9), Some(10))
-                .expect("lagging sequenced cursors are stale")
+            !canonical_cursors_are_fresh(Some(111), Some(109), Some(101), Some(100))
+                .expect("lagging dispatch cursor is stale")
         );
         assert!(canonical_cursors_are_fresh(
             Some(u32::MAX),
@@ -4067,8 +3565,59 @@ mod tests {
         .is_err());
     }
 
+    #[test]
+    fn unequal_stream_tips_resume_and_catch_up_independently() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store Merkle cursor");
+
+        let plan = replay_plan(&sources);
+        let mut state = replay_state(&plan);
+        let source_plan = plan.source(5).expect("source plan");
+        assert_eq!(source_plan.dispatch_floor, Some(100));
+        assert_eq!(source_plan.merkle_floor, Some(90));
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 100, dispatch_data(100, b"dispatch")),
+                &sources,
+            )
+            .expect("replay dispatch boundary");
+        state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    90,
+                    merkle_data_for(90, H256::from_low_u64_be(2), H256::from_low_u64_be(90), 100),
+                ),
+                &sources,
+            )
+            .expect("replay Merkle boundary");
+        assert!(source_caught_up(
+            &HashMap::from([
+                ((5, EventKind::Dispatch), 100),
+                ((5, EventKind::MerkleTreeInsertion), 90),
+            ]),
+            &state,
+            5,
+        )
+        .expect("independent caught-up frontiers"));
+
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan, &gas_payment_cursors(), true)
+                .expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "99");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+    }
+
     #[tokio::test]
-    async fn canonical_freshness_restores_fallback_then_reacquires_after_pairing() {
+    async fn canonical_freshness_restores_fallback_then_reacquires() {
         let fixture = fixture();
         let mut source = fixture.sources[&5].clone();
         source
@@ -4077,10 +3626,9 @@ mod tests {
         source
             .store_cursor(EventKind::MerkleTreeInsertion, 8)
             .expect("store lagging Merkle cursor");
-        source
-            .store_correlation_cursor(9)
-            .expect("store lagging correlation cursor");
-        source = source.with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
+        source = source
+            .with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)))
+            .with_merkle_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
         let metrics = CoreMetrics::new("scraper-authority-frontier-test", 9090, Registry::new())
             .expect("create test metrics");
         let monitor = ScraperWebSocketMonitor::new_with_authority(
@@ -4118,9 +3666,6 @@ mod tests {
         source
             .store_cursor(EventKind::MerkleTreeInsertion, 9)
             .expect("advance Merkle cursor");
-        source
-            .store_correlation_cursor(10)
-            .expect("advance correlation cursor");
         let refresh = monitor.refresh_authority_once();
         tokio::pin!(refresh);
         assert!(timeout(Duration::from_millis(10), &mut refresh)
@@ -4140,16 +3685,14 @@ mod tests {
         let fixture = fixture();
         let source = fixture.sources[&5]
             .clone()
-            .with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
+            .with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)))
+            .with_merkle_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
         source
             .store_cursor(EventKind::Dispatch, 9)
             .expect("dispatch cursor");
         source
             .store_cursor(EventKind::MerkleTreeInsertion, 9)
             .expect("Merkle cursor");
-        source
-            .store_correlation_cursor(10)
-            .expect("correlation cursor");
         let metrics = CoreMetrics::new("scraper-gas-freshness-test", 9090, Registry::new())
             .expect("test metrics");
         let monitor = Arc::new(
@@ -4233,7 +3776,8 @@ mod tests {
         let fixture = fixture();
         let source = fixture.sources[&5]
             .clone()
-            .with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
+            .with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)))
+            .with_merkle_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
         let metrics = CoreMetrics::new("scraper-freshness-timeout-test", 9090, Registry::new())
             .expect("create test metrics");
         let monitor = ScraperWebSocketMonitor::new_with_authority(
@@ -4844,7 +4388,6 @@ mod tests {
             stream_cursor: 41,
         };
         let mut state = StreamState::default();
-        state.correlation_next.insert(5, 99);
         state.cursors.insert(
             (5, EventKind::Dispatch),
             StreamCursor::from_durable_sequence(99),
@@ -4854,7 +4397,6 @@ mod tests {
 
         state.reset_sequenced(&plan);
 
-        assert!(state.correlation_next.is_empty());
         assert!(state.cursors.is_empty());
         assert_eq!(state.gas_payment_degraded, HashSet::from([5]));
         assert_eq!(state.gas_payment_rows, HashMap::from([(5, cursor)]));
@@ -4892,7 +4434,7 @@ mod tests {
                 .expect("initial subscription"),
         )
         .expect("initial subscription JSON");
-        assert_eq!(initial["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(initial["streams"][0]["cursors"][0]["afterSequence"], "99");
         assert_eq!(
             initial["streams"][2]["cursors"][0]["afterStreamCursor"],
             "41"
@@ -4901,9 +4443,6 @@ mod tests {
         source
             .store_cursor(EventKind::MerkleTreeInsertion, 100)
             .expect("advance Merkle cursor");
-        source
-            .store_correlation_cursor(100)
-            .expect("advance correlated cursor");
         let reconnect_plan = replay_plan(sources);
         state.reset_sequenced(&reconnect_plan);
         assert_eq!(state.gas_payment_rows[&5].stream_cursor, 41);
@@ -5015,41 +4554,6 @@ mod tests {
     }
 
     #[test]
-    fn caught_up_does_not_jump_pending_replay_cursor() {
-        let sources = sources();
-        let source = &sources[&5];
-        let mut replay = StreamState::default();
-        replay
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"pending")),
-                &sources,
-            )
-            .expect("replayed event");
-
-        store_fresh_caught_up_baseline(
-            source,
-            EventKind::Dispatch,
-            20,
-            None,
-            false,
-            replay.has_cursor(5, EventKind::Dispatch),
-            1,
-        )
-        .expect("skip baseline with replay pending");
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("cursor read"),
-            None
-        );
-
-        store_fresh_caught_up_baseline(source, EventKind::Dispatch, 20, None, false, false, 0)
-            .expect("store true fresh-start baseline");
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("cursor read"),
-            Some(20)
-        );
-    }
-
-    #[test]
     fn restores_durable_sequence_after_process_restart() {
         let sources = sources();
         let initial_plan = replay_plan(&sources);
@@ -5086,404 +4590,6 @@ mod tests {
                 &sources,
             )
             .expect("replayed event after durable cursor");
-    }
-
-    #[test]
-    fn fresh_event_anchors_correlation_before_stream_cursor() {
-        let sources = sources();
-        let source = &sources[&5];
-        let plan = replay_plan(&sources);
-        let mut state = replay_state(&plan);
-        state
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
-                &sources,
-            )
-            .expect("first event");
-
-        let sequence = state
-            .latest_sequence(5, EventKind::Dispatch)
-            .expect("dispatch cursor");
-        let anchor = state
-            .initialize_correlation(5, sequence)
-            .expect("fresh correlation anchor");
-        source
-            .store_correlation_cursor(anchor)
-            .expect("store correlation anchor");
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            Some(7)
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-
-        source
-            .store_cursor(EventKind::Dispatch, sequence)
-            .expect("store dispatch cursor");
-        let restart_plan = replay_plan(&sources);
-        assert_eq!(restart_plan.source(5).expect("source plan").floor, Some(7));
-    }
-
-    #[test]
-    fn restart_replays_both_stream_boundaries_before_caught_up() {
-        let sources = sources();
-        let source = &sources[&5];
-        source
-            .store_cursor(EventKind::Dispatch, 100)
-            .expect("store dispatch cursor");
-        source
-            .store_cursor(EventKind::MerkleTreeInsertion, 90)
-            .expect("store Merkle cursor");
-        let initial_plan = replay_plan(&sources);
-        assert_eq!(initial_plan.source(5).expect("source plan").floor, Some(90));
-        let request: serde_json::Value = serde_json::from_str(
-            &subscription(&sources, &initial_plan, &gas_payment_cursors(), true)
-                .expect("subscription should serialize"),
-        )
-        .expect("subscription JSON");
-        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
-        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
-
-        let mut healing = replay_state(&initial_plan);
-        for sequence in 90_u32..=100 {
-            let body = sequence.to_be_bytes();
-            let message_id = dispatch_message(sequence, &body).id();
-            healing
-                .validate(
-                    event(
-                        MERKLE_EVENT_TYPE,
-                        sequence,
-                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
-                    ),
-                    &sources,
-                )
-                .expect("replay Merkle event");
-            source
-                .store_cursor(EventKind::MerkleTreeInsertion, sequence)
-                .expect("store Merkle cursor");
-            assert_eq!(
-                healing.advance_correlation(5).expect("advance correlation"),
-                None
-            );
-        }
-        for sequence in 90_u32..=95 {
-            let body = sequence.to_be_bytes();
-            if sequence == 95 {
-                assert!(healing
-                    .validate(
-                        event(
-                            DISPATCH_EVENT_TYPE,
-                            sequence,
-                            dispatch_data(sequence, b"wrong")
-                        ),
-                        &sources,
-                    )
-                    .expect_err("mismatch below high cursor must reject")
-                    .to_string()
-                    .contains("message IDs differ"));
-            }
-            healing
-                .validate(
-                    event(
-                        DISPATCH_EVENT_TYPE,
-                        sequence,
-                        dispatch_data(sequence, &body),
-                    ),
-                    &sources,
-                )
-                .expect("replay dispatch event");
-            source
-                .store_cursor(EventKind::Dispatch, sequence)
-                .expect("store dispatch cursor");
-            if let Some(next) = healing.advance_correlation(5).expect("advance correlation") {
-                source
-                    .store_correlation_cursor(next)
-                    .expect("store correlation cursor");
-            }
-        }
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            Some(96)
-        );
-
-        let restart_plan = replay_plan(&sources);
-        assert_eq!(restart_plan.source(5).expect("source plan").floor, Some(96));
-        let restart_subscription: serde_json::Value = serde_json::from_str(
-            &subscription(&sources, &restart_plan, &gas_payment_cursors(), true)
-                .expect("subscription should serialize"),
-        )
-        .expect("subscription JSON");
-        assert_eq!(
-            restart_subscription["streams"][0]["cursors"][0]["afterSequence"],
-            "95"
-        );
-        assert_eq!(
-            restart_subscription["streams"][1]["cursors"][0]["afterSequence"],
-            "95"
-        );
-
-        let mut restarted = replay_state(&restart_plan);
-        for sequence in 96_u32..=100 {
-            let body = sequence.to_be_bytes();
-            let message_id = dispatch_message(sequence, &body).id();
-            restarted
-                .validate(
-                    event(
-                        DISPATCH_EVENT_TYPE,
-                        sequence,
-                        dispatch_data(sequence, &body),
-                    ),
-                    &sources,
-                )
-                .expect("replay dispatch event after crash");
-            source
-                .store_cursor(EventKind::Dispatch, sequence)
-                .expect("store dispatch cursor");
-            restarted
-                .validate(
-                    event(
-                        MERKLE_EVENT_TYPE,
-                        sequence,
-                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
-                    ),
-                    &sources,
-                )
-                .expect("replay Merkle event after crash");
-            source
-                .store_cursor(EventKind::MerkleTreeInsertion, sequence)
-                .expect("store Merkle cursor");
-            if let Some(next) = restarted
-                .advance_correlation(5)
-                .expect("advance correlation")
-            {
-                source
-                    .store_correlation_cursor(next)
-                    .expect("store correlation cursor");
-            }
-        }
-        assert!((96_u32..=100).all(|sequence| restarted.cross_stream.complete(5, sequence)));
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            Some(101)
-        );
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), 100),
-            ((5, EventKind::MerkleTreeInsertion), 100),
-        ]);
-        assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
-    }
-
-    #[test]
-    fn fresh_unequal_baselines_reconnect_at_common_floor() {
-        let sources = sources();
-        let source = &sources[&5];
-        let initial_plan = replay_plan(&sources);
-        assert!(!initial_plan
-            .correlation_required(5)
-            .expect("correlation requirement"));
-
-        let mut state = replay_state(&initial_plan);
-        state
-            .set_baseline(5, EventKind::Dispatch, 100)
-            .expect("set fresh dispatch baseline");
-        let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
-        assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one fresh marker"));
-        assert_eq!(
-            fresh_baseline_write_order(&caught_up, 5).expect("baseline order"),
-            None
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-
-        state
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 101, dispatch_data(101, b"one-oh-one")),
-                &sources,
-            )
-            .expect("fresh live event after first marker");
-        assert!(
-            !sequenced_persistence_ready(&initial_plan, &caught_up, &state, 5, 101)
-                .expect("persistence readiness")
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            None
-        );
-        state
-            .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
-            .expect("set fresh Merkle baseline");
-        caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
-        let baselines = fresh_baseline_write_order(&caught_up, 5)
-            .expect("baseline order")
-            .expect("both baselines");
-        assert_eq!(
-            baselines,
-            [
-                (EventKind::MerkleTreeInsertion, 90),
-                (EventKind::Dispatch, 100),
-            ]
-        );
-        source
-            .store_cursor(baselines[0].0, baselines[0].1)
-            .expect("store lower fresh baseline");
-
-        let interrupted_plan = replay_plan(&sources);
-        assert_eq!(
-            interrupted_plan.source(5).expect("source plan").floor,
-            Some(90)
-        );
-        source
-            .store_cursor(baselines[1].0, baselines[1].1)
-            .expect("store higher fresh baseline");
-        assert!(source_caught_up(false, &caught_up, &state, 5)
-            .expect_err("unequal fresh baselines must reconnect")
-            .to_string()
-            .contains("Fresh scraper caught-up baselines differ"));
-
-        let reconnect_plan = replay_plan(&sources);
-        let source_plan = reconnect_plan.source(5).expect("source plan");
-        assert_eq!(source_plan.floor, Some(90));
-        assert_eq!(source_plan.correlation_next, Some(90));
-        assert!(reconnect_plan
-            .correlation_required(5)
-            .expect("correlation requirement"));
-        let request: serde_json::Value = serde_json::from_str(
-            &subscription(&sources, &reconnect_plan, &gas_payment_cursors(), true)
-                .expect("subscription should serialize"),
-        )
-        .expect("subscription JSON");
-        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
-        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
-    }
-
-    #[test]
-    fn fresh_equal_baselines_preserve_readiness() {
-        let sources = sources();
-        let source = &sources[&5];
-        let plan = replay_plan(&sources);
-        let mut state = replay_state(&plan);
-        state
-            .set_baseline(5, EventKind::Dispatch, 100)
-            .expect("set fresh dispatch baseline");
-        state
-            .set_baseline(5, EventKind::MerkleTreeInsertion, 100)
-            .expect("set fresh Merkle baseline");
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), 100),
-            ((5, EventKind::MerkleTreeInsertion), 100),
-        ]);
-        let baselines = fresh_baseline_write_order(&caught_up, 5)
-            .expect("baseline order")
-            .expect("both baselines");
-        for (kind, sequence) in baselines {
-            source
-                .store_cursor(kind, sequence)
-                .expect("store equal fresh baseline");
-        }
-
-        assert!(source_caught_up(false, &caught_up, &state, 5).expect("readiness check"));
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            Some(100)
-        );
-        assert_eq!(
-            source
-                .cursor(EventKind::MerkleTreeInsertion)
-                .expect("Merkle cursor"),
-            Some(100)
-        );
-    }
-
-    #[test]
-    fn fresh_negative_lower_baseline_persists_neither_tip() {
-        let sources = sources();
-        let source = &sources[&5];
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), 100),
-            ((5, EventKind::MerkleTreeInsertion), -1),
-        ]);
-
-        assert_eq!(
-            fresh_baseline_write_order(&caught_up, 5).expect("baseline order"),
-            None
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-        assert_eq!(
-            source
-                .cursor(EventKind::MerkleTreeInsertion)
-                .expect("Merkle cursor"),
-            None
-        );
-        assert!(
-            source_caught_up(false, &caught_up, &StreamState::default(), 5)
-                .expect_err("negative unequal fresh baselines must reconnect")
-                .to_string()
-                .contains("Fresh scraper caught-up baselines differ")
-        );
-    }
-
-    #[test]
-    fn staged_parity_does_not_cross_unequal_fresh_markers() {
-        let sources = sources();
-        let source = &sources[&5];
-        let plan = replay_plan(&sources);
-        let mut state = replay_state(&plan);
-        let mut staged = StagedParity::default();
-        let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
-        state
-            .set_baseline(5, EventKind::Dispatch, 100)
-            .expect("set dispatch marker");
-        staged
-            .push(
-                5,
-                state
-                    .validate(
-                        event(DISPATCH_EVENT_TYPE, 101, dispatch_data(101, b"one-oh-one")),
-                        &sources,
-                    )
-                    .expect("stage dispatch after first marker"),
-            )
-            .expect("stage parity");
-        assert!(staged
-            .drain_ready(&plan, &caught_up, &state, 5)
-            .expect("read staged frontier")
-            .is_empty());
-
-        state
-            .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
-            .expect("set delayed Merkle marker");
-        caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
-        assert!(staged
-            .drain_ready(&plan, &caught_up, &state, 5)
-            .expect("unequal markers do not admit parity")
-            .is_empty());
-        assert_eq!(staged.len, 1);
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-
-        let baselines = fresh_baseline_write_order(&caught_up, 5)
-            .expect("baseline order")
-            .expect("both positive baselines");
-        source
-            .store_cursor(baselines[0].0, baselines[0].1)
-            .expect("persist lower baseline before reconnect");
-        assert_eq!(
-            replay_plan(&sources).source(5).expect("source plan").floor,
-            Some(90)
-        );
     }
 
     #[test]
@@ -5524,10 +4630,6 @@ mod tests {
                 .contains("expected 101"));
             assert_eq!(staged.len, 1, "rejected parity remains unadmitted");
             assert_eq!(source.cursor(kind).expect("stream cursor"), None);
-            assert_eq!(
-                source.correlation_cursor().expect("correlation cursor"),
-                None
-            );
 
             let mut contiguous = StreamState::default();
             contiguous
@@ -5594,10 +4696,11 @@ mod tests {
             ready,
             vec![
                 (EventKind::Dispatch, 0),
+                (EventKind::Dispatch, 1),
                 (EventKind::MerkleTreeInsertion, 0),
             ]
         );
-        assert_eq!(staged.len, 1, "dispatch one waits for Merkle one");
+        assert_eq!(staged.len, 0);
 
         staged
             .push(
@@ -5622,156 +4725,13 @@ mod tests {
         assert_eq!(
             staged
                 .drain_ready(&plan, &caught_up, &state, 5)
-                .expect("drain next complete pair")
+                .expect("drain next ready event")
                 .into_iter()
                 .map(|event| (event.kind, event.sequence))
                 .collect::<Vec<_>>(),
-            vec![
-                (EventKind::Dispatch, 1),
-                (EventKind::MerkleTreeInsertion, 1),
-            ]
+            vec![(EventKind::MerkleTreeInsertion, 1)]
         );
         assert_eq!(staged.len, 0);
-    }
-
-    #[test]
-    fn fresh_empty_parity_advances_beyond_cross_stream_window() {
-        let sources = sources();
-        let source = &sources[&5];
-        let plan = replay_plan(&sources);
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), -1),
-            ((5, EventKind::MerkleTreeInsertion), -1),
-        ]);
-        let mut state = replay_state(&plan);
-        let mut staged = StagedParity::default();
-
-        for sequence in 0..=CROSS_STREAM_WINDOW as u32 {
-            let body = sequence.to_be_bytes();
-            let message_id = dispatch_message(sequence, &body).id();
-            let dispatch = state
-                .validate(
-                    event(
-                        DISPATCH_EVENT_TYPE,
-                        sequence,
-                        dispatch_data(sequence, &body),
-                    ),
-                    &sources,
-                )
-                .expect("validate dispatch");
-            staged.push(5, dispatch).expect("stage dispatch");
-            assert!(staged
-                .drain_ready(&plan, &caught_up, &state, 5)
-                .expect("hold incomplete pair")
-                .is_empty());
-
-            let merkle = state
-                .validate(
-                    event(
-                        MERKLE_EVENT_TYPE,
-                        sequence,
-                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
-                    ),
-                    &sources,
-                )
-                .expect("validate Merkle insertion");
-            staged.push(5, merkle).expect("stage Merkle insertion");
-            let ready = staged
-                .drain_ready(&plan, &caught_up, &state, 5)
-                .expect("drain complete pair");
-            assert_eq!(ready.len(), 2);
-
-            if let Some(anchor) = state.initialize_correlation(5, sequence) {
-                source
-                    .store_correlation_cursor(anchor)
-                    .expect("store correlation anchor");
-            }
-            let next = state
-                .advance_correlation(5)
-                .expect("advance correlation")
-                .expect("complete pair advances correlation");
-            source
-                .store_correlation_cursor(next)
-                .expect("store correlation frontier");
-        }
-
-        assert_eq!(staged.len, 0);
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            Some(CROSS_STREAM_WINDOW as u32 + 1)
-        );
-    }
-
-    #[tokio::test]
-    async fn fresh_empty_parity_anchors_replay_before_queue_admission() {
-        let monitor = Arc::new(monitor(Arc::new(MockParityDatabase::new())));
-        monitor.parity_read_disabled.store(true, Ordering::Release);
-        let plan = replay_plan(&monitor.sources);
-        monitor.reset_correlation_gate(1, &plan);
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), -1),
-            ((5, EventKind::MerkleTreeInsertion), -1),
-        ]);
-        let mut state = replay_state(&plan);
-        let mut staged = StagedParity::default();
-
-        for event in [
-            event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"zero")),
-            event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
-        ] {
-            let validated = state
-                .validate(event, &monitor.sources)
-                .expect("validate dispatch");
-            staged.push(5, validated).expect("stage dispatch");
-            monitor
-                .flush_staged_parity(&mut state, &plan, &caught_up, 1, 5, &mut staged)
-                .await
-                .expect("unpaired dispatch remains staged");
-        }
-        assert_eq!(
-            monitor.sources[&5]
-                .correlation_cursor()
-                .expect("correlation cursor"),
-            None
-        );
-
-        let merkle_zero = state
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    0,
-                    merkle_data_for(
-                        0,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(0, b"zero").id(),
-                        100,
-                    ),
-                ),
-                &monitor.sources,
-            )
-            .expect("validate Merkle zero");
-        staged.push(5, merkle_zero).expect("stage Merkle zero");
-        monitor
-            .flush_staged_parity(&mut state, &plan, &caught_up, 1, 5, &mut staged)
-            .await
-            .expect("admit complete zero pair");
-
-        assert_eq!(
-            monitor.sources[&5]
-                .correlation_cursor()
-                .expect("correlation cursor"),
-            Some(0),
-            "the replay anchor is durable before parity workers can advance"
-        );
-        let gate = monitor.correlation_gate.lock();
-        let gate_source = gate.sources.get(&5).expect("correlation gate source");
-        assert_eq!(gate_source.durable_next, Some(0));
-        assert_eq!(gate_source.cross_next, Some(1));
-        drop(gate);
-        assert_eq!(staged.len, 1, "dispatch one waits for Merkle one");
-        for queue in monitor.parity_queues.values() {
-            assert!(queue.lock().jobs.is_empty(), "parity reads are disabled");
-        }
     }
 
     #[test]
@@ -5804,164 +4764,6 @@ mod tests {
     }
 
     #[test]
-    fn fresh_empty_baselines_wait_for_first_complete_pair() {
-        let sources = sources();
-        let source = &sources[&5];
-        let plan = replay_plan(&sources);
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), -1),
-            ((5, EventKind::MerkleTreeInsertion), -1),
-        ]);
-        let mut skipped = replay_state(&plan);
-        skipped
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 5, dispatch_data(5, b"five")),
-                &sources,
-            )
-            .expect("first nonzero dispatch event");
-        assert!(
-            sequenced_persistence_ready(&plan, &caught_up, &skipped, 5, 5)
-                .expect_err("empty stream must start at zero")
-                .to_string()
-                .contains("expected 0")
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-
-        let mut state = replay_state(&plan);
-        state
-            .set_baseline(5, EventKind::Dispatch, -1)
-            .expect("set empty dispatch baseline");
-        state
-            .set_baseline(5, EventKind::MerkleTreeInsertion, -1)
-            .expect("set empty Merkle baseline");
-        assert!(source_caught_up(false, &caught_up, &state, 5).expect("readiness check"));
-
-        state
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"zero")),
-                &sources,
-            )
-            .expect("first dispatch event");
-        assert!(
-            !sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
-                .expect("persistence readiness")
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            None
-        );
-        state
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
-                &sources,
-            )
-            .expect("second dispatch event");
-        assert!(
-            !sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
-                .expect("persistence readiness")
-        );
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            None
-        );
-
-        state
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    0,
-                    merkle_data_for(
-                        0,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(0, b"zero").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("first Merkle event");
-        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
-            .expect("persistence readiness"));
-        let cursors = sequenced_cursor_write_order(&state, 5).expect("cursor write order");
-        assert_eq!(
-            cursors,
-            [
-                (EventKind::MerkleTreeInsertion, 0),
-                (EventKind::Dispatch, 1),
-            ]
-        );
-        for (kind, sequence) in cursors {
-            source
-                .store_cursor(kind, sequence)
-                .expect("seed first complete pair cursor");
-        }
-        let correlation = state
-            .initialize_correlation(5, 0)
-            .expect("initialize correlation");
-        source
-            .store_correlation_cursor(correlation)
-            .expect("store initial correlation");
-        let correlation = state
-            .advance_correlation(5)
-            .expect("advance correlation")
-            .expect("complete pair advances correlation");
-        source
-            .store_correlation_cursor(correlation)
-            .expect("store advanced correlation");
-
-        assert_eq!(
-            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            Some(1)
-        );
-        assert_eq!(
-            source
-                .cursor(EventKind::MerkleTreeInsertion)
-                .expect("Merkle cursor"),
-            Some(0)
-        );
-        assert_eq!(
-            source.correlation_cursor().expect("correlation cursor"),
-            Some(1)
-        );
-        state
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    1,
-                    merkle_data_for(
-                        1,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(1, b"one").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("next Merkle event");
-        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
-            .expect("initialized persistence readiness"));
-        let reconnect_plan = replay_plan(&sources);
-        assert_eq!(
-            reconnect_plan.source(5).expect("source plan").floor,
-            Some(0)
-        );
-        let request: serde_json::Value = serde_json::from_str(
-            &subscription(&sources, &reconnect_plan, &gas_payment_cursors(), true)
-                .expect("subscription should serialize"),
-        )
-        .expect("subscription JSON");
-        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "-1");
-        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "-1");
-    }
-
-    #[test]
     fn fresh_empty_merkle_can_advance_while_waiting_for_dispatch() {
         let sources = sources();
         let plan = replay_plan(&sources);
@@ -5986,10 +4788,15 @@ mod tests {
                     &sources,
                 )
                 .expect("Merkle event while dispatch is pending");
-            assert!(
-                !sequenced_persistence_ready(&plan, &caught_up, &state, 5, sequence)
-                    .expect("persistence readiness")
-            );
+            assert!(sequenced_persistence_ready(
+                &plan,
+                &caught_up,
+                &state,
+                5,
+                EventKind::MerkleTreeInsertion,
+                sequence,
+            )
+            .expect("persistence readiness"));
         }
 
         state
@@ -5998,14 +4805,9 @@ mod tests {
                 &sources,
             )
             .expect("first dispatch event");
-        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
-            .expect("persistence readiness"));
-        assert_eq!(
-            sequenced_cursor_write_order(&state, 5).expect("cursor write order"),
-            [
-                (EventKind::Dispatch, 0),
-                (EventKind::MerkleTreeInsertion, 1),
-            ]
+        assert!(
+            sequenced_persistence_ready(&plan, &caught_up, &state, 5, EventKind::Dispatch, 0,)
+                .expect("persistence readiness")
         );
     }
 
@@ -6038,79 +4840,13 @@ mod tests {
                 EventKind::GasPayment => unreachable!("test only covers sequenced streams"),
             };
             let mut caught_up = HashMap::from([((5, kind), -1)]);
-            assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one empty marker"));
+            assert!(!source_caught_up(&caught_up, &state, 5).expect("one empty marker"));
             caught_up.insert((5, peer), -1);
-            assert!(source_caught_up(false, &caught_up, &state, 5)
+            assert!(source_caught_up(&caught_up, &state, 5)
                 .expect_err("peer marker must reject staged nonzero start")
                 .to_string()
                 .contains("expected 0"));
         }
-    }
-
-    #[test]
-    fn restart_replays_missing_peer_and_rechecks_late_correlation() {
-        let sources = sources();
-        let source = &sources[&5];
-        source
-            .store_cursor(EventKind::Dispatch, 7)
-            .expect("store dispatch cursor");
-
-        let plan = replay_plan(&sources);
-        let message: serde_json::Value = serde_json::from_str(
-            &subscription(&sources, &plan, &gas_payment_cursors(), true)
-                .expect("subscription should serialize"),
-        )
-        .expect("subscription JSON");
-        assert_eq!(message["streams"][0]["cursors"][0]["afterSequence"], "6");
-        assert_eq!(message["streams"][1]["cursors"][0]["afterSequence"], "6");
-        let streams = subscribed_streams(&sources, &plan);
-        assert_eq!(
-            streams[0].cursors.as_ref().expect("dispatch cursors")[0].after_sequence,
-            Some("6".to_owned())
-        );
-        assert_eq!(
-            streams[1].cursors.as_ref().expect("Merkle cursors")[0].after_sequence,
-            Some("6".to_owned())
-        );
-        validate_subscription(&streams, &sources, &plan, &gas_payment_cursors(), true)
-            .expect("subscription confirmation");
-
-        let mut restarted = replay_state(&plan);
-        restarted
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
-                &sources,
-            )
-            .expect("replay dispatch boundary");
-        let caught_up = HashMap::from([
-            ((5, EventKind::Dispatch), 7),
-            ((5, EventKind::MerkleTreeInsertion), 6),
-        ]);
-        assert!(!source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
-
-        restarted
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    7,
-                    merkle_data_for(
-                        7,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(7, b"seven").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("late Merkle correlation");
-        let next = restarted
-            .advance_correlation(5)
-            .expect("advance correlation")
-            .expect("late pair advances correlation");
-        source
-            .store_correlation_cursor(next)
-            .expect("store correlation cursor");
-        assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
     }
 
     #[test]
@@ -6138,11 +4874,7 @@ mod tests {
         source
             .store_cursor(EventKind::MerkleTreeInsertion, 200)
             .expect("advance Merkle cursor");
-        source
-            .store_correlation_cursor(200)
-            .expect("advance correlation cursor");
-
-        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "99");
         assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
         let streams = subscribed_streams(&sources, &plan);
         handshake
@@ -6151,47 +4883,9 @@ mod tests {
         handshake
             .event()
             .expect("caught-up accepted after confirmation");
-        validate_caught_up_floor(&plan, 5, 90).expect("captured replay floor");
-        assert!(validate_caught_up_floor(&plan, 5, 89).is_err());
-    }
-
-    #[test]
-    fn parity_matches_do_not_combine_across_connection_generations() {
-        let database = MockParityDatabase::new();
-        let monitor = monitor(Arc::new(database));
-        let source = &monitor.sources[&5];
-        source
-            .store_correlation_cursor(7)
-            .expect("store replay anchor");
-        let plan = SequencedReplayPlan::load(&monitor.sources).expect("replay plan");
-
-        monitor.reset_correlation_gate(1, &plan);
-        monitor.note_cross_stream_next(1, 5, 8);
-        monitor
-            .finish_parity_correlation(1, 5, EventKind::Dispatch, 7, ParityResult::Match.label())
-            .expect("old generation dispatch match");
-        assert_eq!(source.correlation_cursor().expect("cursor read"), Some(7));
-
-        monitor.reset_correlation_gate(2, &plan);
-        monitor.note_cross_stream_next(2, 5, 8);
-        monitor
-            .finish_parity_correlation(
-                2,
-                5,
-                EventKind::MerkleTreeInsertion,
-                7,
-                ParityResult::Match.label(),
-            )
-            .expect("new generation Merkle match");
-        monitor
-            .finish_parity_correlation(1, 5, EventKind::Dispatch, 7, ParityResult::Match.label())
-            .expect("late old generation completion ignored");
-        assert_eq!(source.correlation_cursor().expect("cursor read"), Some(7));
-
-        monitor
-            .finish_parity_correlation(2, 5, EventKind::Dispatch, 7, ParityResult::Match.label())
-            .expect("same generation dispatch match");
-        assert_eq!(source.correlation_cursor().expect("cursor read"), Some(8));
+        validate_caught_up_floor(&plan, 5, EventKind::MerkleTreeInsertion, 90)
+            .expect("captured replay floor");
+        assert!(validate_caught_up_floor(&plan, 5, EventKind::MerkleTreeInsertion, 89).is_err());
     }
 
     #[test]
@@ -6523,7 +5217,6 @@ mod tests {
             .get(&(5, EventKind::Dispatch))
             .expect("dispatch queue");
         queue.lock().jobs.push_back(ParityJob {
-            generation: 1,
             input: queued_event.parity.expect("sequenced parity input"),
             queue_permit: monitor
                 .parity_queue_permit
@@ -7807,7 +6500,7 @@ mod tests {
     }
 
     #[test]
-    fn correlates_dispatch_and_merkle_projection() {
+    fn validates_dispatch_and_merkle_projections_independently() {
         let fixture = fixture();
         let mut state = StreamState::default();
         let message = dispatch_message(7, b"payload");
@@ -7826,92 +6519,47 @@ mod tests {
                 ),
                 &fixture.sources,
             )
-            .expect("matching Merkle insertion should validate");
+            .expect("Merkle insertion should validate");
     }
 
     #[test]
-    fn rejects_cross_stream_message_and_block_mismatches() {
+    fn accepts_different_message_ids_at_the_same_stream_sequence() {
         let fixture = fixture();
-        let message = dispatch_message(7, b"payload");
-        let mut wrong_message = StreamState::default();
-        wrong_message
+        let first = dispatch_message(7, b"first");
+        let second = dispatch_message(8, b"second");
+        let mut state = StreamState::default();
+        state
             .validate(
-                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"first")),
                 &fixture.sources,
             )
             .expect("dispatch should validate");
-        assert!(wrong_message
+        state
             .validate(
                 event(
                     MERKLE_EVENT_TYPE,
                     7,
-                    merkle_data_for(7, H256::from_low_u64_be(2), H256::from_low_u64_be(8), 100,),
+                    merkle_data_for(7, H256::from_low_u64_be(2), second.id(), 100),
                 ),
                 &fixture.sources,
             )
-            .expect_err("message mismatch must reject")
-            .to_string()
-            .contains("message IDs differ"));
-
-        let mut wrong_block = StreamState::default();
-        wrong_block
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
-                &fixture.sources,
-            )
-            .expect("dispatch should validate");
-        assert!(wrong_block
+            .expect("same numeric sequence may identify another message");
+        state
             .validate(
                 event(
                     MERKLE_EVENT_TYPE,
-                    7,
-                    merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 101),
+                    8,
+                    merkle_data_for(8, H256::from_low_u64_be(2), first.id(), 100),
                 ),
                 &fixture.sources,
             )
-            .expect_err("block mismatch must reject")
-            .to_string()
-            .contains("block numbers differ"));
-    }
-
-    #[test]
-    fn bounds_unmatched_cross_stream_projections() {
-        let projection = ProtocolProjection {
-            block_number: 100,
-            message_id: H256::from_low_u64_be(7),
-        };
-        let mut state = CrossStreamState::default();
-        for sequence in 0..CROSS_STREAM_WINDOW as u32 {
-            state
-                .validate(5, sequence, EventKind::Dispatch, projection)
-                .expect("projection inside window");
-        }
-        assert_eq!(state.entries[&5].len(), CROSS_STREAM_WINDOW);
-        assert!(state
-            .validate(
-                5,
-                CROSS_STREAM_WINDOW as u32,
-                EventKind::Dispatch,
-                projection,
-            )
-            .expect_err("unmatched projection must not be evicted")
-            .to_string()
-            .contains("skew exceeds"));
-
-        state
-            .validate(5, 0, EventKind::MerkleTreeInsertion, projection)
-            .expect("oldest projection should complete");
+            .expect("first message may appear at another Merkle sequence");
         state
             .validate(
-                5,
-                CROSS_STREAM_WINDOW as u32,
-                EventKind::Dispatch,
-                projection,
+                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"second")),
+                &fixture.sources,
             )
-            .expect("completed oldest projection should be evicted");
-        assert_eq!(state.entries[&5].len(), CROSS_STREAM_WINDOW);
-        assert!(!state.entries[&5].contains_key(&0));
-        assert!(state.entries[&5].contains_key(&(CROSS_STREAM_WINDOW as u32)));
+            .expect("second message may appear at another dispatch sequence");
     }
 
     #[test]
@@ -8517,7 +7165,6 @@ mod tests {
             state.cursors[&(5, EventKind::MerkleTreeInsertion)].next_sequence,
             8
         );
-        assert!(state.cross_stream.entries[&5][&7].complete());
         assert_eq!(
             monitor
                 .events

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1780,12 +1780,27 @@ impl ScraperAuthorityReceiver {
     }
 }
 
+#[cfg(test)]
+struct AuthorityRevocationHook {
+    entered: std::sync::mpsc::Sender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct AuthorityRevocationHooks {
+    before_publish: Option<AuthorityRevocationHook>,
+    after_publish: Option<AuthorityRevocationHook>,
+}
+
 /// One process-wide, read-only scraper stream monitor.
 pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
     authority: IntGaugeVec,
     authority_active: AtomicBool,
     authority_enabled: bool,
+    #[cfg(test)]
+    authority_revocation_hooks: parking_lot::Mutex<AuthorityRevocationHooks>,
     authority_handoff: Arc<AuthorityHandoff>,
     authority_sender: watch::Sender<AuthorityCommand>,
     caught_up: IntGaugeVec,
@@ -1914,6 +1929,8 @@ impl ScraperWebSocketMonitor {
             authority,
             authority_active: AtomicBool::new(false),
             authority_enabled,
+            #[cfg(test)]
+            authority_revocation_hooks: parking_lot::Mutex::default(),
             authority_handoff,
             authority_sender,
             caught_up,
@@ -2665,28 +2682,13 @@ impl ScraperWebSocketMonitor {
                                     let source = self.sources.get(&domain).context(
                                         "Invalid gas payment source unexpectedly missing",
                                     )?;
-                                    source.store_gas_payment_degraded()?;
-                                    if state.gas_payment_degraded.insert(domain) {
-                                        self.set_source_caught_up(
-                                            source,
-                                            EventKind::GasPayment,
-                                            false,
-                                        );
-                                        self.degraded
-                                            .with_label_values(&[
-                                                source.chain.as_str(),
-                                                GAS_PAYMENT_EVENT_TYPE,
-                                            ])
-                                            .set(1);
+                                    if self.degrade_gas_payment(state, source)? {
                                         warn!(
                                             ?err,
                                             domain,
                                             "Relayer scraper-proxy gas payment shadow stream degraded"
                                         );
                                     }
-                                    // Invalidate readiness before revoking authority so a
-                                    // concurrent freshness result cannot reactivate it.
-                                    self.deactivate_authority();
                                 }
                             }
                         }
@@ -2868,10 +2870,47 @@ impl ScraperWebSocketMonitor {
         }
     }
 
+    fn degrade_gas_payment(&self, state: &mut StreamState, source: &ScraperSource) -> Result<bool> {
+        source.store_gas_payment_degraded()?;
+        let newly_degraded = state.gas_payment_degraded.insert(source.domain);
+        // Invalidate readiness before revoking authority so an in-flight
+        // freshness result cannot reactivate the degraded stream.
+        self.set_source_caught_up(source, EventKind::GasPayment, false);
+        self.degraded
+            .with_label_values(&[source.chain.as_str(), GAS_PAYMENT_EVENT_TYPE])
+            .set(1);
+        self.deactivate_authority();
+        Ok(newly_degraded)
+    }
+
+    #[cfg(test)]
+    fn wait_for_revocation_hook(&self, before_publish: bool) {
+        let hook = {
+            let mut hooks = self.authority_revocation_hooks.lock();
+            if before_publish {
+                hooks.before_publish.take()
+            } else {
+                hooks.after_publish.take()
+            }
+        };
+        if let Some(hook) = hook {
+            hook.entered.send(()).expect("signal revocation hook");
+            hook.release
+                .recv_timeout(Duration::from_secs(5))
+                .expect("release revocation hook");
+        }
+    }
+
+    fn publish_authority_revocation(&self, update: impl FnOnce(&mut AuthorityCommand) -> bool) {
+        #[cfg(test)]
+        self.wait_for_revocation_hook(true);
+        self.authority_sender.send_if_modified(update);
+    }
+
     fn deactivate_authority(&self) {
         // Serialize the active flag and gauges with command publication. RPC must
         // not resume between clearing the flag and a concurrent activation.
-        self.authority_sender.send_if_modified(|current| {
+        self.publish_authority_revocation(|current| {
             if self.authority_active.swap(false, Ordering::AcqRel) {
                 info!("Restoring direct RPC indexing fallback");
             }
@@ -2891,6 +2930,8 @@ impl ScraperWebSocketMonitor {
             }
         });
         self.authority_handoff.notify_state_changed();
+        #[cfg(test)]
+        self.wait_for_revocation_hook(false);
     }
 
     fn refresh_parity_ready(&self, source: &ScraperSource) {
@@ -3093,42 +3134,49 @@ impl ScraperWebSocketMonitor {
             .collect::<Vec<_>>()
             .await;
 
-        let mut all_fresh = true;
-        for result in results {
-            match result {
-                Ok((
-                    chain,
-                    is_fresh,
-                    canonical_count,
-                    dispatch_cursor,
-                    merkle_cursor,
-                    correlation_cursor,
-                )) => {
-                    self.fresh
-                        .with_label_values(&[chain.as_str()])
-                        .set(i64::from(is_fresh));
-                    if !is_fresh {
+        let mut all_fresh = false;
+        self.authority_sender.send_if_modified(|_| {
+            if !self.base_authority_ready() {
+                return false;
+            }
+            all_fresh = true;
+            for result in results {
+                match result {
+                    Ok((
+                        chain,
+                        is_fresh,
+                        canonical_count,
+                        dispatch_cursor,
+                        merkle_cursor,
+                        correlation_cursor,
+                    )) => {
+                        self.fresh
+                            .with_label_values(&[chain.as_str()])
+                            .set(i64::from(is_fresh));
+                        if !is_fresh {
+                            all_fresh = false;
+                            if should_warn(&self.freshness_warned_at) {
+                                warn!(
+                                    %chain,
+                                    ?canonical_count,
+                                    ?dispatch_cursor,
+                                    ?merkle_cursor,
+                                    ?correlation_cursor,
+                                    "Scraper sequenced cursors are not canonically fresh"
+                                );
+                            }
+                        }
+                    }
+                    Err(err) => {
                         all_fresh = false;
                         if should_warn(&self.freshness_warned_at) {
-                            warn!(
-                                %chain,
-                                ?canonical_count,
-                                ?dispatch_cursor,
-                                ?merkle_cursor,
-                                ?correlation_cursor,
-                                "Scraper sequenced cursors are not canonically fresh"
-                            );
+                            warn!(?err, "Canonical scraper freshness probe failed");
                         }
                     }
                 }
-                Err(err) => {
-                    all_fresh = false;
-                    if should_warn(&self.freshness_warned_at) {
-                        warn!(?err, "Canonical scraper freshness probe failed");
-                    }
-                }
             }
-        }
+            false
+        });
         if all_fresh {
             self.maybe_activate_authority().await;
         } else {
@@ -3910,33 +3958,29 @@ mod tests {
         authority.set(1);
         fresh.set(1);
 
-        // Pin the command while another thread attempts revocation. Previously
-        // revocation cleared the flag/gauges before obtaining this lock, allowing
-        // activation to restore them under the still-current pause command.
+        // Pause revocation exactly before command publication, avoiding any
+        // dependence on how quickly its thread is scheduled.
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        monitor.authority_revocation_hooks.lock().before_publish = Some(AuthorityRevocationHook {
+            entered: entered_tx,
+            release: release_rx,
+        });
         let receiver = monitor.authority_sender.subscribe();
-        let command = receiver.borrow();
         std::thread::scope(|threads| {
-            let (started_tx, started_rx) = std::sync::mpsc::channel();
-            let (done_tx, done_rx) = std::sync::mpsc::channel();
-            let monitor = &monitor;
-            threads.spawn(move || {
-                started_tx.send(()).expect("signal revocation start");
-                monitor.deactivate_authority();
-                done_tx.send(()).expect("signal revocation completion");
-            });
-            started_rx.recv().expect("revocation thread started");
-            assert!(done_rx.recv_timeout(Duration::from_millis(100)).is_err());
-            let remained_active = monitor.authority_active.load(Ordering::Acquire);
-            let authority_before_unlock = authority.get();
-            let fresh_before_unlock = fresh.get();
-            // Release before asserting so a regression cannot deadlock thread join.
-            drop(command);
-            done_rx
+            threads.spawn(|| monitor.deactivate_authority());
+            entered_rx
                 .recv_timeout(Duration::from_secs(5))
-                .expect("revocation completed");
+                .expect("revocation reached publication");
+            let remained_active = monitor.authority_active.load(Ordering::Acquire);
+            let authority_before_publication = authority.get();
+            let fresh_before_publication = fresh.get();
+            let desired_before_publication = receiver.borrow().desired;
+            release_tx.send(()).expect("release revocation");
             assert!(remained_active);
-            assert_eq!(authority_before_unlock, 1);
-            assert_eq!(fresh_before_unlock, 1);
+            assert!(desired_before_publication);
+            assert_eq!(authority_before_publication, 1);
+            assert_eq!(fresh_before_publication, 1);
         });
         assert!(!receiver.borrow().desired);
         assert!(!monitor.authority_active.load(Ordering::Acquire));
@@ -4089,6 +4133,99 @@ mod tests {
 
         assert!(monitor.authority_active.load(Ordering::Acquire));
         assert_eq!(monitor.fresh.with_label_values(&["test"]).get(), 1);
+    }
+
+    #[tokio::test]
+    async fn gas_degradation_blocks_in_flight_freshness_reactivation() {
+        let fixture = fixture();
+        let source = fixture.sources[&5]
+            .clone()
+            .with_freshness_indexer(Arc::new(FixedSequenceIndexer(10)));
+        source
+            .store_cursor(EventKind::Dispatch, 9)
+            .expect("dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 9)
+            .expect("Merkle cursor");
+        source
+            .store_correlation_cursor(10)
+            .expect("correlation cursor");
+        let metrics = CoreMetrics::new("scraper-gas-freshness-test", 9090, Registry::new())
+            .expect("test metrics");
+        let monitor = Arc::new(
+            ScraperWebSocketMonitor::new_with_authority(
+                Url::parse("ws://localhost:1").expect("test URL"),
+                vec![source],
+                &metrics,
+                true,
+            )
+            .expect("authority monitor"),
+        );
+        monitor.set_active(true);
+        monitor.gas_payment_enabled.store(true, Ordering::Release);
+        let source = &monitor.sources[&5];
+        for kind in [
+            EventKind::Dispatch,
+            EventKind::GasPayment,
+            EventKind::MerkleTreeInsertion,
+        ] {
+            monitor.set_source_caught_up(source, kind, true);
+        }
+        monitor.refresh_parity_ready(source);
+        monitor.fresh.with_label_values(&["test"]).set(1);
+        monitor.authority.with_label_values(&["test"]).set(1);
+        monitor.authority_active.store(true, Ordering::Release);
+        monitor
+            .authority_sender
+            .send_modify(|command| command.desired = true);
+
+        // Start a valid freshness probe, but hold its cursor read until gas
+        // degradation has published revocation and paused before returning.
+        let permits =
+            u32::try_from(monitor.parity_read_permit.available_permits()).expect("permit count");
+        let capacity = monitor
+            .parity_read_permit
+            .clone()
+            .acquire_many_owned(permits)
+            .await
+            .expect("cursor capacity");
+        let mut refresh = Box::pin(monitor.refresh_authority_once());
+        assert!(futures::poll!(&mut refresh).is_pending());
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        monitor.authority_revocation_hooks.lock().after_publish = Some(AuthorityRevocationHook {
+            entered: entered_tx,
+            release: release_rx,
+        });
+        let worker_monitor = monitor.clone();
+        let worker = std::thread::spawn(move || {
+            let mut state = StreamState::default();
+            worker_monitor.degrade_gas_payment(&mut state, &worker_monitor.sources[&5])
+        });
+        entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("gas degradation revoked authority");
+        drop(capacity);
+        let refreshed = timeout(Duration::from_secs(2), &mut refresh).await.is_ok();
+        drop(refresh);
+        let active = monitor.authority_active.load(Ordering::Acquire);
+        let command = *monitor.authority_sender.borrow();
+        let fresh = monitor.fresh.with_label_values(&["test"]).get();
+        release_tx.send(()).expect("release gas degradation");
+        assert!(worker
+            .join()
+            .expect("degradation thread")
+            .expect("gas degradation"));
+        assert!(refreshed, "degraded stream must not request a new handoff");
+        assert!(!active);
+        assert!(!command.desired);
+        assert_eq!(
+            command.generation, 0,
+            "degraded stream must not request another handoff"
+        );
+        assert_eq!(fresh, 0);
+        assert_eq!(monitor.authority.with_label_values(&["test"]).get(), 0);
+        assert!(source.gas_payment_degraded().expect("durable degradation"));
     }
 
     #[tokio::test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1498,6 +1498,13 @@ struct AuthorityHandoff {
     state_changed: Notify,
 }
 
+#[derive(Debug)]
+struct SourceAuthority {
+    active: Arc<AtomicBool>,
+    handoff: Arc<AuthorityHandoff>,
+    sender: watch::Sender<AuthorityCommand>,
+}
+
 impl AuthorityHandoff {
     fn new(expected: HashSet<u32>) -> Self {
         Self {
@@ -1591,12 +1598,16 @@ struct AuthorityRevocationHooks {
 pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
     authority: IntGaugeVec,
-    authority_active: AtomicBool,
     authority_enabled: bool,
     #[cfg(test)]
     authority_revocation_hooks: parking_lot::Mutex<AuthorityRevocationHooks>,
+    #[cfg(test)]
+    authority_active: Arc<AtomicBool>,
+    #[cfg(test)]
     authority_handoff: Arc<AuthorityHandoff>,
+    #[cfg(test)]
     authority_sender: watch::Sender<AuthorityCommand>,
+    source_authorities: HashMap<u32, SourceAuthority>,
     caught_up: IntGaugeVec,
     degraded: IntGaugeVec,
     fresh: IntGaugeVec,
@@ -1681,11 +1692,30 @@ impl ScraperWebSocketMonitor {
             .into_iter()
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
-        let authority_handoff = Arc::new(AuthorityHandoff::new(sources.keys().copied().collect()));
-        let (authority_sender, _) = watch::channel(AuthorityCommand {
-            desired: false,
-            generation: 0,
-        });
+        let source_authorities = sources
+            .keys()
+            .copied()
+            .map(|domain| {
+                let handoff = Arc::new(AuthorityHandoff::new(HashSet::from([domain])));
+                let (sender, _) = watch::channel(AuthorityCommand {
+                    desired: false,
+                    generation: 0,
+                });
+                (
+                    domain,
+                    SourceAuthority {
+                        active: Arc::new(AtomicBool::new(false)),
+                        handoff,
+                        sender,
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        #[cfg(test)]
+        let test_authority = source_authorities
+            .values()
+            .next()
+            .expect("test scraper monitor requires a source");
         let mut parity_unhealthy = HashSet::new();
         let mut parity_queues = HashMap::new();
         for source in sources.values() {
@@ -1720,12 +1750,16 @@ impl ScraperWebSocketMonitor {
         Ok(Self {
             active,
             authority,
-            authority_active: AtomicBool::new(false),
             authority_enabled,
             #[cfg(test)]
             authority_revocation_hooks: parking_lot::Mutex::default(),
-            authority_handoff,
-            authority_sender,
+            #[cfg(test)]
+            authority_active: test_authority.active.clone(),
+            #[cfg(test)]
+            authority_handoff: test_authority.handoff.clone(),
+            #[cfg(test)]
+            authority_sender: test_authority.sender.clone(),
+            source_authorities,
             caught_up,
             degraded,
             fresh,
@@ -1746,10 +1780,16 @@ impl ScraperWebSocketMonitor {
         })
     }
 
-    pub(crate) fn authority_receiver(&self) -> Option<ScraperAuthorityReceiver> {
-        self.authority_enabled.then(|| ScraperAuthorityReceiver {
-            desired: self.authority_sender.subscribe(),
-            handoff: self.authority_handoff.clone(),
+    pub(crate) fn authority_receiver(&self, domain: u32) -> Option<ScraperAuthorityReceiver> {
+        self.authority_enabled.then(|| {
+            let authority = self
+                .source_authorities
+                .get(&domain)
+                .expect("authority receiver requested for unknown scraper source");
+            ScraperAuthorityReceiver {
+                desired: authority.sender.subscribe(),
+                handoff: authority.handoff.clone(),
+            }
         })
     }
 
@@ -1871,7 +1911,7 @@ impl ScraperWebSocketMonitor {
             let source = source.clone();
             let broadcaster = source.broadcaster.clone();
             let parity_input = parity_input.clone();
-            let authority_active = self.authority_active.load(Ordering::Acquire);
+            let authority_active = self.source_authority(domain).active.load(Ordering::Acquire);
             let permit = match timeout(
                 PARITY_READ_TIMEOUT,
                 self.parity_read_permit.clone().acquire_owned(),
@@ -1950,7 +1990,7 @@ impl ScraperWebSocketMonitor {
             .inc();
         if terminal != ParityResult::Match.label() {
             self.parity_unhealthy.lock().insert((domain, kind));
-            self.deactivate_authority();
+            self.deactivate_source_authority(domain);
             if should_warn(&self.parity_warned_at) {
                 warn!(%chain, event_type, result = terminal, "Scraper event did not reach matching local DB parity");
             }
@@ -1959,7 +1999,7 @@ impl ScraperWebSocketMonitor {
         pending.dec();
         if pending.get() == 0 && !self.parity_unhealthy.lock().contains(&(domain, kind)) {
             self.parity_ready.with_label_values(&labels).set(1);
-            self.maybe_activate_authority().await;
+            self.maybe_activate_source_authority(domain).await;
         }
         terminal
     }
@@ -2364,7 +2404,7 @@ impl ScraperWebSocketMonitor {
                                 }
                                 self.set_source_caught_up(source, EventKind::GasPayment, true);
                                 self.record(domain, GAS_PAYMENT_EVENT_TYPE, "caught_up");
-                                self.maybe_activate_authority().await;
+                                self.maybe_activate_source_authority(domain).await;
                                 continue;
                             }
                             if row_id.is_some() || stream_cursor.is_some() {
@@ -2503,7 +2543,7 @@ impl ScraperWebSocketMonitor {
         self.degraded
             .with_label_values(&[source.chain.as_str(), GAS_PAYMENT_EVENT_TYPE])
             .set(1);
-        self.deactivate_authority();
+        self.deactivate_source_authority(source.domain);
         Ok(newly_degraded)
     }
 
@@ -2525,27 +2565,35 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    fn publish_authority_revocation(&self, update: impl FnOnce(&mut AuthorityCommand) -> bool) {
-        #[cfg(test)]
-        self.wait_for_revocation_hook(true);
-        self.authority_sender.send_if_modified(update);
+    fn source_authority(&self, domain: u32) -> &SourceAuthority {
+        self.source_authorities
+            .get(&domain)
+            .expect("validated scraper source must have authority state")
     }
 
-    fn deactivate_authority(&self) {
+    fn deactivate_source_authority(&self, domain: u32) {
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper source must exist");
+        let authority = self.source_authority(domain);
         // Serialize the active flag and gauges with command publication. RPC must
         // not resume between clearing the flag and a concurrent activation.
-        self.publish_authority_revocation(|current| {
-            if self.authority_active.swap(false, Ordering::AcqRel) {
-                info!("Restoring direct RPC indexing fallback");
+        #[cfg(test)]
+        self.wait_for_revocation_hook(true);
+        authority.sender.send_if_modified(|current| {
+            if authority.active.swap(false, Ordering::AcqRel) {
+                info!(
+                    chain = source.chain,
+                    "Restoring direct RPC indexing fallback"
+                );
             }
-            for source in self.sources.values() {
-                self.authority
-                    .with_label_values(&[source.chain.as_str()])
-                    .set(0);
-                self.fresh
-                    .with_label_values(&[source.chain.as_str()])
-                    .set(0);
-            }
+            self.authority
+                .with_label_values(&[source.chain.as_str()])
+                .set(0);
+            self.fresh
+                .with_label_values(&[source.chain.as_str()])
+                .set(0);
             if current.desired {
                 current.desired = false;
                 true
@@ -2553,9 +2601,16 @@ impl ScraperWebSocketMonitor {
                 false
             }
         });
-        self.authority_handoff.notify_state_changed();
+        authority.handoff.notify_state_changed();
         #[cfg(test)]
         self.wait_for_revocation_hook(false);
+    }
+
+    fn deactivate_authority(&self) {
+        let domains = self.sources.keys().copied().collect::<Vec<_>>();
+        for domain in domains {
+            self.deactivate_source_authority(domain);
+        }
     }
 
     fn refresh_parity_ready(&self, source: &ScraperSource) {
@@ -2572,17 +2627,19 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn maybe_activate_authority(&self) {
-        if self.authority_active.load(Ordering::Acquire)
-            || !self.base_authority_ready()
-            || !self
-                .sources
-                .values()
-                .all(|source| self.fresh.with_label_values(&[source.chain.as_str()]).get() == 1)
+    async fn maybe_activate_source_authority(&self, domain: u32) {
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper source must exist");
+        let authority = self.source_authority(domain);
+        if authority.active.load(Ordering::Acquire)
+            || !self.base_source_authority_ready(source)
+            || self.fresh.with_label_values(&[source.chain.as_str()]).get() != 1
         {
             return;
         }
-        self.authority_sender.send_if_modified(|current| {
+        authority.sender.send_if_modified(|current| {
             if current.desired {
                 false
             } else {
@@ -2594,88 +2651,102 @@ impl ScraperWebSocketMonitor {
                 true
             }
         });
-        let command = *self.authority_sender.borrow();
+        let command = *authority.sender.borrow();
         let handoff_complete = matches!(
             timeout(
                 AUTHORITY_HANDOFF_TIMEOUT,
-                self.authority_handoff
-                    .wait_until_paused(&self.authority_sender, command.generation),
+                authority
+                    .handoff
+                    .wait_until_paused(&authority.sender, command.generation),
             )
             .await,
             Ok(true)
         );
         if !handoff_complete
-            || *self.authority_sender.borrow() != command
-            || !self.base_authority_ready()
-            || !self
-                .sources
-                .values()
-                .all(|source| self.fresh.with_label_values(&[source.chain.as_str()]).get() == 1)
+            || *authority.sender.borrow() != command
+            || !self.base_source_authority_ready(source)
+            || self.fresh.with_label_values(&[source.chain.as_str()]).get() != 1
         {
             if !handoff_complete {
                 warn!(
+                    chain = source.chain,
                     generation = command.generation,
                     "RPC indexers did not acknowledge scraper authority handoff"
                 );
             }
-            self.deactivate_authority();
+            self.deactivate_source_authority(domain);
             return;
         }
-        self.authority_sender.send_if_modified(|current| {
+        authority.sender.send_if_modified(|current| {
             // Use the same watch write lock as revocation so neither the flag nor
             // its gauges can be activated after this command has been revoked.
             if *current == command
                 && current.desired
-                && self
-                    .authority_active
+                && authority
+                    .active
                     .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                     .is_ok()
             {
-                for source in self.sources.values() {
-                    self.authority
-                        .with_label_values(&[source.chain.as_str()])
-                        .set(1);
-                }
-                info!("Scraper-proxy indexing is authoritative; pausing direct RPC indexing");
+                self.authority
+                    .with_label_values(&[source.chain.as_str()])
+                    .set(1);
+                info!(
+                    chain = source.chain,
+                    "Scraper-proxy indexing is authoritative; pausing direct RPC indexing"
+                );
             }
             false // Activation does not change the already acknowledged command.
         });
     }
 
-    fn base_authority_ready(&self) -> bool {
+    fn base_source_authority_ready(&self, source: &ScraperSource) -> bool {
         self.authority_enabled
             && self.gas_payment_enabled.load(Ordering::Acquire)
-            && !self.sources.is_empty()
-            && self.sources.values().all(|source| {
-                self.active
-                    .with_label_values(&[source.chain.as_str()])
+            && self
+                .active
+                .with_label_values(&[source.chain.as_str()])
+                .get()
+                == 1
+            && [
+                EventKind::Dispatch,
+                EventKind::GasPayment,
+                EventKind::MerkleTreeInsertion,
+            ]
+            .into_iter()
+            .all(|kind| {
+                self.caught_up
+                    .with_label_values(&[source.chain.as_str(), kind.label()])
                     .get()
                     == 1
-                    && [
-                        EventKind::Dispatch,
-                        EventKind::GasPayment,
-                        EventKind::MerkleTreeInsertion,
-                    ]
-                    .into_iter()
-                    .all(|kind| {
-                        self.caught_up
-                            .with_label_values(&[source.chain.as_str(), kind.label()])
-                            .get()
-                            == 1
-                    })
-                    && self
-                        .degraded
-                        .with_label_values(&[source.chain.as_str(), GAS_PAYMENT_EVENT_TYPE])
-                        .get()
-                        == 0
-                    && [EventKind::Dispatch, EventKind::MerkleTreeInsertion]
-                        .into_iter()
-                        .all(|kind| {
-                            let labels = [source.chain.as_str(), kind.label()];
-                            self.parity_pending.with_label_values(&labels).get() == 0
-                                && self.parity_ready.with_label_values(&labels).get() == 1
-                        })
             })
+            && self
+                .degraded
+                .with_label_values(&[source.chain.as_str(), GAS_PAYMENT_EVENT_TYPE])
+                .get()
+                == 0
+            && [EventKind::Dispatch, EventKind::MerkleTreeInsertion]
+                .into_iter()
+                .all(|kind| {
+                    let labels = [source.chain.as_str(), kind.label()];
+                    self.parity_pending.with_label_values(&labels).get() == 0
+                        && self.parity_ready.with_label_values(&labels).get() == 1
+                })
+    }
+
+    #[cfg(test)]
+    async fn maybe_activate_authority(&self) {
+        for domain in self.sources.keys().copied() {
+            self.maybe_activate_source_authority(domain).await;
+        }
+    }
+
+    #[cfg(test)]
+    fn base_authority_ready(&self) -> bool {
+        !self.sources.is_empty()
+            && self
+                .sources
+                .values()
+                .all(|source| self.base_source_authority_ready(source))
     }
 
     async fn run_authority_freshness(self: Arc<Self>) {
@@ -2688,106 +2759,117 @@ impl ScraperWebSocketMonitor {
     }
 
     async fn refresh_authority_once(&self) {
-        if !self.base_authority_ready() {
-            self.deactivate_authority();
-            return;
-        }
-
-        let results = stream::iter(self.sources.values().cloned())
+        let ready_sources = self
+            .sources
+            .values()
+            .filter_map(|source| {
+                let ready = self.base_source_authority_ready(source);
+                if !ready {
+                    self.deactivate_source_authority(source.domain);
+                }
+                ready.then(|| source.clone())
+            })
+            .collect::<Vec<_>>();
+        let results = stream::iter(ready_sources)
             .map(|source| async move {
+                let domain = source.domain;
                 let chain = source.chain.clone();
-                let indexer = source
-                    .freshness_indexer
-                    .clone()
-                    .context("Missing canonical dispatch freshness indexer")?;
-                let merkle_indexer = source
-                    .merkle_freshness_indexer
-                    .clone()
-                    .context("Missing canonical Merkle freshness indexer")?;
-                let (dispatch_canonical_count, _) = timeout(
-                    AUTHORITY_FRESHNESS_TIMEOUT,
-                    indexer.latest_sequence_count_and_tip(),
-                )
-                .await
-                .context("Canonical dispatch freshness probe timed out")??;
-                let (merkle_canonical_count, _) = timeout(
-                    AUTHORITY_FRESHNESS_TIMEOUT,
-                    merkle_indexer.latest_sequence_count_and_tip(),
-                )
-                .await
-                .context("Canonical Merkle freshness probe timed out")??;
-                let cursor_source = source.clone();
-                let cursor_read = async {
-                    let permit = self
-                        .parity_read_permit
+                let result = async {
+                    let indexer = source
+                        .freshness_indexer
                         .clone()
-                        .acquire_owned()
-                        .await
-                        .expect("parity semaphore is never closed");
-                    if self.parity_read_disabled.load(Ordering::Acquire) {
-                        bail!("Canonical scraper freshness reads are disabled");
-                    }
-                    tokio::task::spawn_blocking(move || -> Result<_> {
-                        let _permit = permit;
-                        Ok((
-                            cursor_source.cursor(EventKind::Dispatch)?,
-                            cursor_source.cursor(EventKind::MerkleTreeInsertion)?,
-                        ))
-                    })
+                        .context("Missing canonical dispatch freshness indexer")?;
+                    let merkle_indexer = source
+                        .merkle_freshness_indexer
+                        .clone()
+                        .context("Missing canonical Merkle freshness indexer")?;
+                    let (dispatch_canonical_count, _) = timeout(
+                        AUTHORITY_FRESHNESS_TIMEOUT,
+                        indexer.latest_sequence_count_and_tip(),
+                    )
                     .await
-                    .context("Canonical scraper freshness cursor task failed")?
-                };
-                let (dispatch_cursor, merkle_cursor) =
-                    match timeout(PARITY_READ_TIMEOUT, cursor_read).await {
-                        Ok(result) => result?,
-                        Err(_) => {
-                            self.disable_parity_reads(
-                                &chain,
-                                DISPATCH_EVENT_TYPE,
-                                "canonical freshness cursor read timed out",
-                            );
-                            bail!("Canonical scraper freshness cursor read timed out");
+                    .context("Canonical dispatch freshness probe timed out")??;
+                    let (merkle_canonical_count, _) = timeout(
+                        AUTHORITY_FRESHNESS_TIMEOUT,
+                        merkle_indexer.latest_sequence_count_and_tip(),
+                    )
+                    .await
+                    .context("Canonical Merkle freshness probe timed out")??;
+                    let cursor_source = source.clone();
+                    let cursor_read = async {
+                        let permit = self
+                            .parity_read_permit
+                            .clone()
+                            .acquire_owned()
+                            .await
+                            .expect("parity semaphore is never closed");
+                        if self.parity_read_disabled.load(Ordering::Acquire) {
+                            bail!("Canonical scraper freshness reads are disabled");
                         }
+                        tokio::task::spawn_blocking(move || -> Result<_> {
+                            let _permit = permit;
+                            Ok((
+                                cursor_source.cursor(EventKind::Dispatch)?,
+                                cursor_source.cursor(EventKind::MerkleTreeInsertion)?,
+                            ))
+                        })
+                        .await
+                        .context("Canonical scraper freshness cursor task failed")?
                     };
-                Ok::<_, eyre::Report>((
-                    chain,
-                    canonical_cursors_are_fresh(
+                    let (dispatch_cursor, merkle_cursor) =
+                        match timeout(PARITY_READ_TIMEOUT, cursor_read).await {
+                            Ok(result) => result?,
+                            Err(_) => {
+                                self.disable_parity_reads(
+                                    &chain,
+                                    DISPATCH_EVENT_TYPE,
+                                    "canonical freshness cursor read timed out",
+                                );
+                                bail!("Canonical scraper freshness cursor read timed out");
+                            }
+                        };
+                    Ok::<_, eyre::Report>((
+                        canonical_cursors_are_fresh(
+                            dispatch_canonical_count,
+                            dispatch_cursor,
+                            merkle_canonical_count,
+                            merkle_cursor,
+                        )?,
                         dispatch_canonical_count,
-                        dispatch_cursor,
                         merkle_canonical_count,
+                        dispatch_cursor,
                         merkle_cursor,
-                    )?,
-                    dispatch_canonical_count,
-                    merkle_canonical_count,
-                    dispatch_cursor,
-                    merkle_cursor,
-                ))
+                    ))
+                }
+                .await;
+                (domain, chain, result)
             })
             .buffer_unordered(AUTHORITY_FRESHNESS_CONCURRENCY)
             .collect::<Vec<_>>()
             .await;
 
-        let mut all_fresh = false;
-        self.authority_sender.send_if_modified(|_| {
-            if !self.base_authority_ready() {
-                return false;
-            }
-            all_fresh = true;
-            for result in results {
-                match result {
-                    Ok((
-                        chain,
-                        is_fresh,
-                        dispatch_canonical_count,
-                        merkle_canonical_count,
-                        dispatch_cursor,
-                        merkle_cursor,
-                    )) => {
-                        self.fresh
-                            .with_label_values(&[chain.as_str()])
-                            .set(i64::from(is_fresh));
+        for (domain, chain, result) in results {
+            match result {
+                Ok((
+                    is_fresh,
+                    dispatch_canonical_count,
+                    merkle_canonical_count,
+                    dispatch_cursor,
+                    merkle_cursor,
+                )) => {
+                    let source = &self.sources[&domain];
+                    let mut readiness_still_valid = false;
+                    self.source_authority(domain).sender.send_if_modified(|_| {
+                        if self.base_source_authority_ready(source) {
+                            readiness_still_valid = true;
+                            self.fresh
+                                .with_label_values(&[chain.as_str()])
+                                .set(i64::from(is_fresh));
+                        }
+                        false
+                    });
+                    if !readiness_still_valid || !is_fresh {
                         if !is_fresh {
-                            all_fresh = false;
                             if should_warn(&self.freshness_warned_at) {
                                 warn!(
                                     %chain,
@@ -2799,21 +2881,18 @@ impl ScraperWebSocketMonitor {
                                 );
                             }
                         }
-                    }
-                    Err(err) => {
-                        all_fresh = false;
-                        if should_warn(&self.freshness_warned_at) {
-                            warn!(?err, "Canonical scraper freshness probe failed");
-                        }
+                        self.deactivate_source_authority(domain);
+                    } else {
+                        self.maybe_activate_source_authority(domain).await;
                     }
                 }
+                Err(err) => {
+                    if should_warn(&self.freshness_warned_at) {
+                        warn!(%chain, ?err, "Canonical scraper freshness probe failed");
+                    }
+                    self.deactivate_source_authority(domain);
+                }
             }
-            false
-        });
-        if all_fresh {
-            self.maybe_activate_authority().await;
-        } else {
-            self.deactivate_authority();
         }
     }
 
@@ -2853,7 +2932,7 @@ impl ScraperWebSocketMonitor {
             self.set_source_caught_up(source, kind, true);
         }
         self.refresh_parity_ready(source);
-        self.maybe_activate_authority().await;
+        self.maybe_activate_source_authority(domain).await;
         Ok(())
     }
 
@@ -3383,7 +3462,7 @@ mod tests {
             true,
         )
         .expect("create authority monitor");
-        let mut receiver = monitor.authority_receiver().expect("authority receiver");
+        let mut receiver = monitor.authority_receiver(5).expect("authority receiver");
 
         monitor.set_active(true);
         monitor.gas_payment_enabled.store(true, Ordering::Release);
@@ -3508,22 +3587,12 @@ mod tests {
             .expect("create test metrics");
         let monitor = ScraperWebSocketMonitor::new_with_authority(
             Url::parse("ws://localhost:1").expect("test URL"),
-            sources_for(&[5, 6]).into_values().collect(),
+            sources_for(&[5]).into_values().collect(),
             &metrics,
             true,
         )
         .expect("create authority monitor");
-        let mut observer = monitor.authority_receiver().expect("authority observer");
-        let mut receiver = monitor.authority_receiver().expect("authority receiver");
-        let paused_then_resumed = tokio::spawn(async move {
-            receiver.changed().await.expect("pause command");
-            let command = receiver.borrow_and_update();
-            assert!(command.desired);
-            receiver.mark_paused(5, command.generation);
-            receiver.changed().await.expect("fallback command");
-            assert!(!receiver.borrow_and_update().desired);
-            receiver.mark_running(5);
-        });
+        let mut observer = monitor.authority_receiver(5).expect("authority observer");
 
         monitor.set_active(true);
         monitor.gas_payment_enabled.store(true, Ordering::Release);
@@ -3544,13 +3613,88 @@ mod tests {
 
         monitor.maybe_activate_authority().await;
 
-        assert!(!monitor.authority_active.load(Ordering::Acquire));
+        assert!(!monitor.source_authority(5).active.load(Ordering::Acquire));
         assert!(!observer.borrow_and_update().desired);
-        timeout(Duration::from_secs(1), paused_then_resumed)
+        assert!(monitor.source_authority(5).handoff.paused.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sources_activate_and_revoke_authority_independently() {
+        let metrics = CoreMetrics::new("scraper-authority-per-source-test", 9090, Registry::new())
+            .expect("create test metrics");
+        let monitor = ScraperWebSocketMonitor::new_with_authority(
+            Url::parse("ws://localhost:1").expect("test URL"),
+            sources_for(&[5, 6]).into_values().collect(),
+            &metrics,
+            true,
+        )
+        .expect("create authority monitor");
+        let mut source_5_receiver = monitor.authority_receiver(5).expect("source 5 receiver");
+        let mut source_6_receiver = monitor.authority_receiver(6).expect("source 6 receiver");
+
+        monitor.set_active(true);
+        monitor.gas_payment_enabled.store(true, Ordering::Release);
+        let source_5 = monitor.sources.get(&5).expect("source 5");
+        for kind in [
+            EventKind::Dispatch,
+            EventKind::GasPayment,
+            EventKind::MerkleTreeInsertion,
+        ] {
+            monitor.set_source_caught_up(source_5, kind, true);
+        }
+        monitor.refresh_parity_ready(source_5);
+        monitor
+            .fresh
+            .with_label_values(&[source_5.chain.as_str()])
+            .set(1);
+
+        let source_5_activation = monitor.maybe_activate_source_authority(5);
+        tokio::pin!(source_5_activation);
+        assert!(timeout(Duration::from_millis(10), &mut source_5_activation)
             .await
-            .expect("paused supervisor resumes after timeout")
-            .expect("supervisor simulation");
-        assert!(monitor.authority_handoff.paused.lock().is_empty());
+            .is_err());
+        let source_5_command = source_5_receiver.borrow_and_update();
+        assert!(source_5_command.desired);
+        assert!(!source_6_receiver.borrow_and_update().desired);
+
+        // An acknowledgement for another origin cannot complete this handoff.
+        source_5_receiver.mark_paused(6, source_5_command.generation);
+        assert!(timeout(Duration::from_millis(10), &mut source_5_activation)
+            .await
+            .is_err());
+        source_5_receiver.mark_paused(5, source_5_command.generation);
+        source_5_activation.await;
+        assert!(monitor.source_authority(5).active.load(Ordering::Acquire));
+        assert!(!monitor.source_authority(6).active.load(Ordering::Acquire));
+
+        let source_6 = monitor.sources.get(&6).expect("source 6");
+        for kind in [
+            EventKind::Dispatch,
+            EventKind::GasPayment,
+            EventKind::MerkleTreeInsertion,
+        ] {
+            monitor.set_source_caught_up(source_6, kind, true);
+        }
+        monitor.refresh_parity_ready(source_6);
+        monitor
+            .fresh
+            .with_label_values(&[source_6.chain.as_str()])
+            .set(1);
+        let source_6_activation = monitor.maybe_activate_source_authority(6);
+        tokio::pin!(source_6_activation);
+        assert!(timeout(Duration::from_millis(10), &mut source_6_activation)
+            .await
+            .is_err());
+        let source_6_command = source_6_receiver.borrow_and_update();
+        source_6_receiver.mark_paused(6, source_6_command.generation);
+        source_6_activation.await;
+        assert!(monitor.source_authority(6).active.load(Ordering::Acquire));
+
+        monitor.deactivate_source_authority(6);
+        assert!(monitor.source_authority(5).active.load(Ordering::Acquire));
+        assert!(source_5_receiver.borrow_and_update().desired);
+        assert!(!monitor.source_authority(6).active.load(Ordering::Acquire));
+        assert!(!source_6_receiver.borrow_and_update().desired);
     }
 
     #[test]
@@ -3650,7 +3794,7 @@ mod tests {
             true,
         )
         .expect("create authority monitor");
-        let mut receiver = monitor.authority_receiver().expect("authority receiver");
+        let mut receiver = monitor.authority_receiver(5).expect("authority receiver");
         monitor.set_active(true);
         monitor.gas_payment_enabled.store(true, Ordering::Release);
         for source in monitor.sources.values() {
@@ -3799,7 +3943,7 @@ mod tests {
             true,
         )
         .expect("create authority monitor");
-        let mut receiver = monitor.authority_receiver().expect("authority receiver");
+        let mut receiver = monitor.authority_receiver(5).expect("authority receiver");
         monitor.set_active(true);
         monitor.gas_payment_enabled.store(true, Ordering::Release);
         monitor.set_caught_up(true);

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -60,6 +60,9 @@ const PARITY_READ_TIMEOUT: Duration = Duration::from_millis(250);
 const PARITY_RETRY_DELAY: Duration = Duration::from_secs(1);
 #[cfg(test)]
 const PARITY_RETRY_DELAY: Duration = Duration::from_millis(10);
+#[cfg(not(test))]
+const PARITY_RETRY_ATTEMPTS: usize = 300;
+#[cfg(test)]
 const PARITY_RETRY_ATTEMPTS: usize = 60;
 const PARITY_WARN_INTERVAL: Duration = Duration::from_secs(60);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -2666,7 +2666,6 @@ impl ScraperWebSocketMonitor {
                                         "Invalid gas payment source unexpectedly missing",
                                     )?;
                                     source.store_gas_payment_degraded()?;
-                                    self.deactivate_authority();
                                     if state.gas_payment_degraded.insert(domain) {
                                         self.set_source_caught_up(
                                             source,
@@ -2685,6 +2684,9 @@ impl ScraperWebSocketMonitor {
                                             "Relayer scraper-proxy gas payment shadow stream degraded"
                                         );
                                     }
+                                    // Invalidate readiness before revoking authority so a
+                                    // concurrent freshness result cannot reactivate it.
+                                    self.deactivate_authority();
                                 }
                             }
                         }

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -33,6 +33,9 @@ use hyperlane_core::{
 };
 
 const RETRY_DELAY: Duration = Duration::from_secs(5);
+// Rejected subscriptions usually require scraper history/configuration to change.
+// Keep RPC indexing active and periodically probe instead of hammering catch-up.
+const REJECTED_STREAM_RETRY_DELAY: Duration = Duration::from_secs(300);
 const RETRY_JITTER_MS: u32 = 5_000;
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const PROGRESS_CHECK_INTERVAL: Duration = Duration::from_secs(30);
@@ -45,6 +48,22 @@ const NEXT_SEQUENCE_KEY: &str = "merkle_tree_hook_websocket_next_sequence_";
 // Bound crash recovery scans without writing the cursor for every replayed leaf.
 const NEXT_SEQUENCE_PERSIST_INTERVAL: u32 = 256;
 pub(crate) type MerkleTreeCursorState = Arc<Mutex<Option<u32>>>;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Scraper-proxy rejected Merkle tree hook stream: {0}")]
+struct RejectedStream(String);
+
+fn stream_retry_delay(result: &Result<()>, retry_delay: Duration) -> Duration {
+    if result
+        .as_ref()
+        .err()
+        .is_some_and(|err| err.downcast_ref::<RejectedStream>().is_some())
+    {
+        REJECTED_STREAM_RETRY_DELAY.saturating_add(retry_delay)
+    } else {
+        retry_delay
+    }
+}
 
 pub(crate) fn merkle_tree_cursor_state() -> MerkleTreeCursorState {
     Arc::new(Mutex::new(None))
@@ -421,7 +440,7 @@ impl MerkleTreeHookWebSocketSync {
         // backed by a lagging scraper.
         let mut fallback = Some(start_fallback());
         loop {
-            match self
+            let result = self
                 .stream_with_timeout(
                     &mut next_sequence,
                     backfill_target,
@@ -429,8 +448,9 @@ impl MerkleTreeHookWebSocketSync {
                     timeouts,
                     &dependencies,
                 )
-                .await
-            {
+                .await;
+            let reconnect_delay = stream_retry_delay(&result, retry_delay);
+            match result {
                 Ok(()) => warn!(
                     domain = self.domain,
                     "Merkle tree hook WebSocket closed; reconnecting"
@@ -438,6 +458,7 @@ impl MerkleTreeHookWebSocketSync {
                 Err(err) => warn!(
                     ?err,
                     domain = self.domain,
+                    ?reconnect_delay,
                     "Merkle tree hook WebSocket failed; reconnecting"
                 ),
             }
@@ -449,7 +470,7 @@ impl MerkleTreeHookWebSocketSync {
                     "Switched Merkle tree hook indexing to RPC fallback"
                 );
             }
-            sleep(retry_delay).await;
+            sleep(reconnect_delay).await;
         }
     }
 
@@ -644,7 +665,7 @@ impl MerkleTreeHookWebSocketSync {
                         }
                     }
                     ServerMessage::Error { error } => {
-                        bail!("Scraper-proxy rejected Merkle tree hook stream: {error}")
+                        return Err(RejectedStream(error).into());
                     }
                     ServerMessage::Other => {}
                 },
@@ -1987,6 +2008,89 @@ mod tests {
         assert!(sync
             .validate_caught_up(&hook, 1, EVENT_TYPE, "-2", 0)
             .is_err());
+    }
+
+    #[test]
+    fn rejected_streams_use_slow_retry_but_transport_errors_do_not() {
+        let rejected =
+            Err(RejectedStream("Failed to catch up merkle_tree_insertion".into()).into());
+        assert_eq!(
+            stream_retry_delay(&rejected, RETRY_DELAY),
+            Duration::from_secs(305)
+        );
+        assert_eq!(
+            stream_retry_delay(&Err(eyre!("connection reset")), RETRY_DELAY),
+            RETRY_DELAY
+        );
+        assert_eq!(stream_retry_delay(&Ok(()), RETRY_DELAY), RETRY_DELAY);
+    }
+
+    #[tokio::test]
+    async fn rejected_catch_up_keeps_rpc_active_without_reconnect_churn() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener");
+        let (mut sync, _temp_dir) = test_sync();
+        sync.url = Url::parse(&format!(
+            "ws://{}",
+            listener.local_addr().expect("test listener address")
+        ))
+        .expect("test WebSocket URL");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("first connection");
+            let mut socket = accept_async(stream).await.expect("WebSocket");
+            socket
+                .send(Message::Text(r#"{"type":"ready"}"#.into()))
+                .await
+                .expect("send ready");
+            socket
+                .next()
+                .await
+                .expect("subscription")
+                .expect("read subscription");
+            socket
+                .send(Message::Text(
+                    r#"{"type":"error","error":"Failed to catch up merkle_tree_insertion"}"#.into(),
+                ))
+                .await
+                .expect("reject unavailable history");
+            // Normal reconnects use 1ms in this test. A history rejection must
+            // leave the fallback running instead of repeatedly resubscribing.
+            assert!(timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err());
+        });
+        let active = sync.fallback_active.clone();
+        let active_in_fallback = active.clone();
+        let websocket_active = sync.websocket_active.clone();
+        let task = tokio::spawn(async move {
+            sync.run_loop(
+                4,
+                4,
+                StreamTimeouts {
+                    read: Duration::from_secs(1),
+                    progress_check: Duration::from_secs(1),
+                    progress_grace: Duration::from_secs(1),
+                },
+                Duration::from_millis(1),
+                test_dependencies_with_count(Arc::new(AtomicUsize::new(4))),
+                move || {
+                    active_in_fallback.set(1);
+                    RpcFallback {
+                        handle: tokio::spawn(pending()),
+                        active: active_in_fallback.clone(),
+                    }
+                },
+            )
+            .await;
+        });
+        timeout(Duration::from_secs(5), server)
+            .await
+            .expect("server completed")
+            .expect("server assertions passed");
+        assert_eq!(active.get(), 1);
+        assert_eq!(websocket_active.get(), 0);
+        task.abort();
     }
 
     #[tokio::test]

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,34 +43,34 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'be18813-20260908-054007',
-  relayerRC: 'be18813-20260908-054007',
-  relayerFastPath: 'be18813-20260908-054007',
-  validator: 'cb7237c-20260908-141540',
-  validatorRC: 'be18813-20260908-054007',
-  validatorFastPath: 'cb7237c-20260908-141540',
-  scraper: 'be18813-20260908-054007',
+  relayer: '01ccfea-20260908-170823',
+  relayerRC: '01ccfea-20260908-170823',
+  relayerFastPath: '01ccfea-20260908-170823',
+  validator: '01ccfea-20260908-170823',
+  validatorRC: '01ccfea-20260908-170823',
+  validatorFastPath: '01ccfea-20260908-170823',
+  scraper: '01ccfea-20260908-170823',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
-  keyFunder: '757150f-20260908-042619',
-  warpMonitor: '757150f-20260908-042619',
-  rebalancer: '757150f-20260908-042619',
-  scraperProxy: 'cb7237c-20260908-145436',
+  keyFunder: '01ccfea-20260908-170716',
+  warpMonitor: '01ccfea-20260908-170716',
+  rebalancer: '01ccfea-20260908-170716',
+  scraperProxy: '01ccfea-20260908-170716',
   feeQuoting: '12d899d-20260325-184337',
 };
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: 'be18813-20260908-054007',
-  relayerRC: 'be18813-20260908-054007',
-  relayerFastPath: 'be18813-20260908-054007',
-  validator: 'cb7237c-20260908-141540',
-  validatorRC: 'be18813-20260908-054007',
-  validatorFastPath: 'cb7237c-20260908-141540',
-  scraper: 'be18813-20260908-054007',
+  relayer: '01ccfea-20260908-170823',
+  relayerRC: '01ccfea-20260908-170823',
+  relayerFastPath: '01ccfea-20260908-170823',
+  validator: '01ccfea-20260908-170823',
+  validatorRC: '01ccfea-20260908-170823',
+  validatorFastPath: '01ccfea-20260908-170823',
+  scraper: '01ccfea-20260908-170823',
   // standalone services
-  keyFunder: '757150f-20260908-042619',
-  scraperProxy: '757150f-20260908-042619',
+  keyFunder: '01ccfea-20260908-170716',
+  scraperProxy: '01ccfea-20260908-170716',
 };

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '038b3c3-20260908-184110',
-  relayerRC: '038b3c3-20260908-184110',
-  relayerFastPath: '038b3c3-20260908-184110',
-  validator: '038b3c3-20260908-184110',
-  validatorRC: '038b3c3-20260908-184110',
-  validatorFastPath: '038b3c3-20260908-184110',
-  scraper: '038b3c3-20260908-184110',
+  relayer: '97b9381-20260908-190838',
+  relayerRC: '97b9381-20260908-190838',
+  relayerFastPath: '97b9381-20260908-190838',
+  validator: '97b9381-20260908-190838',
+  validatorRC: '97b9381-20260908-190838',
+  validatorFastPath: '97b9381-20260908-190838',
+  scraper: '97b9381-20260908-190838',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '038b3c3-20260908-184110',
-  relayerRC: '038b3c3-20260908-184110',
-  relayerFastPath: '038b3c3-20260908-184110',
-  validator: '038b3c3-20260908-184110',
-  validatorRC: '038b3c3-20260908-184110',
-  validatorFastPath: '038b3c3-20260908-184110',
-  scraper: '038b3c3-20260908-184110',
+  relayer: '97b9381-20260908-190838',
+  relayerRC: '97b9381-20260908-190838',
+  relayerFastPath: '97b9381-20260908-190838',
+  validator: '97b9381-20260908-190838',
+  validatorRC: '97b9381-20260908-190838',
+  validatorFastPath: '97b9381-20260908-190838',
+  scraper: '97b9381-20260908-190838',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
   scraperProxy: 'fc544bf-20260908-174702',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,34 +43,34 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '01ccfea-20260908-170823',
-  relayerRC: '01ccfea-20260908-170823',
-  relayerFastPath: '01ccfea-20260908-170823',
-  validator: '01ccfea-20260908-170823',
-  validatorRC: '01ccfea-20260908-170823',
-  validatorFastPath: '01ccfea-20260908-170823',
-  scraper: '01ccfea-20260908-170823',
+  relayer: '98c7f55-20260908-174457',
+  relayerRC: '98c7f55-20260908-174457',
+  relayerFastPath: '98c7f55-20260908-174457',
+  validator: '98c7f55-20260908-174457',
+  validatorRC: '98c7f55-20260908-174457',
+  validatorFastPath: '98c7f55-20260908-174457',
+  scraper: '98c7f55-20260908-174457',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
-  keyFunder: '01ccfea-20260908-170716',
-  warpMonitor: '01ccfea-20260908-170716',
-  rebalancer: '01ccfea-20260908-170716',
-  scraperProxy: '01ccfea-20260908-170716',
+  keyFunder: 'fc544bf-20260908-174702',
+  warpMonitor: 'fc544bf-20260908-174702',
+  rebalancer: 'fc544bf-20260908-174702',
+  scraperProxy: 'fc544bf-20260908-174702',
   feeQuoting: '12d899d-20260325-184337',
 };
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '01ccfea-20260908-170823',
-  relayerRC: '01ccfea-20260908-170823',
-  relayerFastPath: '01ccfea-20260908-170823',
-  validator: '01ccfea-20260908-170823',
-  validatorRC: '01ccfea-20260908-170823',
-  validatorFastPath: '01ccfea-20260908-170823',
-  scraper: '01ccfea-20260908-170823',
+  relayer: '98c7f55-20260908-174457',
+  relayerRC: '98c7f55-20260908-174457',
+  relayerFastPath: '98c7f55-20260908-174457',
+  validator: '98c7f55-20260908-174457',
+  validatorRC: '98c7f55-20260908-174457',
+  validatorFastPath: '98c7f55-20260908-174457',
+  scraper: '98c7f55-20260908-174457',
   // standalone services
-  keyFunder: '01ccfea-20260908-170716',
-  scraperProxy: '01ccfea-20260908-170716',
+  keyFunder: 'fc544bf-20260908-174702',
+  scraperProxy: 'fc544bf-20260908-174702',
 };

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '98c7f55-20260908-174457',
-  relayerRC: '98c7f55-20260908-174457',
-  relayerFastPath: '98c7f55-20260908-174457',
-  validator: '98c7f55-20260908-174457',
-  validatorRC: '98c7f55-20260908-174457',
-  validatorFastPath: '98c7f55-20260908-174457',
-  scraper: '98c7f55-20260908-174457',
+  relayer: '038b3c3-20260908-184110',
+  relayerRC: '038b3c3-20260908-184110',
+  relayerFastPath: '038b3c3-20260908-184110',
+  validator: '038b3c3-20260908-184110',
+  validatorRC: '038b3c3-20260908-184110',
+  validatorFastPath: '038b3c3-20260908-184110',
+  scraper: '038b3c3-20260908-184110',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '98c7f55-20260908-174457',
-  relayerRC: '98c7f55-20260908-174457',
-  relayerFastPath: '98c7f55-20260908-174457',
-  validator: '98c7f55-20260908-174457',
-  validatorRC: '98c7f55-20260908-174457',
-  validatorFastPath: '98c7f55-20260908-174457',
-  scraper: '98c7f55-20260908-174457',
+  relayer: '038b3c3-20260908-184110',
+  relayerRC: '038b3c3-20260908-184110',
+  relayerFastPath: '038b3c3-20260908-184110',
+  validator: '038b3c3-20260908-184110',
+  validatorRC: '038b3c3-20260908-184110',
+  validatorFastPath: '038b3c3-20260908-184110',
+  scraper: '038b3c3-20260908-184110',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
   scraperProxy: 'fc544bf-20260908-174702',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '97b9381-20260908-190838',
-  relayerRC: '97b9381-20260908-190838',
-  relayerFastPath: '97b9381-20260908-190838',
-  validator: '97b9381-20260908-190838',
-  validatorRC: '97b9381-20260908-190838',
-  validatorFastPath: '97b9381-20260908-190838',
-  scraper: '97b9381-20260908-190838',
+  relayer: '6ceef02-20260908-192717',
+  relayerRC: '6ceef02-20260908-192717',
+  relayerFastPath: '6ceef02-20260908-192717',
+  validator: '6ceef02-20260908-192717',
+  validatorRC: '6ceef02-20260908-192717',
+  validatorFastPath: '6ceef02-20260908-192717',
+  scraper: '6ceef02-20260908-192717',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '97b9381-20260908-190838',
-  relayerRC: '97b9381-20260908-190838',
-  relayerFastPath: '97b9381-20260908-190838',
-  validator: '97b9381-20260908-190838',
-  validatorRC: '97b9381-20260908-190838',
-  validatorFastPath: '97b9381-20260908-190838',
-  scraper: '97b9381-20260908-190838',
+  relayer: '6ceef02-20260908-192717',
+  relayerRC: '6ceef02-20260908-192717',
+  relayerFastPath: '6ceef02-20260908-192717',
+  validator: '6ceef02-20260908-192717',
+  validatorRC: '6ceef02-20260908-192717',
+  validatorFastPath: '6ceef02-20260908-192717',
+  scraper: '6ceef02-20260908-192717',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
   scraperProxy: 'fc544bf-20260908-174702',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '6ceef02-20260908-192717',
-  relayerRC: '6ceef02-20260908-192717',
-  relayerFastPath: '6ceef02-20260908-192717',
-  validator: '6ceef02-20260908-192717',
-  validatorRC: '6ceef02-20260908-192717',
-  validatorFastPath: '6ceef02-20260908-192717',
-  scraper: '6ceef02-20260908-192717',
+  relayer: '856576e-20260908-194828',
+  relayerRC: '856576e-20260908-194828',
+  relayerFastPath: '856576e-20260908-194828',
+  validator: '856576e-20260908-194828',
+  validatorRC: '856576e-20260908-194828',
+  validatorFastPath: '856576e-20260908-194828',
+  scraper: '856576e-20260908-194828',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '6ceef02-20260908-192717',
-  relayerRC: '6ceef02-20260908-192717',
-  relayerFastPath: '6ceef02-20260908-192717',
-  validator: '6ceef02-20260908-192717',
-  validatorRC: '6ceef02-20260908-192717',
-  validatorFastPath: '6ceef02-20260908-192717',
-  scraper: '6ceef02-20260908-192717',
+  relayer: '856576e-20260908-194828',
+  relayerRC: '856576e-20260908-194828',
+  relayerFastPath: '856576e-20260908-194828',
+  validator: '856576e-20260908-194828',
+  validatorRC: '856576e-20260908-194828',
+  validatorFastPath: '856576e-20260908-194828',
+  scraper: '856576e-20260908-194828',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
   scraperProxy: 'fc544bf-20260908-174702',

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -241,6 +241,85 @@ void it('keeps agent capacity independent from Explorer capacity', async () => {
   );
 });
 
+void it('accepts fleet-sized agent subscriptions without raising the Explorer payload limit', async () => {
+  const { EventWebSocketServer } = await import('./event-websocket.js');
+  const payloadHttp = createServer();
+  const payloadEvents = new EventWebSocketServer(
+    {
+      ...db,
+      async listen() {
+        return async () => undefined;
+      },
+    },
+    {
+      maxAgentClients: 1,
+      maxBufferedBytes: 65_536,
+      maxExplorerClients: 1,
+      maxTotalBufferedBytes: 65_536,
+    },
+  );
+  await new Promise<void>((resolve) =>
+    payloadHttp.listen(0, '127.0.0.1', resolve),
+  );
+  const address = payloadHttp.address();
+  assert(address && typeof address !== 'string');
+  await payloadEvents.start(payloadHttp);
+
+  const payloadUrl = `ws://127.0.0.1:${address.port}`;
+  const agent = new WebSocket(`${payloadUrl}/agents`);
+  const agentMessages: Record<string, unknown>[] = [];
+  agent.on('message', (data) => agentMessages.push(parseRecord(rawData(data))));
+  const explorer = new WebSocket(`${payloadUrl}/messages`, {
+    headers: { 'cf-connecting-ip': '203.0.113.100' },
+  });
+  const explorerMessages: Record<string, unknown>[] = [];
+  explorer.on('message', (data) =>
+    explorerMessages.push(parseRecord(rawData(data))),
+  );
+
+  try {
+    await Promise.all([
+      waitFor(agentMessages, 'ready'),
+      waitFor(explorerMessages, 'ready'),
+    ]);
+    const subscription = JSON.stringify({
+      streams: [
+        {
+          cursors: Array.from({ length: 64 }, (_, domain) => ({
+            address: `0x${domain.toString(16).padStart(40, '0')}`,
+            afterSequence: '0',
+            domain,
+          })),
+          eventType: 'dispatch',
+        },
+      ],
+      type: 'subscribe',
+    });
+    assert(Buffer.byteLength(subscription) > 4_096);
+    agent.send(subscription);
+    await waitFor(agentMessages, 'subscribed');
+    assert.equal(agent.readyState, WebSocket.OPEN);
+
+    explorer.send('x'.repeat(4_097));
+    const code = await new Promise<number>((resolve) =>
+      explorer.once('close', resolve),
+    );
+    assert.equal(code, 1009);
+  } finally {
+    agent.close();
+    explorer.close();
+    await waitUntil(() =>
+      [agent, explorer].every(
+        ({ readyState }) => readyState === WebSocket.CLOSED,
+      ),
+    );
+    await payloadEvents.stop();
+    await new Promise<void>((resolve, reject) =>
+      payloadHttp.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
 void it('requires the Cloudflare client IP in production', async () => {
   const nodeEnv = process.env.NODE_ENV;
   process.env.NODE_ENV = 'production';

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -40,6 +40,7 @@ import {
 import { rawData } from './websocket-data.js';
 
 const AGENT_PATH = '/agents';
+const MAX_AGENT_MESSAGE_BYTES = 1_048_576;
 const MESSAGE_PATH = '/messages';
 const EVENT_CHANNEL = 'scraper_event';
 const EXPLORER_CHANNEL = 'scraper_explorer_event';
@@ -219,7 +220,10 @@ export class EventWebSocketServer {
     }
     await this.connectListener();
     this.agentServer = new WebSocketServer({
-      maxPayload: 4_096,
+      // Agent subscriptions carry one cursor per chain and stream, so the
+      // fleet-wide relayer payload is substantially larger than an Explorer
+      // client request. Keep it bounded independently from outbound buffers.
+      maxPayload: MAX_AGENT_MESSAGE_BYTES,
       noServer: true,
     });
     this.explorerServer = new WebSocketServer({


### PR DESCRIPTION
## Summary

- pins every mainnet/testnet Rust-agent role to `856576e-20260908-194828`
- completes the centralized scraper-WebSocket relayer rollout
- fixes rollout-discovered parity/cutover issues without weakening RPC fallback
- keeps RC disabled

## Runtime fixes

- tracks dispatch and Merkle stream sequences independently
- gives finalized RPC parity up to five minutes to converge
- accepts Sealevel's explicit zero transaction-ID sentinel; nonzero mismatches still conflict
- versions the false-positive parity poison epoch after exhaustive first-deployment log review
- moves scraper authority from all-or-nothing fleet gating to independent per-origin handoffs
- retains caught-up, parity, freshness, and acknowledged RPC-pause gates before authoritative writes

## Validation

- `cargo check -p relayer --tests`
- `cargo fmt --all -- --check`
- `cargo test -p relayer scraper_websocket::tests` — 76 passed
- independent focused review: no safety blocker
- [agent build 34271086716](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34271086716) succeeded from `856576e7f3`
- image digest: `sha256:34d18feeea2ef45aa2c1f7b031aa67d31dd9e7466cbfae98682487089d738619`

## Rollout readback

- testnet4 standard/fastpath relayers: revisions 249/24, Ready, zero restarts
- mainnet3 standard/fastpath relayers: revisions 629/49, Ready, zero restarts
- mainnet standard: 74/74 sources active, 222/222 streams caught up, zero pending parity, 67/74 origins authoritative
- mainnet fastpath: 7/7 authoritative, 21/21 streams caught up, zero pending parity
- remaining standard origins retain safe RPC fallback: Adichain, Apechain, LazAI, Moca Chain, Nexus, Somnia, Stable
- RC remains scaled to zero

The rollout's scraper-proxy alert was transient client-disconnect `send_error` noise during pod replacement. Listener readiness remained 1; no restart, limit rejection, buffer pressure, or queue overflow was observed.
