### PR TITLE
fix(cosmos): derive legacy multisig transaction senders

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
@@ -1,7 +1,12 @@
 use cometbft::account::Id as TendermintAccountId;
 use cometbft::public_key::PublicKey as TendermintPublicKey;
-use cosmrs::{crypto::PublicKey, AccountId};
+use cosmrs::{
+    crypto::{LegacyAminoMultisig, PublicKey},
+    AccountId,
+};
 use hyperlane_cosmwasm_interface::types::keccak256_hash;
+use protobuf::CodedOutputStream;
+use sha2::{Digest, Sha256};
 
 use crypto::decompress_public_key;
 use hyperlane_core::{AccountAddressType, ChainCommunicationError, ChainResult, H256};
@@ -27,6 +32,57 @@ impl<'a> CosmosAccountId<'a> {
             AccountAddressType::Bitcoin => Self::bitcoin_style(pub_key, prefix),
             AccountAddressType::Ethereum => Self::ethereum_style(pub_key, prefix),
         }
+    }
+
+    /// Legacy multisig accounts use SHA256(Amino(pubkey))[..20], not the
+    /// single secp256k1 key's RIPEMD160 address derivation.
+    /// Source: <https://github.com/cosmos/cosmos-sdk/blob/v0.50.13/crypto/keys/multisig/multisig.go>
+    pub fn account_id_from_multisig(
+        key: &LegacyAminoMultisig,
+        prefix: &str,
+    ) -> ChainResult<AccountId> {
+        if key.threshold == 0 || u64::from(key.threshold) > key.public_keys.len() as u64 {
+            return Err(HyperlaneCosmosError::PublicKeyError(
+                "invalid multisig threshold".to_owned(),
+            )
+            .into());
+        }
+
+        // Amino type prefixes, including the fixed-length member key size.
+        // https://github.com/cosmos/cosmjs/blob/v0.36.0/packages/amino/src/encoding.ts
+        const MULTISIG_PREFIX: [u8; 4] = [0x22, 0xc1, 0xf7, 0xe2];
+        const SECP256K1_PREFIX: [u8; 5] = [0xeb, 0x5a, 0xe9, 0x87, 0x21];
+        const ED25519_PREFIX: [u8; 5] = [0x16, 0x24, 0xde, 0x64, 0x20];
+        let mut amino = MULTISIG_PREFIX.to_vec();
+        {
+            let mut output = CodedOutputStream::vec(&mut amino);
+            output
+                .write_uint32(1, key.threshold)
+                .map_err(HyperlaneCosmosError::from)?;
+            for member in &key.public_keys {
+                let prefix = match member.type_url() {
+                    PublicKey::SECP256K1_TYPE_URL => SECP256K1_PREFIX,
+                    PublicKey::ED25519_TYPE_URL => ED25519_PREFIX,
+                    other => {
+                        return Err(HyperlaneCosmosError::PublicKeyError(format!(
+                            "unsupported multisig member key: {other}"
+                        ))
+                        .into())
+                    }
+                };
+                let mut encoded = prefix.to_vec();
+                encoded.extend(member.to_bytes());
+                output
+                    .write_bytes(2, &encoded)
+                    .map_err(HyperlaneCosmosError::from)?;
+            }
+            output.flush().map_err(HyperlaneCosmosError::from)?;
+        }
+        let hash = Sha256::digest(amino);
+        AccountId::new(prefix, &hash[..20])
+            .map_err(Box::new)
+            .map_err(Into::<HyperlaneCosmosError>::into)
+            .map_err(Into::into)
     }
 
     /// Returns a Bitcoin style address: RIPEMD160(SHA256(pubkey))

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account/celestia_multisig.json
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account/celestia_multisig.json
@@ -1,0 +1,112 @@
+[
+  {
+    "nonce": 1979,
+    "height": "8537428",
+    "sequence": "10",
+    "public_key": {
+      "@type": "/cosmos.crypto.multisig.LegacyAminoPubKey",
+      "threshold": 1,
+      "public_keys": [
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AgWNmqhtJkIEJJolRyUtMxFToHkZMuwkayXX6/V2T0CE"
+        },
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "As8uguvNTRAUEhwGl+Fc+WjG+jh/0wgPyI9aeTltk4kF"
+        }
+      ]
+    },
+    "address": "celestia18y9jtqqaxhx787536ysqhx5x5swat8vtcsqmhw",
+    "signer_bits": 64,
+    "legacy_amino_json": false
+  },
+  {
+    "nonce": 1980,
+    "height": "8539315",
+    "sequence": "11",
+    "public_key": {
+      "@type": "/cosmos.crypto.multisig.LegacyAminoPubKey",
+      "threshold": 1,
+      "public_keys": [
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AgWNmqhtJkIEJJolRyUtMxFToHkZMuwkayXX6/V2T0CE"
+        },
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "As8uguvNTRAUEhwGl+Fc+WjG+jh/0wgPyI9aeTltk4kF"
+        }
+      ]
+    },
+    "address": "celestia18y9jtqqaxhx787536ysqhx5x5swat8vtcsqmhw",
+    "signer_bits": 64,
+    "legacy_amino_json": true
+  },
+  {
+    "nonce": 1981,
+    "height": "8544063",
+    "sequence": "13",
+    "public_key": {
+      "@type": "/cosmos.crypto.multisig.LegacyAminoPubKey",
+      "threshold": 1,
+      "public_keys": [
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AgWNmqhtJkIEJJolRyUtMxFToHkZMuwkayXX6/V2T0CE"
+        },
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "As8uguvNTRAUEhwGl+Fc+WjG+jh/0wgPyI9aeTltk4kF"
+        }
+      ]
+    },
+    "address": "celestia18y9jtqqaxhx787536ysqhx5x5swat8vtcsqmhw",
+    "signer_bits": 64,
+    "legacy_amino_json": true
+  },
+  {
+    "nonce": 1982,
+    "height": "8546716",
+    "sequence": "0",
+    "public_key": {
+      "@type": "/cosmos.crypto.multisig.LegacyAminoPubKey",
+      "threshold": 1,
+      "public_keys": [
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "A0dBrBVPP5wmMbNhF5qyxO6S08hPE8T5R1R8O17L4omM"
+        },
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AlNscAfiLR8wxvTup6FiwN+MBu2/m5vdrcOpZPNouUmX"
+        }
+      ]
+    },
+    "address": "celestia1frflhvg28v5qgvsy7ep08f5lp6rjvj8echsas0",
+    "signer_bits": 128,
+    "legacy_amino_json": true
+  },
+  {
+    "nonce": 1983,
+    "height": "8546743",
+    "sequence": "1",
+    "public_key": {
+      "@type": "/cosmos.crypto.multisig.LegacyAminoPubKey",
+      "threshold": 1,
+      "public_keys": [
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "A0dBrBVPP5wmMbNhF5qyxO6S08hPE8T5R1R8O17L4omM"
+        },
+        {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AlNscAfiLR8wxvTup6FiwN+MBu2/m5vdrcOpZPNouUmX"
+        }
+      ]
+    },
+    "address": "celestia1frflhvg28v5qgvsy7ep08f5lp6rjvj8echsas0",
+    "signer_bits": 128,
+    "legacy_amino_json": true
+  }
+]

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account/tests.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account/tests.rs
@@ -95,13 +95,14 @@ fn test_celestia_multisig_accounts() {
     // reproduced with @cosmjs/amino 0.36.0 pubkeyToAddress and matched
     // the on-chain sender (and account public key for the last transaction).
     let fixtures: Vec<MultisigFixture> =
-        serde_json::from_str(include_str!("celestia_multisig.json")).unwrap();
+        serde_json::from_str(include_str!("celestia_multisig.json")).expect("valid test fixture");
     for fixture in fixtures {
         let key = cosmrs::crypto::LegacyAminoMultisig {
             threshold: fixture.public_key.threshold,
             public_keys: fixture.public_key.public_keys,
         };
-        let actual = CosmosAccountId::account_id_from_multisig(&key, "celestia").unwrap();
+        let actual = CosmosAccountId::account_id_from_multisig(&key, "celestia")
+            .expect("valid test fixture");
         assert_eq!(actual.as_ref(), fixture.address);
     }
 }
