### PR TITLE
chore(infra): deploy relayer cardinality fix

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,9 +43,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '856576e-20260908-194828',
-  relayerRC: '856576e-20260908-194828',
-  relayerFastPath: '856576e-20260908-194828',
+  relayer: '736ace8-20260909-012244',
+  relayerRC: '736ace8-20260909-012244',
+  relayerFastPath: '736ace8-20260909-012244',
   validator: '856576e-20260908-194828',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',
@@ -63,9 +63,9 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '856576e-20260908-194828',
-  relayerRC: '856576e-20260908-194828',
-  relayerFastPath: '856576e-20260908-194828',
+  relayer: '736ace8-20260909-012244',
+  relayerRC: '736ace8-20260909-012244',
+  relayerFastPath: '736ace8-20260909-012244',
   validator: '856576e-20260908-194828',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',


### PR DESCRIPTION
## Summary

- updates mainnet3 and testnet4 standard, RC, and fastpath relayer tags to the agent image built from merged #9585
- keeps RC workloads down; only records the current tag for future use

## Rollout

- testnet4 standard + fastpath: Ready, zero restarts
- mainnet3 standard + fastpath: Ready, zero restarts
- mainnet post-rollout logs: no ERROR, panic, critical, or MessageDbLoader failures

Image: `ghcr.io/hyperlane-xyz/hyperlane-agent:736ace8-20260909-012244`
Digest: `sha256:66c8bf323da4973010bdd2dfa911d13c0e6948efb15a6e0b4a8d5dcb0472d375`
Build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34298935613
