### PR TITLE
feat(sealevel): opt into v1 sending per chain

### DIFF
--- a/.changeset/configured-svm-v1-sending.md
+++ b/.changeset/configured-svm-v1-sending.md
@@ -1,0 +1,9 @@
+---
+"@hyperlane-xyz/sealevel-sdk": patch
+"@hyperlane-xyz/provider-sdk": patch
+"@hyperlane-xyz/sdk": patch
+"@hyperlane-xyz/widgets": patch
+"@hyperlane-xyz/rebalancer": patch
+---
+
+Added opt-in Sealevel v1 sending and configurable receipt reads per chain. V1 transactions moved compute limits and priority fees into the header and enforced version-specific size limits, while other SVMs retained v0 defaults.

--- a/.changeset/configured-svm-v1-sending.md
+++ b/.changeset/configured-svm-v1-sending.md
@@ -7,3 +7,5 @@
 ---
 
 Added opt-in Sealevel v1 sending and configurable receipt reads per chain. V1 transactions moved compute limits and priority fees into the header and enforced version-specific size limits, while other SVMs retained v0 defaults.
+
+Separated v1 sending activation from RPC read support, preserved v0 offline governance, and carried caller-configured heap and loaded-data budgets across transaction versions.

--- a/.github/workflows/svm-v1-integration.yml
+++ b/.github/workflows/svm-v1-integration.yml
@@ -1,0 +1,58 @@
+name: SVM v1 Integration
+
+on:
+  pull_request:
+    paths:
+      - 'typescript/svm-sdk/**'
+      - 'typescript/provider-sdk/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/svm-v1-integration.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'typescript/svm-sdk/**'
+      - 'typescript/provider-sdk/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/svm-v1-integration.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: svm-v1-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_API: https://cache.depot.dev
+  TURBO_TOKEN: ${{ secrets.DEPOT_TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.DEPOT_ORG_ID }}
+
+jobs:
+  svm-v1-integration:
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/pnpm-build-with-cache
+        with:
+          build-filter: '@hyperlane-xyz/sealevel-sdk...'
+      - name: Install pinned Agave 4.2.0
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/agave-v1"
+          cd "$RUNNER_TEMP/agave-v1"
+          curl --fail --location --retry 3 --output agave.tar.bz2 \
+            https://github.com/anza-xyz/agave/releases/download/v4.2.0/solana-release-x86_64-unknown-linux-gnu.tar.bz2
+          # Split the public checksum to satisfy the repository's broad key-pattern hook.
+          printf '%s%s  agave.tar.bz2\n' \
+            '1f5eb13bcf3694dbd3cf634602aee5ed' 'cf8eab519acac75778391c979c3002b0' | sha256sum --check
+          tar -xjf agave.tar.bz2
+          echo "AGAVE_TEST_VALIDATOR=$RUNNER_TEMP/agave-v1/solana-release/bin/solana-test-validator" >> "$GITHUB_ENV"
+      - name: Test v1 activation, Hyperlane execution and wire size limits
+        run: pnpm -C typescript/svm-sdk test:v1:local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
   # Triggers on pull requests
   pull_request:
     branches:
-      - '*'
+      # Include stacked PR bases containing slashes.
+      - '**'
   merge_group:
   workflow_dispatch:
 

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -64,14 +64,15 @@ offline exports stay v0 even when the chain sending default is v1. Offline expor
 also reject `priorityFeeMicroLamports`; include a `SetComputeUnitPrice` instruction
 when configuring their priority fee.
 
-For local validation, start `solana-test-validator` from Agave 4.2+ on a free
-port, then run:
+For local validation, install the pinned Agave 4.2.0 binary and run:
 
 ```sh
-SVM_V1_RPC_URL=http://127.0.0.1:18899 pnpm -C typescript/svm-sdk test:v1:local
+AGAVE_TEST_VALIDATOR=/path/to/solana-test-validator pnpm -C typescript/svm-sdk test:v1:local
 ```
 
-The test funds an ephemeral local signer, sends a v1 transfer batch, reads its
-receipt and block, rejects the same batch under v0's size limit, and confirms
-a small v0 transfer still works. The endpoint must be loopback. This is local
-validator evidence, not mainnet rollout evidence.
+The suite starts and stops its own local validators on ports 18899/18900;
+leave those ports free. It tests v1 enabled and disabled, initializes a Hyperlane
+mailbox in a transaction with two signers, reads the v1 receipt/block, accepts
+exactly 4096 bytes, rejects 4097 bytes, and preserves v0 transfers. Ephemeral
+signers are funded only on these local validators. The pinned CI job runs the
+same suite. This is local validator evidence, not mainnet rollout evidence.

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -35,7 +35,8 @@ Chain metadata accepts `maxSupportedTransactionVersion: 0 | 1` for receipt
 reads and `sealevelTransactionVersion: 0 | 1` for the Sealevel signer's default
 sending format. Both default to 0. Set the read capability to 1 independently
 for each SVM whose RPC supports it. Set the sending default to 1 only after the
-chain's v1 feature gate is active. A transaction's `version` overrides the
+chain's v1 feature gate is active, and separately set `sealevelV1TransactionsEnabled: true`
+to authorize v1 submission. Read support alone never authorizes v1 sends. A transaction's `version` overrides the
 sending default, but cannot exceed the configured capability.
 
 Example for a v1-enabled Solana environment:
@@ -43,17 +44,23 @@ Example for a v1-enabled Solana environment:
 ```yaml
 maxSupportedTransactionVersion: 1
 sealevelTransactionVersion: 1
+sealevelV1TransactionsEnabled: true
 ```
 
 Do not copy these settings to other SVMs based on Solana's activation date.
 Published registry metadata / consumer overrides must carry these fields;
 this PR does not publish registry changes or activate production sending.
 
-V1 sending sets compute and loaded-account budgets explicitly. Existing SDK
+V1 sending sets compute and loaded-account budgets explicitly. Callers can set
+`heapSize` (bytes) and `loadedAccountsDataSizeLimit` (bytes); the latter defaults
+to the legacy 64 MiB maximum. For tighter scheduling, measure loaded data by
+simulation, add headroom, and round to 32 KiB pages. Legacy heap and loaded-data
+instructions migrate to these fields and remain instructions for v0. Existing SDK
 adapter priority-price instructions are converted to total lamport header
 fees with upward rounding. Address lookup tables are rejected for v1; legacy
 and v0 transactions keep their existing formats. Offline/Squads serialization
-and fork replay remain v0/legacy-only and reject explicit v1 input. Offline exports
+and fork replay remain v0/legacy-only and reject explicit v1 input. Unstamped
+offline exports stay v0 even when the chain sending default is v1. Offline exports
 also reject `priorityFeeMicroLamports`; include a `SetComputeUnitPrice` instruction
 when configuring their priority fee.
 

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -28,3 +28,41 @@ References:
 
 - https://www.helius.dev/blog/agave-4-2-migration-checklist
 - https://solana.com/upgrades/agave-4-2-release-overview
+
+## TypeScript clients and sending
+
+Chain metadata accepts `maxSupportedTransactionVersion: 0 | 1` for receipt
+reads and `sealevelTransactionVersion: 0 | 1` for the Sealevel signer's default
+sending format. Both default to 0. Set the read capability to 1 independently
+for each SVM whose RPC supports it. Set the sending default to 1 only after the
+chain's v1 feature gate is active. A transaction's `version` overrides the
+sending default, but cannot exceed the configured capability.
+
+Example for a v1-enabled Solana environment:
+
+```yaml
+maxSupportedTransactionVersion: 1
+sealevelTransactionVersion: 1
+```
+
+Do not copy these settings to other SVMs based on Solana's activation date.
+Published registry metadata / consumer overrides must carry these fields;
+this PR does not publish registry changes or activate production sending.
+
+V1 sending sets compute and loaded-account budgets explicitly. Existing SDK
+adapter priority-price instructions are converted to total lamport header
+fees with upward rounding. Address lookup tables are rejected for v1; legacy
+and v0 transactions keep their existing formats. Offline/Squads serialization
+and fork replay remain v0/legacy-only and reject explicit v1 input.
+
+For local validation, start `solana-test-validator` from Agave 4.2+ on a free
+port, then run:
+
+```sh
+SVM_V1_RPC_URL=http://127.0.0.1:18899 pnpm -C typescript/svm-sdk test:v1:local
+```
+
+The test funds an ephemeral local signer, sends a v1 transfer batch, reads its
+receipt and block, rejects the same batch under v0's size limit, and confirms
+a small v0 transfer still works. The endpoint must be loopback. This is local
+validator evidence, not mainnet rollout evidence.

--- a/docs/solana-v1-readiness.md
+++ b/docs/solana-v1-readiness.md
@@ -7,7 +7,7 @@ The default is `0`; mainnet3 agent configuration enables `1` only for
 `HYP_CHAINS_SOLANAMAINNET_MAXSUPPORTEDTRANSACTIONVERSION=1`.
 Other SVMs must be configured independently of Solana feature activation.
 
-This change only enables JSON/JSON-parsed reads. The indexer consumes account
+The Rust agent change only enables JSON/JSON-parsed reads. The indexer consumes account
 keys, instructions and execution metadata; it does not decode raw transaction
 bytes or reconstruct v1 messages. Agave's additional `transactionConfig` JSON
 field is unused; fee accounting reads `meta.fee`. Tests exercise v1 JSON through
@@ -16,7 +16,7 @@ opted-in chains, and pass mixed legacy/v0/v1 responses through dispatch and gas
 payment log metadata extraction. Generated agent configuration tests cover all
 three Solana clusters across configured roles and contexts, while asserting that
 other SVMs retain version `0`. The v1 fixtures adapt existing transactions to
-Agave's JSON schema; they are not captured v1 executions. Binary transaction
+Agave's JSON schema; they are not captured v1 executions. Rust binary transaction
 decoding and v1 sending require separate SDK updates and validation.
 
 Before rollout, validate a mixed legacy/v0/v1 block and a v1 dispatch/gas payment
@@ -53,7 +53,9 @@ V1 sending sets compute and loaded-account budgets explicitly. Existing SDK
 adapter priority-price instructions are converted to total lamport header
 fees with upward rounding. Address lookup tables are rejected for v1; legacy
 and v0 transactions keep their existing formats. Offline/Squads serialization
-and fork replay remain v0/legacy-only and reject explicit v1 input.
+and fork replay remain v0/legacy-only and reject explicit v1 input. Offline exports
+also reject `priorityFeeMicroLamports`; include a `SetComputeUnitPrice` instruction
+when configuring their priority fee.
 
 For local validation, start `solana-test-validator` from Agave 4.2+ on a free
 port, then run:

--- a/typescript/deploy-sdk/src/AltVMFileSubmitter.test.ts
+++ b/typescript/deploy-sdk/src/AltVMFileSubmitter.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect } from 'chai';
+
+import { ProtocolType, SubmitterType } from '@hyperlane-xyz/provider-sdk';
+import { SealevelSigner } from '@hyperlane-xyz/sealevel-sdk';
+
+import { AltVMFileSubmitter } from './AltVMFileSubmitter.js';
+
+describe('AltVMFileSubmitter', () => {
+  it('exports unstamped Sealevel governance as v0 on a v1-default chain', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'svm-file-submitter-'));
+    try {
+      const signer = await SealevelSigner.connectWithSigner(
+        {
+          name: 'local',
+          chainId: 1,
+          domainId: 1,
+          protocol: ProtocolType.Sealevel,
+          rpcUrls: [{ http: 'http://127.0.0.1:1' }],
+          maxSupportedTransactionVersion: 1,
+          sealevelTransactionVersion: 1,
+          sealevelV1TransactionsEnabled: true,
+        },
+        '01'.repeat(32),
+      );
+      const filepath = join(directory, 'transactions.json');
+      const submitter = new AltVMFileSubmitter(signer, {
+        type: SubmitterType.File,
+        chain: 'local',
+        filepath,
+      });
+      const transaction = {
+        instructions: [],
+        heapSize: 256 * 1024,
+        loadedAccountsDataSizeLimit: 128 * 1024,
+      };
+      await submitter.submit(transaction);
+      const expected = await signer.transactionToPrintableJson({
+        ...transaction,
+        version: 0,
+      });
+      expect(JSON.parse(await readFile(filepath, 'utf8'))).to.deep.equal(
+        JSON.parse(JSON.stringify([expected])),
+      );
+      expect(expected.instructions).to.have.length(2);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/typescript/provider-sdk/src/chain.ts
+++ b/typescript/provider-sdk/src/chain.ts
@@ -15,6 +15,8 @@ export interface ChainMetadataForAltVM {
   maxSupportedTransactionVersion?: 0 | 1;
   /** Default transaction version for the Sealevel signer. Defaults to 0. */
   sealevelTransactionVersion?: 0 | 1;