@@ -137,21 +138,21 @@ fn test_cosmjs_two_of_three_multisig_vector() {
                 PublicKey::from_json(&format!(
                     r#"{{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"{key}"}}"#
                 ))
-                .unwrap()
+                .expect("valid test fixture")
             })
             .collect(),
     };
     let expected = "wasm1pzf2wlat97n7rykrk7e8g8nxste6hde0r8jqsy";
     assert_eq!(
         CosmosAccountId::account_id_from_multisig(&key, "wasm")
-            .unwrap()
+            .expect("valid test fixture")
             .as_ref(),
         expected
     );
     key.public_keys.reverse();
     assert_ne!(
         CosmosAccountId::account_id_from_multisig(&key, "wasm")
-            .unwrap()
+            .expect("valid test fixture")
             .as_ref(),
         expected
     );
@@ -163,12 +164,12 @@ fn test_multisig_ed25519_member() {
         threshold: 1,
         public_keys: vec![PublicKey::from_json(
             r#"{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Eu5vWB/lVnOh6eE4Kggp4yB1oKpHY8lovFJuGFLnjJU="}"#
-        ).unwrap()],
+        ).expect("valid test fixture")],
     };
     // Independently generated with @cosmjs/amino 0.36.0 pubkeyToAddress.
     assert_eq!(
         CosmosAccountId::account_id_from_multisig(&key, "cosmos")
-            .unwrap()
+            .expect("valid test fixture")
             .as_ref(),
         "cosmos1mc6djfl6af94vfgxxy04n2zayrfc87l6jeq2f7"
     );

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account/tests.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account/tests.rs
@@ -75,3 +75,101 @@ fn decompressed_public_key() -> PublicKey {
     cometbft_pubkey_to_cosmrs_pubkey(&cometbft_key)
         .expect("Failed to deserialize cosmrs::PublicKey")
 }
