### PR TITLE
fix(ccip-server): suppress successful health probe logs

### DIFF
--- a/.changeset/quiet-health-probes.md
+++ b/.changeset/quiet-health-probes.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/ccip-server": patch
+---
+
+Suppressed successful health-probe completion logs while preserving failed probes and application request logs.

--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -6,7 +6,8 @@
     "./tests/**/cctpMessageMatcher.test.ts",
     "./tests/**/CCTPService.test.ts",
     "./tests/**/AttestationPending.test.ts",
-    "./tests/**/moduleRegistry.test.ts"
+    "./tests/**/moduleRegistry.test.ts",
+    "./tests/**/RequestLogging.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/src/server.ts
+++ b/typescript/ccip-server/src/server.ts
@@ -1,7 +1,7 @@
 import 'zod/compile';
 
 import cors from 'cors';
-import express from 'express';
+import express, { type Request, type Response } from 'express';
 import { pinoHttp } from 'pino-http';
 import { Registry } from 'prom-client';
 
@@ -11,7 +11,7 @@ import { createServiceLogger } from '@hyperlane-xyz/utils';
 import { getEnabledModules } from './config.js';
 import { moduleRegistry } from './moduleRegistry.js';
 import { HealthService } from './services/HealthService.js';
-import { configureTrustProxy } from './utils/http.js';
+import { configureTrustProxy, requestLogLevel } from './utils/http.js';
 import {
   PrometheusMetrics,
   UnhandledErrorReason,
@@ -35,7 +35,9 @@ async function startServer() {
   configureTrustProxy(app);
   app.use(cors());
   app.use(express.json({ limit: '10kb' }));
-  app.use(pinoHttp({ logger }));
+  app.use(
+    pinoHttp<Request, Response>({ logger, customLogLevel: requestLogLevel }),
+  );
 
   if (getEnabledModules().length === 0) {
     logger.warn(

--- a/typescript/ccip-server/src/utils/http.ts
+++ b/typescript/ccip-server/src/utils/http.ts
@@ -1,4 +1,5 @@
-import type { Express } from 'express';
+import type { Express, Request, Response } from 'express';
+import type { LevelWithSilent } from 'pino';
 
 // GCE ingress appends the client and load-balancer addresses to X-Forwarded-For.
 // Trust the direct proxy and the load-balancer address so Express selects the
@@ -7,4 +8,22 @@ export const GCE_INGRESS_PROXY_HOPS = 2;
 
 export function configureTrustProxy(app: Express): void {
   app.set('trust proxy', GCE_INGRESS_PROXY_HOPS);
+}
+
+// Keep failed probes visible; successful probes dominate request completion logs.
+export function requestLogLevel(
+  req: Request,
+  res: Response,
+  error?: Error,
+): LevelWithSilent {
+  if (
+    req.originalUrl === '/health' &&
+    res.statusCode === 200 &&
+    res.writableEnded &&
+    !error &&
+    !res.err
+  ) {
+    return 'silent';
+  }
+  return 'info';
 }

--- a/typescript/ccip-server/tests/services/RequestLogging.test.ts
+++ b/typescript/ccip-server/tests/services/RequestLogging.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import express, { type Request, type Response } from 'express';
+import { pino } from 'pino';
+import { pinoHttp } from 'pino-http';
+
+import { requestLogLevel } from '../../src/utils/http.js';
+
+describe('request completion logging', () => {
+  for (const scenario of [
+    { path: '/health', status: 200, logged: false },
+    { path: '/health', status: 503, logged: true },
+    { path: '/health', status: 200, error: true, logged: true },
+    { path: '/health?detail=1', status: 200, logged: true },
+    { path: '/application', status: 200, logged: true },
+  ]) {
+    it(`logs=${scenario.logged} for ${scenario.path} status=${scenario.status} error=${Boolean(scenario.error)}`, async () => {
+      const lines: string[] = [];
+      const logger = pino({}, { write: (line: string) => lines.push(line) });
+      const app = express();
+      app.use(
+        pinoHttp<Request, Response>({
+          logger,
+          customLogLevel: requestLogLevel,
+        }),
+      );
+      const router = express.Router();
+      router.get('/', (_req, res) => {
+        if (scenario.error) res.err = new Error('probe failed');
+        res.status(scenario.status).send('ok');
+      });
+      app.use('/health', router);
+      app.get('/application', (_req, res) => res.status(200).send('ok'));
+      const server = app.listen(0);
+      await new Promise<void>((resolve) => server.once('listening', resolve));
+      try {
+        const address = server.address();
+        if (!address || typeof address === 'string')
+          throw new Error('Expected TCP server');
+        const response = await fetch(
+          `http://127.0.0.1:${address.port}${scenario.path}`,
+        );
+        expect(response.status).to.equal(scenario.status);
+        await response.text();
+        expect(lines).to.have.length(scenario.logged ? 1 : 0);
+        if (scenario.logged) expect(lines[0]).to.include('"level":30');
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
Successful health probes produced 494 of 518 request-completion logs across the two production offchain lookup servers in a complete ten-minute sample (2026-09-09 00:50–01:00 UTC).

Suppress only completed HTTP 200 requests to `/health`. Failed probes, response errors, aborted responses and application requests retain the existing logging level. Match Express `originalUrl` so mounted routers cannot hide the request path.

Validation: five focused HTTP integration cases passed; scoped lint, formatting and commit hooks passed. Independently reviewed by GPT-6 Astra Medium before push. No deployment performed.

Expected impact: removes 494 completion records per ten minutes at the sampled probe rate (~71,136/day modeled), with no response or request-metric changes. Canary testnet first; require unchanged health responses and retained failed-probe logs. Roll back if application or failed-probe logs disappear.