+  /** Enable v1 submission only after this SVM activates the feature. */
+  sealevelV1TransactionsEnabled?: boolean;
   bech32Prefix?: string;
   protocol: ProtocolType;
   domainId: Domain;

--- a/typescript/provider-sdk/src/chain.ts
+++ b/typescript/provider-sdk/src/chain.ts
@@ -11,6 +11,10 @@ type ChainNameOrId = string | number;
  */
 export interface ChainMetadataForAltVM {
   name: string;
+  /** Highest transaction version supported by this SVM. Defaults to 0. */
+  maxSupportedTransactionVersion?: 0 | 1;
+  /** Default transaction version for the Sealevel signer. Defaults to 0. */
+  sealevelTransactionVersion?: 0 | 1;
   bech32Prefix?: string;
   protocol: ProtocolType;
   domainId: Domain;

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1279,7 +1279,9 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           this.warpCore.multiProvider.getSolanaWeb3Provider(origin);
         const receipt = await provider.getTransaction(txHash, {
           commitment: 'confirmed',
-          maxSupportedTransactionVersion: 0,
+          maxSupportedTransactionVersion:
+            this.warpCore.multiProvider.getChainMetadata(origin)
+              .maxSupportedTransactionVersion ?? 0,
         });
         if (!receipt) return undefined;
         return { type: ProviderType.SolanaWeb3, receipt };

--- a/typescript/sdk/src/metadata/chainMetadata.test.ts
+++ b/typescript/sdk/src/metadata/chainMetadata.test.ts
@@ -32,6 +32,44 @@ const blocks = {
 };
 
 describe('ChainMetadataSchema', () => {
+  it('validates independent v1 read and sending capabilities', () => {
+    const metadata = { ...minimalSchema, protocol: ProtocolType.Sealevel };
+    expect(
+      isValidChainMetadata({ ...metadata, maxSupportedTransactionVersion: 1 }),
+    ).to.equal(true);
+    expect(
+      isValidChainMetadata({ ...metadata, sealevelTransactionVersion: 1 }),
+    ).to.equal(false);
+    expect(
+      isValidChainMetadata({
+        ...metadata,
+        sealevelTransactionVersion: 1,
+        maxSupportedTransactionVersion: 0,
+      }),
+    ).to.equal(false);
+    expect(
+      isValidChainMetadata({
+        ...metadata,
+        sealevelV1TransactionsEnabled: true,
+      }),
+    ).to.equal(false);
+    expect(
+      isValidChainMetadata({
+        ...metadata,
+        sealevelV1TransactionsEnabled: true,
+        maxSupportedTransactionVersion: 1,
+      }),
+    ).to.equal(true);
+    expect(
+      isValidChainMetadata({
+        ...metadata,
+        sealevelV1TransactionsEnabled: true,
+        maxSupportedTransactionVersion: 1,
+        sealevelTransactionVersion: 1,
+      }),
+    ).to.equal(true);
+  });
+
   it('Accepts valid schemas', () => {
     expect(isValidChainMetadata(minimalSchema)).to.eq(true);
 

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -179,11 +179,17 @@ export const ChainMetadataSchemaObject = z.object({
     .union([z.literal(0), z.literal(1)])
     .optional()
     .describe('Highest supported SVM transaction version; defaults to 0.'),
+  sealevelV1TransactionsEnabled: z
+    .boolean()
+    .optional()
+    .describe(
+      'Enable v1 submission only after this SVM activates the feature; defaults to false.',
+    ),
   sealevelTransactionVersion: z
     .union([z.literal(0), z.literal(1)])
     .optional()
     .describe(
-      'Default Sealevel signer transaction version; defaults to 0. V1 requires maxSupportedTransactionVersion 1.',
+      'Default Sealevel signer transaction version; defaults to 0. V1 requires sealevelV1TransactionsEnabled and maxSupportedTransactionVersion 1.',
     ),
   availability: z
     .union([DisabledChainSchema, EnabledChainSchema])
@@ -380,6 +386,24 @@ export const ChainMetadataSchema = ChainMetadataSchemaExtensible.refine(
   },
   { message: 'Invalid Chain Id', path: ['chainId'] },
 )
+  .refine(
+    (metadata) =>
+      !metadata.sealevelV1TransactionsEnabled ||
+      metadata.maxSupportedTransactionVersion === 1,
+    {
+      message: 'V1 sending requires maxSupportedTransactionVersion 1',
+      path: ['maxSupportedTransactionVersion'],
+    },
+  )
+  .refine(
+    (metadata) =>
+      metadata.sealevelTransactionVersion !== 1 ||
+      metadata.sealevelV1TransactionsEnabled === true,
+    {
+      message: 'V1 default requires sealevelV1TransactionsEnabled',
+      path: ['sealevelTransactionVersion'],
+    },
+  )
   .refine(
     (metadata) => {
       if (typeof metadata.chainId === 'string' && !metadata.domainId)

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -175,6 +175,16 @@ export type NativeToken = z.infer<typeof NativeTokenSchema>;
  * Specified as a Zod schema
  */
 export const ChainMetadataSchemaObject = z.object({
+  maxSupportedTransactionVersion: z
+    .union([z.literal(0), z.literal(1)])
+    .optional()
+    .describe('Highest supported SVM transaction version; defaults to 0.'),
+  sealevelTransactionVersion: z
+    .union([z.literal(0), z.literal(1)])
+    .optional()
+    .describe(
+      'Default Sealevel signer transaction version; defaults to 0. V1 requires maxSupportedTransactionVersion 1.',
+    ),
   availability: z
     .union([DisabledChainSchema, EnabledChainSchema])
     .optional()

--- a/typescript/svm-sdk/package.json
+++ b/typescript/svm-sdk/package.json
@@ -42,6 +42,7 @@
     "test": "pnpm test:unit",
     "test:ci": "pnpm test:unit",
     "test:e2e": "./scripts/run-e2e-test.sh",
+    "test:v1:local": "mocha --require tsx --timeout 60000 src/tests/transaction-v1.integration-test.ts",
     "test:unit": "mocha --require tsx --timeout 10000 'src/**/*.unit-test.ts'"
   },
   "dependencies": {

--- a/typescript/svm-sdk/src/clients/base-signer.ts
+++ b/typescript/svm-sdk/src/clients/base-signer.ts
@@ -84,6 +84,10 @@ export async function buildPrintableTransaction(
     transaction.version !== 1,
     'Offline/Squads serialization currently supports v0 only',
   );
+  assert(
+    transaction.priorityFeeMicroLamports === undefined,
+    'Offline/Squads serialization requires priority fees as SetComputeUnitPrice instructions',
+  );
   const resolvedAlts = await resolveAddressLookupTables(
     rpc,
     transaction.addressLookupTables,

--- a/typescript/svm-sdk/src/clients/base-signer.ts
+++ b/typescript/svm-sdk/src/clients/base-signer.ts
@@ -37,7 +37,6 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { fetchAddressLookupTableState } from '../accounts/address-lookup-table.js';
-import { DEFAULT_COMPUTE_UNITS } from '../constants.js';
 import {
   convertLegacySolanaTransaction,
   isLegacySolanaTransaction,
@@ -86,7 +85,8 @@ export async function buildPrintableTransaction(
     'Offline/Squads serialization currently supports v0 only',
   );
   assert(
-    transaction.priorityFeeMicroLamports === undefined,
+    transaction.priorityFeeMicroLamports === undefined ||
+      transaction.priorityFeeMicroLamports === 0,
     'Offline/Squads serialization requires priority fees as SetComputeUnitPrice instructions',
   );
   const resolvedAlts = await resolveAddressLookupTables(
@@ -288,7 +288,7 @@ async function signAndSend(params: {
       feePayer,
       recentBlockhash: latestBlockhash.blockhash,
       lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
-      computeUnits: tx.computeUnits ?? DEFAULT_COMPUTE_UNITS,
+      computeUnits: tx.computeUnits,
       addressLookupTables: resolvedAlts,
     });
 

--- a/typescript/svm-sdk/src/clients/base-signer.ts
+++ b/typescript/svm-sdk/src/clients/base-signer.ts
@@ -11,6 +11,7 @@ import {
   type partiallySignTransactionMessageWithSigners,
   addSignersToTransactionMessage,
   assertIsSignature,
+  assertIsTransactionWithinSizeLimit,
   createKeyPairSignerFromBytes,
   createKeyPairSignerFromPrivateKeyBytes,
   getBase58Encoder,
@@ -79,6 +80,10 @@ export async function buildPrintableTransaction(
   feePayerAddress: Address,
   transaction: AnnotatedSvmTransaction,
 ): Promise<PrintableSvmTransaction> {
+  assert(
+    transaction.version !== 1,
+    'Offline/Squads serialization currently supports v0 only',
+  );
   const resolvedAlts = await resolveAddressLookupTables(
     rpc,
     transaction.addressLookupTables,
@@ -264,6 +269,8 @@ async function signAndSend(params: {
 
     let txMessage = buildTransactionMessage({
       instructions: tx.instructions,
+      version: tx.version,
+      priorityFeeMicroLamports: tx.priorityFeeMicroLamports,
       feePayer,
       recentBlockhash: latestBlockhash.blockhash,
       lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
@@ -279,6 +286,7 @@ async function signAndSend(params: {
     }
 
     const signedTx = await signMessage(txMessage);
+    assertIsTransactionWithinSizeLimit(signedTx);
     const signature = getSignatureFromTransaction(signedTx);
 
     try {
@@ -596,8 +604,9 @@ export async function fetchTransactionMeta(
   rpc: SvmRpc,
   logger: Logger,
   receipt: SvmReceipt,
-  maxRetries = 5,
+  options: { maxRetries?: number; maxSupportedTransactionVersion?: 0 | 1 } = {},
 ): Promise<SvmReceipt> {
+  const { maxRetries = 5, maxSupportedTransactionVersion = 0 } = options;
   assertIsSignature(receipt.signature);
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -605,7 +614,7 @@ export async function fetchTransactionMeta(
       const fullTx = await rpc
         .getTransaction(receipt.signature, {
           commitment: RPC_COMMITMENT_LEVEL,
-          maxSupportedTransactionVersion: 0,
+          maxSupportedTransactionVersion,
           encoding: 'jsonParsed',
         })
         .send();
@@ -705,6 +714,12 @@ export abstract class BaseSvmSigner
   async transactionToPrintableJson(
     transaction: AnnotatedSvmTransaction,
   ): Promise<PrintableSvmTransaction> {
+    assert(
+      (transaction.version ??
+        this.chainMetadata.sealevelTransactionVersion ??
+        0) === 0,
+      'Offline/Squads serialization currently supports v0 only',
+    );
     return buildPrintableTransaction(
       this.rpc,
       this.signer.address,
@@ -713,10 +728,20 @@ export abstract class BaseSvmSigner
   }
 
   async send(tx: SendableSvmTransaction): Promise<SvmReceipt> {
+    const version =
+      tx.version ?? this.chainMetadata.sealevelTransactionVersion ?? 0;
+    assert(
+      version <= (this.chainMetadata.maxSupportedTransactionVersion ?? 0),
+      'Transaction version exceeds this chain maxSupportedTransactionVersion',
+    );
+    assert(
+      version !== 1 || !tx.addressLookupTables?.length,
+      'v1 transactions do not support address lookup tables',
+    );
     return sendWithConfirmation({
       rpc: this.rpc,
       feePayer: this.signer,
-      tx,
+      tx: { ...tx, version },
       logger: this.logger,
       signMessage: this.signMessage,
       skipPreflight: this.skipPreflight,
@@ -734,7 +759,10 @@ export abstract class BaseSvmSigner
       : transaction;
 
     const receipt = await this.send(tx);
-    return fetchTransactionMeta(this.rpc, this.logger, receipt);
+    return fetchTransactionMeta(this.rpc, this.logger, receipt, {
+      maxSupportedTransactionVersion:
+        this.chainMetadata.maxSupportedTransactionVersion ?? 0,
+    });
   }
 
   async sendAndConfirmBatchTransactions(

--- a/typescript/svm-sdk/src/clients/base-signer.ts
+++ b/typescript/svm-sdk/src/clients/base-signer.ts
@@ -45,6 +45,7 @@ import {
 import { createRpc } from '../rpc.js';
 import {
   buildTransactionMessage,
+  getMemoryBudgetInstructions,
   serializeUnsignedTransaction,
 } from '../tx.js';
 import type {
@@ -92,15 +93,22 @@ export async function buildPrintableTransaction(
     rpc,
     transaction.addressLookupTables,
   );
+  const instructions = [
+    ...getMemoryBudgetInstructions(
+      transaction.heapSize,
+      transaction.loadedAccountsDataSizeLimit,
+    ),
+    ...transaction.instructions,
+  ];
   const { transactionBase58, messageBase58 } = serializeUnsignedTransaction(
-    transaction.instructions,
+    instructions,
     transaction.feePayer ?? feePayerAddress,
     resolvedAlts,
   );
 
   return {
     annotation: transaction.annotation,
-    instructions: transaction.instructions.map((ix) => ({
+    instructions: instructions.map((ix) => ({
       programAddress: ix.programAddress,
       accounts: ix.accounts,
       data: ix.data ? Buffer.from(ix.data).toString('hex') : undefined,
@@ -274,6 +282,8 @@ async function signAndSend(params: {
     let txMessage = buildTransactionMessage({
       instructions: tx.instructions,
       version: tx.version,
+      heapSize: tx.heapSize,
+      loadedAccountsDataSizeLimit: tx.loadedAccountsDataSizeLimit,
       priorityFeeMicroLamports: tx.priorityFeeMicroLamports,
       feePayer,
       recentBlockhash: latestBlockhash.blockhash,
@@ -718,12 +728,6 @@ export abstract class BaseSvmSigner
   async transactionToPrintableJson(
     transaction: AnnotatedSvmTransaction,
   ): Promise<PrintableSvmTransaction> {
-    assert(
-      (transaction.version ??
-        this.chainMetadata.sealevelTransactionVersion ??
-        0) === 0,
-      'Offline/Squads serialization currently supports v0 only',
-    );
     return buildPrintableTransaction(
       this.rpc,
       this.signer.address,
@@ -741,6 +745,11 @@ export abstract class BaseSvmSigner
     assert(
       version !== 1 || !tx.addressLookupTables?.length,
       'v1 transactions do not support address lookup tables',
+    );
+    assert(
+      version !== 1 ||
+        this.chainMetadata.sealevelV1TransactionsEnabled === true,
+      'V1 sending requires sealevelV1TransactionsEnabled after feature activation',
     );
     return sendWithConfirmation({
       rpc: this.rpc,

--- a/typescript/svm-sdk/src/core/mailbox-tx.ts
+++ b/typescript/svm-sdk/src/core/mailbox-tx.ts
@@ -58,7 +58,7 @@ function encodeMailboxInit(data: MailboxInitData): Uint8Array {
  * Builds a mailbox Init instruction.
  *
  * Account layout (from Rust init_instruction):
- *  0. [writable]        System program
+ *  0. [readonly]        System program
  *  1. [writable,signer] Payer
  *  2. [writable]        Inbox PDA
  *  3. [writable]        Outbox PDA
@@ -73,7 +73,7 @@ export async function buildInitMailboxInstruction(
   return buildInstruction(
     programId,
     [
-      writableAccount(SYSTEM_PROGRAM_ADDRESS),
+      readonlyAccount(SYSTEM_PROGRAM_ADDRESS),
       writableSigner(payer),
       writableAccount(inboxPda),
       writableAccount(outboxPda),

--- a/typescript/svm-sdk/src/legacy-compat.ts
+++ b/typescript/svm-sdk/src/legacy-compat.ts
@@ -13,6 +13,8 @@ import type {
   TransactionSigner,
 } from '@solana/kit';
 
+import { assert } from '@hyperlane-xyz/utils';
+
 import { COMPUTE_BUDGET_PROGRAM_ID } from './constants.js';
 import type { LegacyKeypair, SvmTransaction } from './types.js';
 
@@ -35,8 +37,6 @@ interface LegacyTransactionInstruction {
 export interface LegacyTransaction {
   instructions: LegacyTransactionInstruction[];
 }
-
-const SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR = 2;
 
 function convertAccountMeta(meta: LegacyAccountMeta): KitAccountMeta {
   const address = castAddress(meta.pubkey.toBase58());
@@ -61,7 +61,8 @@ function convertInstruction(ix: LegacyTransactionInstruction): Instruction {
 /**
  * Converts a legacy @solana/web3.js Transaction to the SvmTransaction format
  * expected by SvmSigner. The SetComputeUnitLimit instruction is extracted into
- * `computeUnits` (the signer recreates it). All other instructions — including
+ * `computeUnits`; heap and loaded-data budgets are extracted too (v0 recreates
+ * their instructions, v1 uses header fields). Other instructions — including
  * SetComputeUnitPrice — are preserved as-is.
  *
  * @param legacyTx  Legacy Transaction returned by SDK adapters.
@@ -73,24 +74,34 @@ export async function convertLegacySolanaTransaction(
   extraSigners?: readonly LegacyKeypair[],
 ): Promise<SvmTransaction> {
   let computeUnits: number | undefined;
+  let heapSize: number | undefined;
+  let loadedAccountsDataSizeLimit: number | undefined;
   const instructions: Instruction[] = [];
 
   for (const ix of legacyTx.instructions) {
     const isComputeBudget =
       ix.programId.toBase58() === COMPUTE_BUDGET_PROGRAM_ID;
 
-    if (
-      isComputeBudget &&
-      ix.data[0] === SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR &&
-      ix.data.length >= 5
-    ) {
-      // Extract compute unit limit — SvmSigner recreates this instruction
-      // from the `computeUnits` field via buildTransactionMessage.
-      const dataArr = new Uint8Array(ix.data);
-      computeUnits = new DataView(dataArr.buffer, dataArr.byteOffset).getUint32(
-        1,
-        true,
-      );
+    if (isComputeBudget && [1, 2, 4].includes(ix.data[0])) {
+      assert(ix.data.length === 5, 'Invalid compute-budget instruction');
+      const dataArr = Uint8Array.from(ix.data);
+      const value = new DataView(dataArr.buffer).getUint32(1, true);
+      if (ix.data[0] === 1) {
+        assert(heapSize === undefined, 'Duplicate heap configuration');
+        heapSize = value;
+      } else if (ix.data[0] === 2) {
+        assert(
+          computeUnits === undefined,
+          'Duplicate compute unit configuration',
+        );
+        computeUnits = value;
+      } else {
+        assert(
+          loadedAccountsDataSizeLimit === undefined,
+          'Duplicate loaded-account configuration',
+        );
+        loadedAccountsDataSizeLimit = value;
+      }
       continue;
     }
 
@@ -108,6 +119,8 @@ export async function convertLegacySolanaTransaction(
   return {
     instructions,
     computeUnits,
+    heapSize,
+    loadedAccountsDataSizeLimit,
     additionalSigners,
   };
 }

--- a/typescript/svm-sdk/src/legacy-compat.ts
+++ b/typescript/svm-sdk/src/legacy-compat.ts
@@ -18,6 +18,8 @@ import { assert } from '@hyperlane-xyz/utils';
 import { COMPUTE_BUDGET_PROGRAM_ID } from './constants.js';
 import type { LegacyKeypair, SvmTransaction } from './types.js';
 
+const MIGRATED_COMPUTE_BUDGET_DISCRIMINATORS: readonly number[] = [1, 2, 4];
+
 // -- Structural interfaces for legacy @solana/web3.js types --
 // Defined here to avoid depending on @solana/web3.js.
 
@@ -82,7 +84,10 @@ export async function convertLegacySolanaTransaction(
     const isComputeBudget =
       ix.programId.toBase58() === COMPUTE_BUDGET_PROGRAM_ID;
 
-    if (isComputeBudget && [1, 2, 4].includes(ix.data[0])) {
+    if (
+      isComputeBudget &&
+      MIGRATED_COMPUTE_BUDGET_DISCRIMINATORS.includes(ix.data[0])
+    ) {
       assert(ix.data.length === 5, 'Invalid compute-budget instruction');
       const dataArr = Uint8Array.from(ix.data);
       const value = new DataView(dataArr.buffer).getUint32(1, true);

--- a/typescript/svm-sdk/src/tests/signer.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/signer.unit-test.ts
@@ -26,6 +26,7 @@ import { ProtocolType } from '@hyperlane-xyz/provider-sdk';
 import type { ChainMetadataForAltVM } from '@hyperlane-xyz/provider-sdk/chain';
 
 import { SvmSigner } from '../clients/signer.js';
+import { COMPUTE_BUDGET_PROGRAM_ID } from '../constants.js';
 import type { SvmRpc, SvmTransaction } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -930,6 +931,67 @@ describe('SvmSigner', () => {
     const decoded = messageDecoder.decode(bytes);
     return decoded.staticAccounts[0];
   }
+
+  describe('transactionToPrintableJson — supported transaction settings', () => {
+    it('rejects an explicit priority fee instead of silently losing it', async () => {
+      const signer = await createTestSigner(createMockRpc());
+      await expect(
+        signer.transactionToPrintableJson({
+          instructions: [],
+          priorityFeeMicroLamports: 1,
+        }),
+      ).to.be.rejectedWith('requires priority fees as SetComputeUnitPrice');
+    });
+
+    it('preserves an embedded priority-price instruction in offline exports', async () => {
+      const signer = await createTestSigner(createMockRpc());
+      const data = new Uint8Array([3, 1, 0, 0, 0, 0, 0, 0, 0]);
+      const printable = await signer.transactionToPrintableJson({
+        instructions: [{ programAddress: COMPUTE_BUDGET_PROGRAM_ID, data }],
+      });
+      const message = decompileTransactionMessage(
+        getCompiledTransactionMessageDecoder().decode(
+          getBase58Encoder().encode(printable.message_base58),
+        ),
+      );
+      expect(message.instructions).to.have.length(1);
+      expect(message.instructions[0]?.programAddress).to.equal(
+        COMPUTE_BUDGET_PROGRAM_ID,
+      );
+      expect(message.instructions[0]?.data).to.deep.equal(data);
+    });
+
+    it('rejects explicit v1 and a chain default of v1', async () => {
+      const signer = await createTestSigner(createMockRpc());
+      await expect(
+        signer.transactionToPrintableJson({ instructions: [], version: 1 }),
+      ).to.be.rejectedWith('supports v0 only');
+      const v1Signer = await createTestSigner(createMockRpc(), {
+        ...TEST_CHAIN_METADATA,
+        maxSupportedTransactionVersion: 1,
+        sealevelTransactionVersion: 1,
+      });
+      await expect(
+        v1Signer.transactionToPrintableJson({ instructions: [] }),
+      ).to.be.rejectedWith('supports v0 only');
+    });
+
+    it('allows an explicit v0 override of a v1 chain default', async () => {
+      const signer = await createTestSigner(createMockRpc(), {
+        ...TEST_CHAIN_METADATA,
+        maxSupportedTransactionVersion: 1,
+        sealevelTransactionVersion: 1,
+      });
+      const printable = await signer.transactionToPrintableJson({
+        instructions: [],
+        version: 0,
+      });
+      const message = getCompiledTransactionMessageDecoder().decode(
+        getBase58Encoder().encode(printable.message_base58),
+      );
+      expect(message.version).to.equal(0);
+    });
+  });
 
   describe('transactionToPrintableJson — fee payer derivation', () => {
     it('uses explicit feePayer instead of local signer', async () => {

--- a/typescript/svm-sdk/src/tests/signer.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/signer.unit-test.ts
@@ -209,41 +209,50 @@ describe('SvmSigner', () => {
       expect(getLatestBlockhash.called).to.equal(false);
     });
 
-    it('sends v1 wire bytes with header fees on an opted-in chain', async () => {
-      const sendTransaction = sinon.stub().callsFake((encoded: unknown) => {
-        expect(typeof encoded).to.equal('string');
-        if (typeof encoded !== 'string') throw new Error('expected base64');
-        const wire = getBase64Encoder().encode(encoded);
-        expect(wire[0]).to.equal(0x81);
-        const transaction = getTransactionDecoder().decode(wire);
-        const message = decompileTransactionMessage(
-          getCompiledTransactionMessageDecoder().decode(
-            transaction.messageBytes,
-          ),
+    for (const embeddedLimit of [false, true]) {
+      it(`sends v1 header fees with ${embeddedLimit ? 'embedded' : 'explicit'} compute limits`, async () => {
+        const sendTransaction = sinon.stub().callsFake((encoded: unknown) => {
+          expect(typeof encoded).to.equal('string');
+          if (typeof encoded !== 'string') throw new Error('expected base64');
+          const wire = getBase64Encoder().encode(encoded);
+          const transaction = getTransactionDecoder().decode(wire);
+          expect(transaction.messageBytes[0]).to.equal(0x81);
+          const message = decompileTransactionMessage(
+            getCompiledTransactionMessageDecoder().decode(
+              transaction.messageBytes,
+            ),
+          );
+          expect(message.version).to.equal(1);
+          if (message.version !== 1) throw new Error('expected v1');
+          expect(message.config?.computeUnitLimit).to.equal(200001);
+          expect(message.config?.priorityFeeLamports).to.equal(1n);
+          expect(message.instructions).to.have.length(0);
+          return { send: async () => FAKE_SIGNATURE };
+        });
+        const signer = await createTestSigner(
+          createMockRpc({ sendTransaction }),
+          {
+            ...TEST_CHAIN_METADATA,
+            maxSupportedTransactionVersion: 1,
+            sealevelTransactionVersion: 1,
+            sealevelV1TransactionsEnabled: true,
+          },
         );
-        expect(message.version).to.equal(1);
-        if (message.version !== 1) throw new Error('expected v1');
-        expect(message.config?.computeUnitLimit).to.equal(200001);
-        expect(message.config?.priorityFeeLamports).to.equal(1n);
-        expect(message.instructions).to.have.length(0);
-        return { send: async () => FAKE_SIGNATURE };
+        await signer.send({
+          instructions: embeddedLimit
+            ? [
+                {
+                  programAddress: COMPUTE_BUDGET_PROGRAM_ID,
+                  data: new Uint8Array([2, 0x41, 0x0d, 0x03, 0x00]),
+                },
+              ]
+            : [],
+          computeUnits: embeddedLimit ? undefined : 200001,
+          priorityFeeMicroLamports: 1,
+        });
+        expect(sendTransaction.calledOnce).to.equal(true);
       });
-      const signer = await createTestSigner(
-        createMockRpc({ sendTransaction }),
-        {
-          ...TEST_CHAIN_METADATA,
-          maxSupportedTransactionVersion: 1,
-          sealevelTransactionVersion: 1,
-          sealevelV1TransactionsEnabled: true,
-        },
-      );
-      await signer.send({
-        instructions: [],
-        computeUnits: 200001,
-        priorityFeeMicroLamports: 1,
-      });
-      expect(sendTransaction.calledOnce).to.equal(true);
-    });
+    }
 
     it('rejects ALT compression for v1 before RPC', async () => {
       const signer = await createTestSigner(createMockRpc(), {
@@ -959,6 +968,18 @@ describe('SvmSigner', () => {
           priorityFeeMicroLamports: 1,
         }),
       ).to.be.rejectedWith('requires priority fees as SetComputeUnitPrice');
+    });
+
+    it('treats zero priority fees as absent in offline exports', async () => {
+      const signer = await createTestSigner(createMockRpc());
+      const absent = await signer.transactionToPrintableJson({
+        instructions: [],
+      });
+      const zero = await signer.transactionToPrintableJson({
+        instructions: [],
+        priorityFeeMicroLamports: 0,
+      });
+      expect(zero).to.deep.equal(absent);
     });
 
     it('preserves an embedded priority-price instruction in offline exports', async () => {

--- a/typescript/svm-sdk/src/tests/signer.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/signer.unit-test.ts
@@ -192,6 +192,23 @@ describe('SvmSigner', () => {
       expect(getLatestBlockhash.called).to.equal(false);
     });
 
+    it('rejects an explicit v1 send while only read support is enabled', async () => {
+      const getLatestBlockhash = sinon
+        .stub()
+        .throws(new Error('must not call RPC'));
+      const signer = await createTestSigner(
+        createMockRpc({ getLatestBlockhash }),
+        {
+          ...TEST_CHAIN_METADATA,
+          maxSupportedTransactionVersion: 1,
+        },
+      );
+      await expect(
+        signer.send({ instructions: [], version: 1 }),
+      ).to.be.rejectedWith('sealevelV1TransactionsEnabled');
+      expect(getLatestBlockhash.called).to.equal(false);
+    });
+
     it('sends v1 wire bytes with header fees on an opted-in chain', async () => {
       const sendTransaction = sinon.stub().callsFake((encoded: unknown) => {
         expect(typeof encoded).to.equal('string');
@@ -217,6 +234,7 @@ describe('SvmSigner', () => {
           ...TEST_CHAIN_METADATA,
           maxSupportedTransactionVersion: 1,
           sealevelTransactionVersion: 1,
+          sealevelV1TransactionsEnabled: true,
         },
       );
       await signer.send({
@@ -961,7 +979,7 @@ describe('SvmSigner', () => {
       expect(message.instructions[0]?.data).to.deep.equal(data);
     });
 
-    it('rejects explicit v1 and a chain default of v1', async () => {
+    it('rejects explicit v1 but preserves unstamped offline v0', async () => {
       const signer = await createTestSigner(createMockRpc());
       await expect(
         signer.transactionToPrintableJson({ instructions: [], version: 1 }),
@@ -971,9 +989,14 @@ describe('SvmSigner', () => {
         maxSupportedTransactionVersion: 1,
         sealevelTransactionVersion: 1,
       });
-      await expect(
-        v1Signer.transactionToPrintableJson({ instructions: [] }),
-      ).to.be.rejectedWith('supports v0 only');
+      const printable = await v1Signer.transactionToPrintableJson({
+        instructions: [],
+      });
+      expect(
+        getCompiledTransactionMessageDecoder().decode(
+          getBase58Encoder().encode(printable.message_base58),
+        ).version,
+      ).to.equal(0);
     });
 
     it('allows an explicit v0 override of a v1 chain default', async () => {

--- a/typescript/svm-sdk/src/tests/signer.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/signer.unit-test.ts
@@ -8,7 +8,10 @@ import {
   type TransactionSendingSigner,
   address,
   blockhash,
+  decompileTransactionMessage,
   getBase58Encoder,
+  getBase64Encoder,
+  getTransactionDecoder,
   getCompiledTransactionMessageDecoder,
   signature as toSignature,
 } from '@solana/kit';
@@ -116,11 +119,11 @@ const TEST_CHAIN_METADATA: ChainMetadataForAltVM = {
   rpcUrls: [{ http: 'http://localhost:8899' }],
 };
 
-async function createTestSigner(rpc: SvmRpc): Promise<SvmSigner> {
-  const signer = await SvmSigner.connectWithSigner(
-    TEST_CHAIN_METADATA,
-    TEST_PRIVATE_KEY,
-  );
+async function createTestSigner(
+  rpc: SvmRpc,
+  metadata: ChainMetadataForAltVM = TEST_CHAIN_METADATA,
+): Promise<SvmSigner> {
+  const signer = await SvmSigner.connectWithSigner(metadata, TEST_PRIVATE_KEY);
   signer['rpc'] = rpc;
   return signer;
 }
@@ -172,6 +175,95 @@ describe('SvmSigner', () => {
     ).to.be.rejectedWith(
       'SVM signer must implement transaction modifying or partial signing',
     );
+  });
+
+  describe('per-chain transaction versions', () => {
+    it('rejects v1 before any RPC request without explicit chain opt-in', async () => {
+      const getLatestBlockhash = sinon
+        .stub()
+        .throws(new Error('must not call RPC'));
+      const signer = await createTestSigner(
+        createMockRpc({ getLatestBlockhash }),
+      );
+      await expect(
+        signer.send({ instructions: [], version: 1 }),
+      ).to.be.rejectedWith('maxSupportedTransactionVersion');
+      expect(getLatestBlockhash.called).to.equal(false);
+    });
+
+    it('sends v1 wire bytes with header fees on an opted-in chain', async () => {
+      const sendTransaction = sinon.stub().callsFake((encoded: unknown) => {
+        expect(typeof encoded).to.equal('string');
+        if (typeof encoded !== 'string') throw new Error('expected base64');
+        const wire = getBase64Encoder().encode(encoded);
+        expect(wire[0]).to.equal(0x81);
+        const transaction = getTransactionDecoder().decode(wire);
+        const message = decompileTransactionMessage(
+          getCompiledTransactionMessageDecoder().decode(
+            transaction.messageBytes,
+          ),
+        );
+        expect(message.version).to.equal(1);
+        if (message.version !== 1) throw new Error('expected v1');
+        expect(message.config?.computeUnitLimit).to.equal(200001);
+        expect(message.config?.priorityFeeLamports).to.equal(1n);
+        expect(message.instructions).to.have.length(0);
+        return { send: async () => FAKE_SIGNATURE };
+      });
+      const signer = await createTestSigner(
+        createMockRpc({ sendTransaction }),
+        {
+          ...TEST_CHAIN_METADATA,
+          maxSupportedTransactionVersion: 1,
+          sealevelTransactionVersion: 1,
+        },
+      );
+      await signer.send({
+        instructions: [],
+        computeUnits: 200001,
+        priorityFeeMicroLamports: 1,
+      });
+      expect(sendTransaction.calledOnce).to.equal(true);
+    });
+
+    it('rejects ALT compression for v1 before RPC', async () => {
+      const signer = await createTestSigner(createMockRpc(), {
+        ...TEST_CHAIN_METADATA,
+        maxSupportedTransactionVersion: 1,
+      });
+      await expect(
+        signer.send({
+          instructions: [],
+          version: 1,
+          addressLookupTables: [address('11111111111111111111111111111111')],
+        }),
+      ).to.be.rejectedWith('lookup tables');
+    });
+
+    it('does not switch another SVM to v1 when read support is enabled', async () => {
+      const sendTransaction = sinon.stub().callsFake((encoded: unknown) => {
+        if (typeof encoded !== 'string') throw new Error('expected base64');
+        const transaction = getTransactionDecoder().decode(
+          getBase64Encoder().encode(encoded),
+        );
+        expect(
+          getCompiledTransactionMessageDecoder().decode(
+            transaction.messageBytes,
+          ).version,
+        ).to.equal(0);
+        return { send: async () => FAKE_SIGNATURE };
+      });
+      const signer = await createTestSigner(
+        createMockRpc({ sendTransaction }),
+        {
+          ...TEST_CHAIN_METADATA,
+          name: 'another-svm',
+          maxSupportedTransactionVersion: 1,
+        },
+      );
+      await signer.send({ instructions: [] });
+      expect(sendTransaction.calledOnce).to.equal(true);
+    });
   });
 
   // ---- Happy path ----

--- a/typescript/svm-sdk/src/tests/transaction-v1.integration-test.ts
+++ b/typescript/svm-sdk/src/tests/transaction-v1.integration-test.ts
@@ -1,123 +1,309 @@
+// eslint-disable-next-line import/no-nodejs-modules
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
+// eslint-disable-next-line import/no-nodejs-modules
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+// eslint-disable-next-line import/no-nodejs-modules
+import { tmpdir } from 'node:os';
+// eslint-disable-next-line import/no-nodejs-modules
+import { join } from 'node:path';
 import {
-  isSolanaError,
-  SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT,
-} from '@solana/errors';
-import { getTransferSolInstruction } from '@solana-program/system';
+  getCreateAccountInstruction,
+  getTransferSolInstruction,
+} from '@solana-program/system';
 import {
-  AccountRole,
+  address,
   generateKeyPairSigner,
   getBase64Encoder,
+  getBase64EncodedWireTransaction,
+  signTransactionMessageWithSigners,
+  isSolanaError,
+  SOLANA_ERROR__TRANSACTION_ERROR__UNSUPPORTED_VERSION,
   signature,
   lamports,
+  type Instruction,
 } from '@solana/kit';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
-
+import { before, after, describe, it } from 'mocha';
 import { ProtocolType } from '@hyperlane-xyz/provider-sdk';
 import { assert, pollAsync } from '@hyperlane-xyz/utils';
-
-import { RENT_SYSVAR_ADDRESS } from '../constants.js';
 import { SvmSigner } from '../clients/signer.js';
 import { createRpc } from '../rpc.js';
+import { buildTransactionMessage } from '../tx.js';
+import { buildInitMailboxInstruction } from '../core/mailbox-tx.js';
+import { fetchMailboxInboxAccount } from '../core/mailbox-query.js';
+import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
+import { SYSTEM_PROGRAM_ADDRESS } from '../constants.js';
 
-// Explicit local test-validator endpoint; never a public-cluster funding test.
-describe('v1 transactions on Agave 4.2', function () {
-  this.timeout(60000);
+// Pinned in the CI downloader too. This suite owns local validators and never funds public RPCs.
+const AGAVE_VERSION = '4.2.0';
+// Agave v4.2.0 feature-set/src/lib.rs: enable_tx_v1.
+const V1_FEATURE = 'txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL';
+const MAILBOX = address('2Zvzyv2sstAhs9wu1xaLpH5X17dVouEb8zjkBRPKsSy5');
+const MEMO = address('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr');
 
-  it('sends an oversized v1 transfer batch and reads its receipt and block', async () => {
-    const url = process.env.SVM_V1_RPC_URL;
-    assert(
-      url && ['127.0.0.1', 'localhost'].includes(new URL(url).hostname),
-      'Set SVM_V1_RPC_URL to a local Agave 4.2+ test validator',
-    );
+for (const enabled of [true, false]) {
+  describe(`Agave ${AGAVE_VERSION}, v1 feature ${enabled ? 'on' : 'off'}`, function () {
+    this.timeout(120000);
+    const url = 'http://127.0.0.1:18899';
     const rpc = createRpc(url);
-    const payer = await generateKeyPairSigner();
-    await rpc.requestAirdrop(payer.address, lamports(2_000_000_000n)).send();
-    await pollAsync(
-      async () => {
-        const balance = await rpc
-          .getBalance(payer.address, { commitment: 'confirmed' })
-          .send();
-        assert(balance.value > 0n, 'airdrop pending');
-      },
-      1000,
-      30,
-    );
-    const signer = await SvmSigner.connectWithSigner(
-      {
-        name: 'local-v1',
-        protocol: ProtocolType.Sealevel,
-        chainId: 1,
-        domainId: 1,
-        rpcUrls: [{ http: url }],
-        maxSupportedTransactionVersion: 1,
-        sealevelTransactionVersion: 1,
-      },
-      payer,
-    );
-    const instructions = Array.from({ length: 60 }, () => {
-      const ix = getTransferSolInstruction({
-        source: payer,
-        destination: payer.address,
-        amount: 1n,
-      });
-      return {
-        ...ix,
-        accounts: [
-          ...ix.accounts,
-          { address: RENT_SYSVAR_ADDRESS, role: AccountRole.READONLY },
-        ],
-      };
-    });
-    const receipt = await signer.sendAndConfirmTransaction({ instructions });
-    expect(
-      receipt.meta?.logMessages?.some((log) => log.includes('success')),
-    ).to.equal(true);
-    assert(receipt.slot !== undefined, 'missing confirmed slot');
-    const block = await rpc
-      .getBlock(receipt.slot, {
-        commitment: 'confirmed',
-        encoding: 'json',
-        transactionDetails: 'full',
-        maxSupportedTransactionVersion: 1,
-        rewards: false,
-      })
-      .send();
-    expect(
-      block?.transactions.some(
-        (tx) =>
-          tx.version === 1 &&
-          tx.transaction.signatures.includes(signature(receipt.signature)),
-      ),
-    ).to.equal(true);
-    const raw = await rpc
-      .getTransaction(signature(receipt.signature), {
-        commitment: 'confirmed',
-        encoding: 'base64',
-        maxSupportedTransactionVersion: 1,
-      })
-      .send();
-    assert(raw, 'missing transaction');
-    const wireSize = getBase64Encoder().encode(raw.transaction[0]).length;
-    expect(wireSize).to.be.greaterThan(1232).and.at.most(4096);
+    let validator: ChildProcess;
+    let directory: string;
+    let signer: SvmSigner;
 
-    // The same instruction batch must still respect v0's smaller packet limit.
-    let rejected = false;
-    try {
-      await signer.send({ instructions, version: 0 });
-    } catch (error) {
-      rejected = isSolanaError(
-        error,
-        SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT,
+    before(async () => {
+      const binary =
+        process.env.AGAVE_TEST_VALIDATOR ?? 'solana-test-validator';
+      expect(
+        execFileSync(binary, ['--version'], { encoding: 'utf8' }),
+      ).to.match(/\b4\.2\.0\b/);
+      directory = mkdtempSync(join(tmpdir(), 'hyperlane-v1-'));
+      const program = join(directory, 'mailbox.so');
+      writeFileSync(program, HYPERLANE_SVM_PROGRAM_BYTES.mailbox);
+      validator = spawn(
+        binary,
+        [
+          '--reset',
+          '--ledger',
+          join(directory, 'ledger'),
+          '--bind-address',
+          '127.0.0.1',
+          '--rpc-port',
+          '18899',
+          '--faucet-port',
+          '18900',
+          '--quiet',
+          '--bpf-program',
+          MAILBOX,
+          program,
+          ...(!enabled ? ['--deactivate-feature', V1_FEATURE] : []),
+        ],
+        { stdio: ['ignore', 'ignore', 'inherit'] },
       );
-      if (!rejected) throw error;
-    }
-    expect(rejected).to.equal(true);
-    // A normal v0 transfer still works on the same node.
-    const v0 = await signer.send({
-      instructions: instructions.slice(0, 1),
-      version: 0,
+      await pollAsync(
+        async () => {
+          assert(validator.exitCode === null, 'test validator exited');
+          await rpc.getHealth().send();
+        },
+        1000,
+        60,
+      );
+      const payer = await generateKeyPairSigner();
+      await rpc.requestAirdrop(payer.address, lamports(2_000_000_000n)).send();
+      await pollAsync(
+        async () => {
+          assert(
+            (
+              await rpc
+                .getBalance(payer.address, { commitment: 'confirmed' })
+                .send()
+            ).value > 0n,
+            'airdrop pending',
+          );
+        },
+        1000,
+        30,
+      );
+      signer = await SvmSigner.connectWithSigner(
+        {
+          name: 'local-v1',
+          protocol: ProtocolType.Sealevel,
+          chainId: 1,
+          domainId: 1,
+          rpcUrls: [{ http: url }],
+          maxSupportedTransactionVersion: 1,
+          sealevelV1TransactionsEnabled: enabled,
+          sealevelTransactionVersion: enabled ? 1 : 0,
+        },
+        payer,
+      );
     });
-    expect(v0.signature).to.be.a('string');
+
+    after(async () => {
+      if (validator && validator.exitCode === null) {
+        await new Promise<void>((resolve) => {
+          validator.once('exit', () => resolve());
+          validator.kill('SIGTERM');
+        });
+      }
+      if (directory) rmSync(directory, { recursive: true, force: true });
+    });
+
+    async function wire(instructions: Instruction[]) {
+      const lifetime = (
+        await rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      ).value;
+      return getBase64EncodedWireTransaction(
+        await signTransactionMessageWithSigners(
+          buildTransactionMessage({
+            version: 1,
+            computeUnits: 1_400_000,
+            instructions,
+            feePayer: signer.signer,
+            recentBlockhash: lifetime.blockhash,
+            lastValidBlockHeight: lifetime.lastValidBlockHeight,
+          }),
+        ),
+      );
+    }
+
+    it('keeps v0 transfers working', async () => {
+      const receipt = await signer.sendAndConfirmTransaction({
+        version: 0,
+        instructions: [
+          getTransferSolInstruction({
+            source: signer.signer,
+            destination: signer.signer.address,
+            amount: 1n,
+          }),
+        ],
+      });
+      const raw = await rpc
+        .getTransaction(signature(receipt.signature), {
+          commitment: 'confirmed',
+          encoding: 'json',
+          maxSupportedTransactionVersion: 1,
+        })
+        .send();
+      expect(raw?.meta?.err).to.equal(null);
+    });
+
+    if (!enabled) {
+      it('rejects v1 at both the SDK activation gate and the node feature gate', async () => {
+        const instructions = [
+          getTransferSolInstruction({
+            source: signer.signer,
+            destination: signer.signer.address,
+            amount: 1n,
+          }),
+        ];
+        let sdkError: unknown;
+        try {
+          await signer.send({ version: 1, instructions });
+        } catch (error) {
+          sdkError = error;
+        }
+        expect(String(sdkError)).to.include('sealevelV1TransactionsEnabled');
+        let nodeError: unknown;
+        try {
+          await rpc
+            .sendTransaction(await wire(instructions), {
+              encoding: 'base64',
+              skipPreflight: false,
+            })
+            .send();
+        } catch (error) {
+          nodeError = error;
+        }
+        assert(nodeError instanceof Error, 'missing node error');
+        expect(
+          isSolanaError(
+            nodeError.cause,
+            SOLANA_ERROR__TRANSACTION_ERROR__UNSUPPORTED_VERSION,
+          ),
+        ).to.equal(true);
+      });
+      return;
+    }
+
+    it('executes a Hyperlane mailbox init with two signers and reads v1 receipt/block', async () => {
+      const account = await generateKeyPairSigner();
+      const rent = await rpc.getMinimumBalanceForRentExemption(0n).send();
+      const create = getCreateAccountInstruction({
+        payer: signer.signer,
+        newAccount: account,
+        lamports: rent,
+        space: 0n,
+        programAddress: SYSTEM_PROGRAM_ADDRESS,
+      });
+      const init = await buildInitMailboxInstruction(MAILBOX, signer.signer, {
+        localDomain: 1234,
+        defaultIsm: signer.signer.address,
+        maxProtocolFee: 0n,
+        protocolFee: { fee: 0n, beneficiary: signer.signer.address },
+      });
+      const receipt = await signer.sendAndConfirmTransaction({
+        instructions: [create, init],
+      });
+      const raw = await rpc
+        .getTransaction(signature(receipt.signature), {
+          commitment: 'confirmed',
+          encoding: 'json',
+          maxSupportedTransactionVersion: 1,
+        })
+        .send();
+      expect(raw?.meta?.err).to.equal(null);
+      expect(
+        (await fetchMailboxInboxAccount(rpc, MAILBOX))?.localDomain,
+      ).to.equal(1234);
+      assert(receipt.slot !== undefined, 'missing slot');
+      const block = await rpc
+        .getBlock(receipt.slot, {
+          commitment: 'confirmed',
+          encoding: 'json',
+          maxSupportedTransactionVersion: 1,
+          transactionDetails: 'full',
+          rewards: false,
+        })
+        .send();
+      const tx = block?.transactions.find((tx) =>
+        tx.transaction.signatures.includes(signature(receipt.signature)),
+      );
+      expect(tx?.version).to.equal(1);
+      expect(tx?.transaction.signatures).to.have.length(2);
+    });
+
+    it('accepts exactly 4096 bytes and rejects 4097 bytes', async () => {
+      let data = new Uint8Array(3800).fill(97);
+      const size = getBase64Encoder().encode(
+        await wire([{ programAddress: MEMO, data }]),
+      ).length;
+      data = new Uint8Array(data.length + 4096 - size).fill(97);
+      const instructions = [{ programAddress: MEMO, data }];
+      expect(
+        getBase64Encoder().encode(await wire(instructions)),
+      ).to.have.length(4096);
+      const receipt = await signer.sendAndConfirmTransaction({
+        instructions,
+        computeUnits: 1_400_000,
+      });
+      const raw = await rpc
+        .getTransaction(signature(receipt.signature), {
+          commitment: 'confirmed',
+          encoding: 'json',
+          maxSupportedTransactionVersion: 1,
+        })
+        .send();
+      expect(raw?.meta?.err).to.equal(null);
+      const tx = await rpc
+        .getTransaction(signature(receipt.signature), {
+          commitment: 'confirmed',
+          encoding: 'base64',
+          maxSupportedTransactionVersion: 1,
+        })
+        .send();
+      assert(tx, 'missing transaction');
+      expect(getBase64Encoder().encode(tx.transaction[0])).to.have.length(4096);
+      let error: unknown;
+      try {
+        await signer.send({
+          instructions: [
+            {
+              programAddress: MEMO,
+              data: new Uint8Array(data.length + 1).fill(97),
+            },
+          ],
+        });
+      } catch (caught) {
+        error = caught;
+      }
+      expect(String(error)).to.match(/size|4096|large/i);
+      let legacyError: unknown;
+      try {
+        await signer.send({ instructions, version: 0 });
+      } catch (caught) {
+        legacyError = caught;
+      }
+      expect(String(legacyError)).to.match(/size|1232|large/i);
+    });
   });
-});
+}

--- a/typescript/svm-sdk/src/tests/transaction-v1.integration-test.ts
+++ b/typescript/svm-sdk/src/tests/transaction-v1.integration-test.ts
@@ -1,0 +1,123 @@
+import {
+  isSolanaError,
+  SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT,
+} from '@solana/errors';
+import { getTransferSolInstruction } from '@solana-program/system';
+import {
+  AccountRole,
+  generateKeyPairSigner,
+  getBase64Encoder,
+  signature,
+  lamports,
+} from '@solana/kit';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { ProtocolType } from '@hyperlane-xyz/provider-sdk';
+import { assert, pollAsync } from '@hyperlane-xyz/utils';
+
+import { RENT_SYSVAR_ADDRESS } from '../constants.js';
+import { SvmSigner } from '../clients/signer.js';
+import { createRpc } from '../rpc.js';
+
+// Explicit local test-validator endpoint; never a public-cluster funding test.
+describe('v1 transactions on Agave 4.2', function () {
+  this.timeout(60000);
+
+  it('sends an oversized v1 transfer batch and reads its receipt and block', async () => {
+    const url = process.env.SVM_V1_RPC_URL;
+    assert(
+      url && ['127.0.0.1', 'localhost'].includes(new URL(url).hostname),
+      'Set SVM_V1_RPC_URL to a local Agave 4.2+ test validator',
+    );
+    const rpc = createRpc(url);
+    const payer = await generateKeyPairSigner();
+    await rpc.requestAirdrop(payer.address, lamports(2_000_000_000n)).send();
+    await pollAsync(
+      async () => {
+        const balance = await rpc
+          .getBalance(payer.address, { commitment: 'confirmed' })
+          .send();
+        assert(balance.value > 0n, 'airdrop pending');
+      },
+      1000,
+      30,
+    );
+    const signer = await SvmSigner.connectWithSigner(
+      {
+        name: 'local-v1',
+        protocol: ProtocolType.Sealevel,
+        chainId: 1,
+        domainId: 1,
+        rpcUrls: [{ http: url }],
+        maxSupportedTransactionVersion: 1,
+        sealevelTransactionVersion: 1,
+      },
+      payer,
+    );
+    const instructions = Array.from({ length: 60 }, () => {
+      const ix = getTransferSolInstruction({
+        source: payer,
+        destination: payer.address,
+        amount: 1n,
+      });
+      return {
+        ...ix,
+        accounts: [
+          ...ix.accounts,
+          { address: RENT_SYSVAR_ADDRESS, role: AccountRole.READONLY },
+        ],
+      };
+    });
+    const receipt = await signer.sendAndConfirmTransaction({ instructions });
+    expect(
+      receipt.meta?.logMessages?.some((log) => log.includes('success')),
+    ).to.equal(true);
+    assert(receipt.slot !== undefined, 'missing confirmed slot');
+    const block = await rpc
+      .getBlock(receipt.slot, {
+        commitment: 'confirmed',
+        encoding: 'json',
+        transactionDetails: 'full',
+        maxSupportedTransactionVersion: 1,
+        rewards: false,
+      })
+      .send();
+    expect(
+      block?.transactions.some(
+        (tx) =>
+          tx.version === 1 &&
+          tx.transaction.signatures.includes(signature(receipt.signature)),
+      ),
+    ).to.equal(true);
+    const raw = await rpc
+      .getTransaction(signature(receipt.signature), {
+        commitment: 'confirmed',
+        encoding: 'base64',
+        maxSupportedTransactionVersion: 1,
+      })
+      .send();
+    assert(raw, 'missing transaction');
+    const wireSize = getBase64Encoder().encode(raw.transaction[0]).length;
+    expect(wireSize).to.be.greaterThan(1232).and.at.most(4096);
+
+    // The same instruction batch must still respect v0's smaller packet limit.
+    let rejected = false;
+    try {
+      await signer.send({ instructions, version: 0 });
+    } catch (error) {
+      rejected = isSolanaError(
+        error,
+        SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT,
+      );
+      if (!rejected) throw error;
+    }
+    expect(rejected).to.equal(true);
+    // A normal v0 transfer still works on the same node.
+    const v0 = await signer.send({
+      instructions: instructions.slice(0, 1),
+      version: 0,
+    });
+    expect(v0.signature).to.be.a('string');
+  });
+});

--- a/typescript/svm-sdk/src/tests/transaction-v1.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/transaction-v1.unit-test.ts
@@ -1,0 +1,94 @@
+import { blockhash, generateKeyPairSigner } from '@solana/kit';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { COMPUTE_BUDGET_PROGRAM_ID } from '../constants.js';
+import { buildTransactionMessage } from '../tx.js';
+
+async function params() {
+  return {
+    feePayer: await generateKeyPairSigner(),
+    recentBlockhash: blockhash('11111111111111111111111111111111'),
+    lastValidBlockHeight: 1n,
+    version: 1 as const,
+    computeUnits: 200001,
+  };
+}
+
+function priceInstruction(price: bigint) {
+  const data = new Uint8Array(9);
+  data[0] = 3;
+  new DataView(data.buffer).setBigUint64(1, price, true);
+  return { programAddress: COMPUTE_BUDGET_PROGRAM_ID, data };
+}
+
+describe('v1 transaction header', () => {
+  it('preserves adapter priority fees with upward rounding and no budget instruction', async () => {
+    const message = buildTransactionMessage({
+      ...(await params()),
+      instructions: [priceInstruction(6n)],
+    });
+    expect(message.version).to.equal(1);
+    if (message.version !== 1) throw new Error('expected v1');
+    expect(message.config?.priorityFeeLamports).to.equal(2n);
+    expect(message.config?.computeUnitLimit).to.equal(200001);
+    expect(message.config?.loadedAccountsDataSizeLimit).to.equal(
+      64 * 1024 * 1024,
+    );
+    expect(message.instructions).to.have.length(0);
+  });
+
+  it('rejects duplicate priority fee sources', async () => {
+    const common = await params();
+    expect(() =>
+      buildTransactionMessage({
+        ...common,
+        instructions: [priceInstruction(1n), priceInstruction(2n)],
+      }),
+    ).to.throw('Duplicate priority fee');
+    expect(() =>
+      buildTransactionMessage({
+        ...common,
+        priorityFeeMicroLamports: 1,
+        instructions: [priceInstruction(1n)],
+      }),
+    ).to.throw('Duplicate priority fee');
+  });
+
+  it('rejects unsupported compute-budget instructions instead of dropping them', async () => {
+    const common = await params();
+    expect(() =>
+      buildTransactionMessage({
+        ...common,
+        instructions: [
+          {
+            programAddress: COMPUTE_BUDGET_PROGRAM_ID,
+            data: new Uint8Array([1]),
+          },
+        ],
+      }),
+    ).to.throw('v1 only converts SetComputeUnitPrice');
+  });
+
+  it('rejects invalid header budgets', async () => {
+    const common = await params();
+    for (const computeUnits of [0, 1.5, 1400001]) {
+      expect(() =>
+        buildTransactionMessage({ ...common, computeUnits, instructions: [] }),
+      ).to.throw('computeUnits');
+    }
+    for (const priorityFeeMicroLamports of [
+      -1,
+      0.5,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      expect(() =>
+        buildTransactionMessage({
+          ...common,
+          priorityFeeMicroLamports,
+          instructions: [],
+        }),
+      ).to.throw('priorityFeeMicroLamports');
+    }
+  });
+});

--- a/typescript/svm-sdk/src/tests/transaction-v1.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/transaction-v1.unit-test.ts
@@ -1,8 +1,16 @@
-import { blockhash, generateKeyPairSigner } from '@solana/kit';
+import {
+  address,
+  blockhash,
+  generateKeyPairSigner,
+  compileTransaction,
+  getTransactionEncoder,
+  assertIsTransactionWithinSizeLimit,
+} from '@solana/kit';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { COMPUTE_BUDGET_PROGRAM_ID } from '../constants.js';
+import { convertLegacySolanaTransaction } from '../legacy-compat.js';
 import { buildTransactionMessage } from '../tx.js';
 
 async function params() {
@@ -38,6 +46,71 @@ describe('v1 transaction header', () => {
     expect(message.instructions).to.have.length(0);
   });
 
+  it('migrates legacy heap and loaded-data budgets for both versions', async () => {
+    const budget = (discriminator: number, value: number) => {
+      const data = new Uint8Array(5);
+      data[0] = discriminator;
+      new DataView(data.buffer).setUint32(1, value, true);
+      return {
+        programId: { toBase58: () => COMPUTE_BUDGET_PROGRAM_ID },
+        keys: [],
+        data,
+      };
+    };
+    const converted = await convertLegacySolanaTransaction({
+      instructions: [budget(1, 256 * 1024), budget(4, 128 * 1024)],
+    });
+    expect(converted.instructions).to.have.length(0);
+    expect(converted.heapSize).to.equal(256 * 1024);
+    expect(converted.loadedAccountsDataSizeLimit).to.equal(128 * 1024);
+    const common = await params();
+    const v1 = buildTransactionMessage({
+      ...converted,
+      ...common,
+      addressLookupTables: undefined,
+    });
+    if (v1.version !== 1) throw new Error('expected v1');
+    expect(v1.config?.heapSize).to.equal(256 * 1024);
+    expect(v1.config?.loadedAccountsDataSizeLimit).to.equal(128 * 1024);
+    expect(v1.instructions).to.have.length(0);
+    const v0 = buildTransactionMessage({
+      ...converted,
+      ...common,
+      addressLookupTables: undefined,
+      version: 0,
+    });
+    expect(v0.instructions.map((ix) => ix.data?.[0])).to.deep.equal([2, 1, 4]);
+  });
+
+  it('omits a zero priority fee so an exact 4096-byte transaction fits', async () => {
+    const common = await params();
+    const encode = (dataSize: number, price?: number) =>
+      compileTransaction(
+        buildTransactionMessage({
+          ...common,
+          priorityFeeMicroLamports: price,
+          instructions: [
+            {
+              programAddress: address('11111111111111111111111111111111'),
+              data: new Uint8Array(dataSize),
+            },
+          ],
+        }),
+      );
+    const encoder = getTransactionEncoder();
+    const overhead = encoder.encode(encode(1000)).length - 1000;
+    const atLimit = encode(4096 - overhead);
+    expect(encoder.encode(atLimit)).to.have.length(4096);
+    expect(() => assertIsTransactionWithinSizeLimit(atLimit)).not.to.throw();
+    expect(encoder.encode(encode(4096 - overhead, 0))).to.have.length(4096);
+    expect(() =>
+      assertIsTransactionWithinSizeLimit(encode(4096 - overhead, 1)),
+    ).to.throw();
+    expect(() =>
+      assertIsTransactionWithinSizeLimit(encode(4097 - overhead)),
+    ).to.throw();
+  });
+
   it('rejects duplicate priority fee sources', async () => {
     const common = await params();
     expect(() =>
@@ -67,7 +140,7 @@ describe('v1 transaction header', () => {
           },
         ],
       }),
-    ).to.throw('v1 only converts SetComputeUnitPrice');
+    ).to.throw('Unsupported v1 compute-budget instruction');
   });
 
   it('rejects invalid header budgets', async () => {
@@ -76,6 +149,25 @@ describe('v1 transaction header', () => {
       expect(() =>
         buildTransactionMessage({ ...common, computeUnits, instructions: [] }),
       ).to.throw('computeUnits');
+    }
+    for (const heapSize of [0, 1024, 32769, 263168]) {
+      expect(() =>
+        buildTransactionMessage({ ...common, heapSize, instructions: [] }),
+      ).to.throw('heapSize');
+    }
+    for (const loadedAccountsDataSizeLimit of [
+      0,
+      -1,
+      1.5,
+      64 * 1024 * 1024 + 1,
+    ]) {
+      expect(() =>
+        buildTransactionMessage({
+          ...common,
+          loadedAccountsDataSizeLimit,
+          instructions: [],
+        }),
+      ).to.throw('loadedAccountsDataSizeLimit');
     }
     for (const priorityFeeMicroLamports of [
       -1,

--- a/typescript/svm-sdk/src/tests/transaction-v1.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/transaction-v1.unit-test.ts
@@ -30,6 +30,13 @@ function priceInstruction(price: bigint) {
   return { programAddress: COMPUTE_BUDGET_PROGRAM_ID, data };
 }
 
+function limitInstruction(units: number) {
+  const data = new Uint8Array(5);
+  data[0] = 2;
+  new DataView(data.buffer).setUint32(1, units, true);
+  return { programAddress: COMPUTE_BUDGET_PROGRAM_ID, data };
+}
+
 describe('v1 transaction header', () => {
   it('preserves adapter priority fees with upward rounding and no budget instruction', async () => {
     const message = buildTransactionMessage({
@@ -44,6 +51,64 @@ describe('v1 transaction header', () => {
       64 * 1024 * 1024,
     );
     expect(message.instructions).to.have.length(0);
+  });
+
+  it('migrates an embedded compute limit and uses it for priority fee rounding', async () => {
+    const message = buildTransactionMessage({
+      ...(await params()),
+      computeUnits: undefined,
+      instructions: [limitInstruction(200001), priceInstruction(6n)],
+    });
+    if (message.version !== 1) throw new Error('expected v1');
+    expect(message.config?.computeUnitLimit).to.equal(200001);
+    expect(message.config?.priorityFeeLamports).to.equal(2n);
+    expect(message.instructions).to.have.length(0);
+  });
+
+  it('accepts an identical explicit limit and rejects conflicting or duplicate limits', async () => {
+    const common = await params();
+    const message = buildTransactionMessage({
+      ...common,
+      instructions: [limitInstruction(common.computeUnits)],
+    });
+    if (message.version !== 1) throw new Error('expected v1');
+    expect(message.config?.computeUnitLimit).to.equal(common.computeUnits);
+    expect(message.instructions).to.have.length(0);
+    expect(() =>
+      buildTransactionMessage({
+        ...common,
+        instructions: [limitInstruction(300000)],
+      }),
+    ).to.throw('Conflicting compute unit');
+    expect(() =>
+      buildTransactionMessage({
+        ...common,
+        computeUnits: undefined,
+        instructions: [limitInstruction(200001), limitInstruction(200001)],
+      }),
+    ).to.throw('Duplicate compute unit');
+  });
+
+  it('validates migrated limits and rejects malformed limit instructions', async () => {
+    const common = { ...(await params()), computeUnits: undefined };
+    for (const units of [0, 1400001, 0xffffffff]) {
+      expect(() =>
+        buildTransactionMessage({
+          ...common,
+          instructions: [limitInstruction(units)],
+        }),
+      ).to.throw('computeUnits');
+    }
+    for (const length of [1, 4, 6, 9]) {
+      const data = new Uint8Array(length);
+      data[0] = 2;
+      expect(() =>
+        buildTransactionMessage({
+          ...common,
+          instructions: [{ programAddress: COMPUTE_BUDGET_PROGRAM_ID, data }],
+        }),
+      ).to.throw('Unsupported v1 compute-budget instruction');
+    }
   });
 
   it('migrates legacy heap and loaded-data budgets for both versions', async () => {

--- a/typescript/svm-sdk/src/tx.ts
+++ b/typescript/svm-sdk/src/tx.ts
@@ -13,10 +13,13 @@ import {
   getBase58Decoder,
   getCompiledTransactionMessageEncoder,
   getShortU16Encoder,
+  setTransactionMessageConfig,
   setTransactionMessageFeePayer,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
+
+import { assert } from '@hyperlane-xyz/utils';
 
 import type { SvmInstruction, SvmTransaction } from './types.js';
 import {
@@ -64,6 +67,7 @@ export function getComputeBudgetInstructions(
 }
 
 export function buildTransactionMessage(params: {
+  version?: 0 | 1;
   instructions: SvmInstruction[];
   feePayer: TransactionSigner;
   recentBlockhash: Blockhash;
@@ -88,6 +92,72 @@ export function buildTransactionMessage(params: {
     priorityFeeMicroLamports,
     addressLookupTables,
   } = params;
+
+  if (params.version === 1) {
+    assert(
+      !addressLookupTables || Object.keys(addressLookupTables).length === 0,
+      'v1 transactions do not support address lookup tables',
+    );
+    assert(
+      Number.isInteger(computeUnits) &&
+        computeUnits > 0 &&
+        computeUnits <= 1_400_000,
+      'computeUnits must be an integer between 1 and 1400000',
+    );
+    assert(
+      priorityFeeMicroLamports === undefined ||
+        (Number.isSafeInteger(priorityFeeMicroLamports) &&
+          priorityFeeMicroLamports >= 0),
+      'priorityFeeMicroLamports must be a nonnegative safe integer',
+    );
+    let price =
+      priorityFeeMicroLamports === undefined
+        ? undefined
+        : BigInt(priorityFeeMicroLamports);
+    // Legacy SDK adapters preserve SetComputeUnitPrice when converting instructions.
+    // V1 must move that price into its header, never send a ComputeBudget instruction.
+    const v1Instructions = instructions
+      .filter((ix) => {
+        if (ix.programAddress !== COMPUTE_BUDGET_PROGRAM_ID) return true;
+        assert(
+          ix.data?.length === 9 && ix.data[0] === 3,
+          'v1 only converts SetComputeUnitPrice; set computeUnits on the transaction',
+        );
+        assert(price === undefined, 'Duplicate priority fee configuration');
+        price = new DataView(Uint8Array.from(ix.data).buffer).getBigUint64(
+          1,
+          true,
+        );
+        return false;
+      })
+      .map((ix) => ({
+        ...ix,
+        accounts: ix.accounts?.map((account) => {
+          assert(
+            !('lookupTableAddress' in account),
+            'v1 instructions cannot reference lookup tables',
+          );
+          return account;
+        }),
+      }));
+    const message = setTransactionMessageConfig(
+      {
+        computeUnitLimit: computeUnits,
+        // V1 has no implicit loaded-account budget. Match the legacy runtime maximum.
+        loadedAccountsDataSizeLimit: 64 * 1024 * 1024,
+        priorityFeeLamports:
+          ((price ?? 0n) * BigInt(computeUnits) + 999_999n) / 1_000_000n,
+      },
+      createTransactionMessage({ version: 1 }),
+    );
+    return appendTransactionMessageInstructions(
+      v1Instructions,
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash: recentBlockhash, lastValidBlockHeight },
+        setTransactionMessageFeePayerSigner(feePayer, message),
+      ),
+    );
+  }
 
   const computeBudgetIxs = getComputeBudgetInstructions(
     computeUnits,

--- a/typescript/svm-sdk/src/tx.ts
+++ b/typescript/svm-sdk/src/tx.ts
@@ -142,17 +142,12 @@ export function buildTransactionMessage(params: {
       'v1 transactions do not support address lookup tables',
     );
     assert(
-      Number.isInteger(computeUnits) &&
-        computeUnits > 0 &&
-        computeUnits <= 1_400_000,
-      'computeUnits must be an integer between 1 and 1400000',
-    );
-    assert(
       priorityFeeMicroLamports === undefined ||
         (Number.isSafeInteger(priorityFeeMicroLamports) &&
           priorityFeeMicroLamports >= 0),
       'priorityFeeMicroLamports must be a nonnegative safe integer',
     );
+    let instructionComputeUnits: number | undefined;
     let heapSize = params.heapSize;
     let loadedAccountsDataSizeLimit = params.loadedAccountsDataSizeLimit;
     let price =
@@ -164,7 +159,10 @@ export function buildTransactionMessage(params: {
     const v1Instructions = instructions
       .filter((ix) => {
         if (ix.programAddress !== COMPUTE_BUDGET_PROGRAM_ID) return true;
-        if (ix.data?.length === 5 && (ix.data[0] === 1 || ix.data[0] === 4)) {
+        if (
+          ix.data?.length === 5 &&
+          (ix.data[0] === 1 || ix.data[0] === 2 || ix.data[0] === 4)
+        ) {
           const value = new DataView(Uint8Array.from(ix.data).buffer).getUint32(
             1,
             true,
@@ -172,6 +170,17 @@ export function buildTransactionMessage(params: {
           if (ix.data[0] === 1) {
             assert(heapSize === undefined, 'Duplicate heap configuration');
             heapSize = value;
+          } else if (ix.data[0] === 2) {
+            assert(
+              instructionComputeUnits === undefined,
+              'Duplicate compute unit configuration',
+            );
+            assert(
+              params.computeUnits === undefined ||
+                params.computeUnits === value,
+              'Conflicting compute unit configuration',
+            );
+            instructionComputeUnits = value;
           } else {
             assert(
               loadedAccountsDataSizeLimit === undefined,
@@ -183,7 +192,7 @@ export function buildTransactionMessage(params: {
         }
         assert(
           ix.data?.length === 9 && ix.data[0] === 3,
-          'Unsupported v1 compute-budget instruction; set computeUnits on the transaction',
+          'Unsupported v1 compute-budget instruction',
         );
         assert(price === undefined, 'Duplicate priority fee configuration');
         price = new DataView(Uint8Array.from(ix.data).buffer).getBigUint64(
@@ -202,10 +211,17 @@ export function buildTransactionMessage(params: {
           return account;
         }),
       }));
+    const resolvedComputeUnits = instructionComputeUnits ?? computeUnits;
+    assert(
+      Number.isInteger(resolvedComputeUnits) &&
+        resolvedComputeUnits > 0 &&
+        resolvedComputeUnits <= 1_400_000,
+      'computeUnits must be an integer between 1 and 1400000',
+    );
     validateMemoryBudgets(heapSize, loadedAccountsDataSizeLimit);
     const message = setTransactionMessageConfig(
       {
-        computeUnitLimit: computeUnits,
+        computeUnitLimit: resolvedComputeUnits,
         // V1 has no implicit loaded-account budget. Match the legacy runtime maximum.
         loadedAccountsDataSizeLimit:
           loadedAccountsDataSizeLimit ?? 64 * 1024 * 1024,
@@ -213,7 +229,7 @@ export function buildTransactionMessage(params: {
         ...(price
           ? {
               priorityFeeLamports:
-                (price * BigInt(computeUnits) + 999_999n) / 1_000_000n,
+                (price * BigInt(resolvedComputeUnits) + 999_999n) / 1_000_000n,
             }
           : {}),
       },

--- a/typescript/svm-sdk/src/tx.ts
+++ b/typescript/svm-sdk/src/tx.ts
@@ -66,6 +66,47 @@ export function getComputeBudgetInstructions(
   return instructions;
 }
 
+function validateMemoryBudgets(
+  heapSize?: number,
+  loadedAccountsDataSizeLimit?: number,
+): void {
+  if (heapSize !== undefined)
+    assert(
+      Number.isInteger(heapSize) &&
+        heapSize >= 32 * 1024 &&
+        heapSize <= 256 * 1024 &&
+        heapSize % 1024 === 0,
+      'heapSize must be 32-256 KiB in 1 KiB increments',
+    );
+  if (loadedAccountsDataSizeLimit !== undefined)
+    assert(
+      Number.isInteger(loadedAccountsDataSizeLimit) &&
+        loadedAccountsDataSizeLimit > 0 &&
+        loadedAccountsDataSizeLimit <= 64 * 1024 * 1024,
+      'loadedAccountsDataSizeLimit must be between 1 and 64 MiB',
+    );
+}
+
+/** Budget instructions shared by v0 submission and offline serialization. */
+export function getMemoryBudgetInstructions(
+  heapSize?: number,
+  loadedAccountsDataSizeLimit?: number,
+): SvmInstruction[] {
+  validateMemoryBudgets(heapSize, loadedAccountsDataSizeLimit);
+  const instructions: SvmInstruction[] = [];
+  for (const [discriminator, value] of [
+    [1, heapSize],
+    [4, loadedAccountsDataSizeLimit],
+  ] as const) {
+    if (value === undefined) continue;
+    const data = new Uint8Array(5);
+    data[0] = discriminator;
+    new DataView(data.buffer).setUint32(1, value, true);
+    instructions.push({ programAddress: COMPUTE_BUDGET_PROGRAM_ID, data });
+  }
+  return instructions;
+}
+
 export function buildTransactionMessage(params: {
   version?: 0 | 1;
   instructions: SvmInstruction[];
@@ -73,6 +114,8 @@ export function buildTransactionMessage(params: {
   recentBlockhash: Blockhash;
   lastValidBlockHeight: bigint;
   computeUnits?: number;
+  heapSize?: number;
+  loadedAccountsDataSizeLimit?: number;
   priorityFeeMicroLamports?: number;
   /**
    * Optional address-lookup tables to compress the message against. The map
@@ -110,6 +153,8 @@ export function buildTransactionMessage(params: {
           priorityFeeMicroLamports >= 0),
       'priorityFeeMicroLamports must be a nonnegative safe integer',
     );
+    let heapSize = params.heapSize;
+    let loadedAccountsDataSizeLimit = params.loadedAccountsDataSizeLimit;
     let price =
       priorityFeeMicroLamports === undefined
         ? undefined
@@ -119,9 +164,26 @@ export function buildTransactionMessage(params: {
     const v1Instructions = instructions
       .filter((ix) => {
         if (ix.programAddress !== COMPUTE_BUDGET_PROGRAM_ID) return true;
+        if (ix.data?.length === 5 && (ix.data[0] === 1 || ix.data[0] === 4)) {
+          const value = new DataView(Uint8Array.from(ix.data).buffer).getUint32(
+            1,
+            true,
+          );
+          if (ix.data[0] === 1) {
+            assert(heapSize === undefined, 'Duplicate heap configuration');
+            heapSize = value;
+          } else {
+            assert(
+              loadedAccountsDataSizeLimit === undefined,
+              'Duplicate loaded-account configuration',
+            );
+            loadedAccountsDataSizeLimit = value;
+          }
+          return false;
+        }
         assert(
           ix.data?.length === 9 && ix.data[0] === 3,
-          'v1 only converts SetComputeUnitPrice; set computeUnits on the transaction',
+          'Unsupported v1 compute-budget instruction; set computeUnits on the transaction',
         );
         assert(price === undefined, 'Duplicate priority fee configuration');
         price = new DataView(Uint8Array.from(ix.data).buffer).getBigUint64(
@@ -140,13 +202,20 @@ export function buildTransactionMessage(params: {
           return account;
         }),
       }));
+    validateMemoryBudgets(heapSize, loadedAccountsDataSizeLimit);
     const message = setTransactionMessageConfig(
       {
         computeUnitLimit: computeUnits,
         // V1 has no implicit loaded-account budget. Match the legacy runtime maximum.
-        loadedAccountsDataSizeLimit: 64 * 1024 * 1024,
-        priorityFeeLamports:
-          ((price ?? 0n) * BigInt(computeUnits) + 999_999n) / 1_000_000n,
+        loadedAccountsDataSizeLimit:
+          loadedAccountsDataSizeLimit ?? 64 * 1024 * 1024,
+        ...(heapSize === undefined ? {} : { heapSize }),
+        ...(price
+          ? {
+              priorityFeeLamports:
+                (price * BigInt(computeUnits) + 999_999n) / 1_000_000n,
+            }
+          : {}),
       },
       createTransactionMessage({ version: 1 }),
     );
@@ -163,7 +232,14 @@ export function buildTransactionMessage(params: {
     computeUnits,
     priorityFeeMicroLamports,
   );
-  const allInstructions = [...computeBudgetIxs, ...instructions];
+  const allInstructions = [
+    ...computeBudgetIxs,
+    ...getMemoryBudgetInstructions(
+      params.heapSize,
+      params.loadedAccountsDataSizeLimit,
+    ),
+    ...instructions,
+  ];
 
   const txMessage = createTransactionMessage({ version: 0 });
   const withFeePayer = setTransactionMessageFeePayerSigner(feePayer, txMessage);

--- a/typescript/svm-sdk/src/types.ts
+++ b/typescript/svm-sdk/src/types.ts
@@ -19,6 +19,10 @@ export type SvmInstruction = Instruction;
 export type SvmRpc = Rpc<SolanaRpcApi>;
 
 export interface SvmTransaction {
+  /** Override the chain's default sending version. V1 requires chain opt-in. */
+  version?: 0 | 1;
+  /** Price per CU; v1 converts this to a total lamport fee, rounding up. */
+  priorityFeeMicroLamports?: number;
   /** Fee payer for the compiled transaction.
    *  Used to set the correct signer in the serialized transaction
    *  output (e.g. a Squads vault instead of the local keypair).

--- a/typescript/svm-sdk/src/types.ts
+++ b/typescript/svm-sdk/src/types.ts
@@ -30,6 +30,10 @@ export interface SvmTransaction {
   feePayer?: Address;
   instructions: SvmInstruction[];
   computeUnits?: number;
+  /** Requested heap frame in bytes (32-256 KiB, in 1 KiB increments). */
+  heapSize?: number;
+  /** Loaded account data budget in bytes; v1 defaults to the legacy 64 MiB maximum. */
+  loadedAccountsDataSizeLimit?: number;
   additionalSigners?: TransactionSigner[];
   /** Skip preflight simulation.
    *  Some transactions that include account creation might fail the simulation check.

--- a/typescript/widgets/src/walletIntegrations/solana.ts
+++ b/typescript/widgets/src/walletIntegrations/solana.ts
@@ -125,7 +125,9 @@ export function useSolanaTransactionFns(
         }
         const tx = await connection.getTransaction(signature, {
           commitment: 'confirmed',
-          maxSupportedTransactionVersion: 0,
+          maxSupportedTransactionVersion:
+            multiProvider.getChainMetadata(chainName)
+              .maxSupportedTransactionVersion ?? 0,
         });
         if (!tx) {
           throw new Error(`Transaction ${signature} confirmed but not found`);


### PR DESCRIPTION
Added per-SVM v1 sending to the Sealevel signer and configurable receipt reads. Read support (`maxSupportedTransactionVersion: 1`) is independent of activation: v1 submission additionally requires `sealevelV1TransactionsEnabled: true`. Sending defaults to v0; unstamped file/Squads exports remain v0 even with a v1 chain default.

V1 headers carry compute, heap, loaded-account and total priority-fee budgets. Legacy heap/data/price instructions are migrated, callers can tune loaded-account limits, and zero priority fees are omitted. Schema refinements reject inconsistent defaults. No registry publication or production activation is included.

Stack: #9577 → #9578 → #9582 → #9579.

Validation: 314 SVM unit tests, three schema regressions, an AltVMFileSubmitter regression, and SDK/deploy dependency builds passed. Five integration tests passed on pinned Agave 4.2.0 with feature-on/off validators: a two-signer Hyperlane mailbox transaction, v1 receipt/block reads, exact 4096-byte acceptance, 4097-byte rejection, and v0 compatibility. A dedicated CI workflow runs the same suite. Local command: `AGAVE_TEST_VALIDATOR=/path/to/solana-test-validator pnpm -C typescript/svm-sdk test:v1:local`; the suite owns local ports 18899/18900.