+
+#[derive(serde::Deserialize)]
+struct MultisigFixture {
+    public_key: MultisigKeyFixture,
+    address: String,
+}
+
+#[derive(serde::Deserialize)]
+struct MultisigKeyFixture {
+    threshold: u32,
+    public_keys: Vec<PublicKey>,
+}
+
+#[test]
+fn test_celestia_multisig_accounts() {
+    // Successful Celestia transactions at heights 8537428, 8539315,
+    // 8544063, 8546716, 8546743. Expected addresses were independently
+    // reproduced with @cosmjs/amino 0.36.0 pubkeyToAddress and matched
+    // the on-chain sender (and account public key for the last transaction).
+    let fixtures: Vec<MultisigFixture> =
+        serde_json::from_str(include_str!("celestia_multisig.json")).unwrap();
+    for fixture in fixtures {
+        let key = cosmrs::crypto::LegacyAminoMultisig {
+            threshold: fixture.public_key.threshold,
+            public_keys: fixture.public_key.public_keys,
+        };
+        let actual = CosmosAccountId::account_id_from_multisig(&key, "celestia").unwrap();
+        assert_eq!(actual.as_ref(), fixture.address);
+    }
+}
+
+#[test]
+fn test_multisig_rejects_invalid_thresholds() {
+    for (threshold, public_keys) in [
+        (0, vec![compressed_public_key()]),
+        (1, vec![]),
+        (2, vec![compressed_public_key()]),
+    ] {
+        let key = cosmrs::crypto::LegacyAminoMultisig {
+            threshold,
+            public_keys,
+        };
+        assert!(CosmosAccountId::account_id_from_multisig(&key, "celestia").is_err());
+    }
+}
+
+#[test]
+fn test_cosmjs_two_of_three_multisig_vector() {
+    // https://github.com/cosmos/cosmjs/blob/v0.36.0/packages/amino/src/addresses.spec.ts
+    let keys = [
+        "A4y1mO5UEw00+OCBjneHqgYTmg4tACbK22YrVc8WhZpn",
+        "ApBvG9lRbIzTtSY5MiyAG/hyTB+l6HjA4yub1sC7iw9o",
+        "A8yTUZ1htobabw6M/5Qx41a0X5EGPtb4H3nd2JiFiADz",
+    ];
+    let mut key = cosmrs::crypto::LegacyAminoMultisig {
+        threshold: 2,
+        public_keys: keys
+            .into_iter()
+            .map(|key| {
+                PublicKey::from_json(&format!(
+                    r#"{{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"{key}"}}"#
+                ))
+                .unwrap()
+            })
+            .collect(),
+    };
+    let expected = "wasm1pzf2wlat97n7rykrk7e8g8nxste6hde0r8jqsy";
+    assert_eq!(
+        CosmosAccountId::account_id_from_multisig(&key, "wasm")
+            .unwrap()
+            .as_ref(),
+        expected
+    );
+    key.public_keys.reverse();
+    assert_ne!(
+        CosmosAccountId::account_id_from_multisig(&key, "wasm")
+            .unwrap()
+            .as_ref(),
+        expected
+    );
+}
+
+#[test]
+fn test_multisig_ed25519_member() {
+    let key = cosmrs::crypto::LegacyAminoMultisig {
+        threshold: 1,
+        public_keys: vec![PublicKey::from_json(
+            r#"{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Eu5vWB/lVnOh6eE4Kggp4yB1oKpHY8lovFJuGFLnjJU="}"#
+        ).unwrap()],
+    };
+    // Independently generated with @cosmjs/amino 0.36.0 pubkeyToAddress.
+    assert_eq!(
+        CosmosAccountId::account_id_from_multisig(&key, "cosmos")
+            .unwrap()
+            .as_ref(),
+        "cosmos1mc6djfl6af94vfgxxy04n2zayrfc87l6jeq2f7"
+    );
+}

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
@@ -1,6 +1,6 @@
 use cosmrs::{
     crypto::PublicKey,
-    tx::{SequenceNumber, SignerInfo},
+    tx::{SequenceNumber, SignerInfo, SignerPublicKey},
     AccountId, Coin, Tx,
 };
 use itertools::Itertools;
@@ -129,13 +129,17 @@ impl<QueryClient: BuildableQueryClient> CosmosProvider<QueryClient> {
         })?;
 
         let (key, account_address_type) = utils::normalize_public_key(signer_public_key)?;
-        let public_key = PublicKey::try_from(key)?;
-
-        let account_id = CosmosAccountId::account_id_from_pubkey(
-            public_key,
-            &self.conf.get_bech32_prefix(),
-            &account_address_type,
-        )?;
+        let prefix = self.conf.get_bech32_prefix();
+        let account_id = match key {
+            SignerPublicKey::LegacyAminoMultisig(key) => {
+                CosmosAccountId::account_id_from_multisig(&key, &prefix)?
+            }
+            key => CosmosAccountId::account_id_from_pubkey(
+                PublicKey::try_from(key)?,
+                &prefix,
+                &account_address_type,
+            )?,
+        };
 
         Ok((account_id, signer_info.sequence))
     }
@@ -322,5 +326,141 @@ impl<T: BuildableQueryClient> HyperlaneProvider for CosmosProvider<T> {
             block_height: height,
             min_gas_price: None,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmrs::{
+        crypto::LegacyAminoMultisig,
+        tx::{AuthInfo, Body, Fee},
+    };
+    use hyperlane_core::{config::OpSubmissionConfig, KnownHyperlaneDomain, NativeToken};
+    use url::Url;
+
+    use super::*;
+    use crate::{native::ModuleQueryClient, RawCosmosAmount};
+
+    fn provider() -> CosmosProvider<ModuleQueryClient> {
+        let conf = ConnectionConf::new(
+            vec![Url::parse("http://localhost:9090").unwrap()],
+            vec![Url::parse("http://localhost:26657").unwrap()],
+            "celestia".to_owned(),
+            "celestia".to_owned(),
+            "utia".to_owned(),
+            RawCosmosAmount::new("utia".to_owned(), "0".to_owned()),
+            32,
+            OpSubmissionConfig::default(),
+            NativeToken {
+                decimals: 6,
+                symbol: "TIA".to_owned(),
+                denom: "utia".to_owned(),
+            },
+            1.4,
+            None,
+        )
+        .unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::CosmosTest99990);
+        CosmosProvider::new(
+            &conf,
+            &ContractLocator::new(&domain, H256::zero()),
+            None,
+            PrometheusClientMetrics::default(),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn transaction(signers: Vec<SignerInfo>, payer: Option<AccountId>) -> Tx {
+        Tx {
+            body: Body::new(Vec::new(), "", 0_u8),
+            auth_info: AuthInfo {
+                signer_infos: signers,
+                fee: Fee {
+                    amount: Vec::new(),
+                    gas_limit: 0,
+                    payer,
+                    granter: None,
+                },
+            },
+            signatures: Vec::new(),
+        }
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Fixture {
+        public_key: KeyFixture,
+        sequence: String,
+        address: String,
+        signer_bits: u8,
+        legacy_amino_json: bool,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct KeyFixture {
+        threshold: u32,
+        public_keys: Vec<PublicKey>,
+    }
+
+    #[tokio::test]
+    async fn multisig_sender_and_nonce_preserves_fee_payer_selection() {
+        let provider = provider();
+        let fixtures: Vec<Fixture> =
+            serde_json::from_str(include_str!("../libs/account/celestia_multisig.json")).unwrap();
+        for fixture in fixtures {
+            let sequence = fixture.sequence.parse().unwrap();
+            let key = LegacyAminoMultisig {
+                threshold: fixture.public_key.threshold,
+                public_keys: fixture.public_key.public_keys,
+            };
+            let single_key = key.public_keys[0];
+            let single_account = CosmosAccountId::account_id_from_pubkey(
+                single_key,
+                "celestia",
+                &hyperlane_core::AccountAddressType::Bitcoin,
+            )
+            .unwrap();
+            let multisig_account: AccountId = fixture.address.parse().unwrap();
+            // Round-trip through protobuf Any, as transaction decoding does.
+            let multisig = SignerPublicKey::try_from(cosmrs::Any::from(key)).unwrap();
+            let signer = SignerInfo {
+                public_key: Some(multisig),
+                mode_info: cosmrs::tx::ModeInfo::Multi(cosmrs::tx::mode_info::Multi {
+                    bitarray: cosmrs::crypto::CompactBitArray::new(2, vec![fixture.signer_bits]),
+                    mode_infos: vec![cosmrs::tx::ModeInfo::single(if fixture.legacy_amino_json {
+                        cosmrs::tx::SignMode::LegacyAminoJson
+                    } else {
+                        cosmrs::tx::SignMode::Direct
+                    })],
+                }),
+                sequence,
+            };
+            let expected = CosmosAddress::from_account_id(multisig_account.clone())
+                .unwrap()
+                .digest();
+            assert_eq!(
+                provider
+                    .sender_and_nonce(&transaction(vec![signer.clone()], None))
+                    .unwrap(),
+                (expected, sequence)
+            );
+            // An explicit payer selects its own sequence, regardless of position.
+            let signers = vec![SignerInfo::single_direct(Some(single_key), 42), signer];
+            assert_eq!(
+                provider
+                    .sender_and_nonce(&transaction(signers.clone(), Some(multisig_account)))
+                    .unwrap(),
+                (expected, sequence)
+            );
+            let single_expected = CosmosAddress::from_account_id(single_account.clone())
+                .unwrap()
+                .digest();
+            assert_eq!(
+                provider
+                    .sender_and_nonce(&transaction(signers, Some(single_account)))
+                    .unwrap(),
+                (single_expected, 42)
+            );
+        }
     }
 }

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
@@ -343,8 +343,8 @@ mod tests {
 
     fn provider() -> CosmosProvider<ModuleQueryClient> {
         let conf = ConnectionConf::new(
-            vec![Url::parse("http://localhost:9090").unwrap()],
-            vec![Url::parse("http://localhost:26657").unwrap()],
+            vec![Url::parse("http://localhost:9090").expect("valid test fixture")],
+            vec![Url::parse("http://localhost:26657").expect("valid test fixture")],
             "celestia".to_owned(),
             "celestia".to_owned(),
             "utia".to_owned(),
@@ -359,7 +359,7 @@ mod tests {
             1.4,
             None,
         )
-        .unwrap();
+        .expect("valid test fixture");
         let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::CosmosTest99990);
         CosmosProvider::new(
             &conf,
@@ -368,7 +368,7 @@ mod tests {
             PrometheusClientMetrics::default(),
             None,
         )
-        .unwrap()
+        .expect("valid test fixture")
     }
 
     fn transaction(signers: Vec<SignerInfo>, payer: Option<AccountId>) -> Tx {
@@ -406,9 +406,10 @@ mod tests {
     async fn multisig_sender_and_nonce_preserves_fee_payer_selection() {
         let provider = provider();
         let fixtures: Vec<Fixture> =
-            serde_json::from_str(include_str!("../libs/account/celestia_multisig.json")).unwrap();
+            serde_json::from_str(include_str!("../libs/account/celestia_multisig.json"))
+                .expect("valid test fixture");
         for fixture in fixtures {
-            let sequence = fixture.sequence.parse().unwrap();
+            let sequence = fixture.sequence.parse().expect("valid test fixture");
             let key = LegacyAminoMultisig {
                 threshold: fixture.public_key.threshold,
                 public_keys: fixture.public_key.public_keys,
@@ -419,10 +420,11 @@ mod tests {
                 "celestia",
                 &hyperlane_core::AccountAddressType::Bitcoin,
             )
-            .unwrap();
-            let multisig_account: AccountId = fixture.address.parse().unwrap();
+            .expect("valid test fixture");
+            let multisig_account: AccountId = fixture.address.parse().expect("valid test fixture");
             // Round-trip through protobuf Any, as transaction decoding does.
-            let multisig = SignerPublicKey::try_from(cosmrs::Any::from(key)).unwrap();
+            let multisig =
+                SignerPublicKey::try_from(cosmrs::Any::from(key)).expect("valid test fixture");
             let signer = SignerInfo {
                 public_key: Some(multisig),
                 mode_info: cosmrs::tx::ModeInfo::Multi(cosmrs::tx::mode_info::Multi {
@@ -436,12 +438,12 @@ mod tests {
                 sequence,
             };
             let expected = CosmosAddress::from_account_id(multisig_account.clone())
-                .unwrap()
+                .expect("valid test fixture")
                 .digest();
             assert_eq!(
                 provider
                     .sender_and_nonce(&transaction(vec![signer.clone()], None))
-                    .unwrap(),
+                    .expect("valid test fixture"),
                 (expected, sequence)
             );
             // An explicit payer selects its own sequence, regardless of position.
@@ -449,16 +451,16 @@ mod tests {
             assert_eq!(
                 provider
                     .sender_and_nonce(&transaction(signers.clone(), Some(multisig_account)))
-                    .unwrap(),
+                    .expect("valid test fixture"),
                 (expected, sequence)
             );
             let single_expected = CosmosAddress::from_account_id(single_account.clone())
-                .unwrap()
+                .expect("valid test fixture")
                 .digest();
             assert_eq!(
                 provider
                     .sender_and_nonce(&transaction(signers, Some(single_account)))
-                    .unwrap(),
+                    .expect("valid test fixture"),
                 (single_expected, 42)
             );
         }


### PR DESCRIPTION
Cosmos transaction enrichment rejected `LegacyAminoMultisig` signer keys by converting every key to a single public key. Derive the multisig account from its ordered Amino encoding and SHA256 prefix, preserving existing single-key behavior, fee-payer selection and signer sequence.

Five historical Celestia dispatch transactions remained pending in the production scraper snapshot ending 2026-09-09 01:00 UTC. Canonical successful transactions and independently reproduced CosmosJS addresses confirm this parser path blocks their enrichment. The patch covers those five signer/sequence fixtures; resolving them still requires deployment and successful reconciliation. Other historical backlog rows have separate causes.

Validation: five multisig tests passed, including provider integration across the five fixtures, fee-payer ordering, invalid thresholds, key order and Ed25519 membership. Seven account regression tests passed. Production Clippy, both formatting scopes and commit hooks passed; Astra Medium independently approved the final diff before push. Broad test-target Clippy remains blocked by baseline test lints; new fixture unwraps were removed.

Canary: testnet Cosmos transaction parsing, then the mainnet Celestia scraper. Require the five rows to enrich with canonical sender/sequence and no single-signer or fee-payer regression. Preserve errors for unsupported keys; no fabricated sender fallback. Roll back the image on parsing or enrichment regression. No database mutation or deployment in this PR.

Part of the [next-wave tracker](https://gist.github.com/paulbalaji/2e32d1700a869af7eb73a4b94b80134a).
