### PR TITLE
feat(metrics): attribute relayer gas payment RPCs

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -38,6 +38,7 @@ use hyperlane_core::{
     rpc_clients::call_and_retry_n_times, ChainCommunicationError, ChainResult, ContractSyncCursor,
     HyperlaneDomain, HyperlaneMessage, Indexer, InterchainGasPayment, MerkleTreeInsertion, U256,
 };
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use lander::{CommandEntrypoint, DispatcherMetrics};
 
 use crate::relay_api::{
@@ -1032,9 +1033,9 @@ impl Relayer {
         chain_metrics: ChainMetrics,
         tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
     ) {
-        let cursor = match Self::instantiate_cursor_with_retries(
-            contract_sync.clone(),
-            index_settings.clone(),
+        let cursor = match with_rpc_operation(
+            RpcOperation::GasPaymentSync,
+            Self::instantiate_cursor_with_retries(contract_sync.clone(), index_settings.clone()),
         )
         .await
         {

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -276,10 +276,12 @@ where
                 .await;
             }
         };
-        let res = with_rpc_operation(RpcOperation::ContractSync, async {
-            tokio::join!(tx_id_task, cursor_task)
-        })
-        .await;
+        let operation = match label {
+            "gas_payments" => RpcOperation::GasPaymentSync,
+            _ => RpcOperation::ContractSync,
+        };
+        let res =
+            with_rpc_operation(operation, async { tokio::join!(tx_id_task, cursor_task) }).await;
 
         // we should never reach this because the 2 tasks should never end
         tracing::error!(chain = chain_name, label, ?res, "contract sync loop exit");
@@ -682,6 +684,144 @@ mod tests {
         // children, not merely schedule their eventual cancellation.
         assert!(cursor_dropped.load(Ordering::SeqCst));
         assert!(tx.is_closed());
+    }
+
+    #[derive(Clone, Debug)]
+    struct AttributedIndexer {
+        operation: RpcOperation,
+        range_calls: StdArc<AtomicUsize>,
+        tx_calls: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Indexer<HyperlaneMessage> for AttributedIndexer {
+        async fn fetch_logs_in_range(
+            &self,
+            _range: RangeInclusive<u32>,
+        ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
+            tokio::task::yield_now().await;
+            assert_eq!(
+                hyperlane_metric::rpc_operation::current_rpc_operation(),
+                self.operation
+            );
+            if self.range_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(ChainCommunicationError::from_other_str("retry range fetch"));
+            }
+            Ok(Vec::new())
+        }
+
+        async fn fetch_logs_by_tx_hash(
+            &self,
+            _tx_hash: H512,
+        ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
+            tokio::task::yield_now().await;
+            assert_eq!(
+                hyperlane_metric::rpc_operation::current_rpc_operation(),
+                self.operation
+            );
+            self.tx_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+
+        async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+            assert_eq!(
+                hyperlane_metric::rpc_operation::current_rpc_operation(),
+                self.operation
+            );
+            Ok(9)
+        }
+    }
+
+    #[derive(Debug)]
+    struct AttributedCursor {
+        indexer: AttributedIndexer,
+        updated: bool,
+    }
+
+    #[async_trait]
+    impl ContractSyncCursor<HyperlaneMessage> for AttributedCursor {
+        async fn next_action(&mut self) -> Result<(CursorAction, Duration)> {
+            if self.updated {
+                return pending().await;
+            }
+            let tip = self.indexer.get_finalized_block_number().await?;
+            Ok((CursorAction::Query(7..=tip), Duration::ZERO))
+        }
+
+        fn latest_queried_block(&self) -> u32 {
+            0
+        }
+
+        async fn update(
+            &mut self,
+            _logs: Vec<(Indexed<HyperlaneMessage>, LogMeta)>,
+            _range: RangeInclusive<u32>,
+        ) -> Result<()> {
+            self.updated = true;
+            Ok(())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gas_rpc_attribution_covers_cursors_tx_ids_and_retries() {
+        for (label, operation) in [
+            ("gas_payments", RpcOperation::GasPaymentSync),
+            ("dispatched_messages", RpcOperation::ContractSync),
+            ("merkle_tree_hook", RpcOperation::ContractSync),
+            ("gas_payment", RpcOperation::ContractSync),
+            ("arbitrary_label", RpcOperation::ContractSync),
+        ] {
+            let indexer = AttributedIndexer {
+                operation,
+                range_calls: StdArc::new(AtomicUsize::new(0)),
+                tx_calls: StdArc::new(AtomicUsize::new(0)),
+            };
+            let metrics = crate::CoreMetrics::new("test", 0, prometheus::Registry::new())
+                .expect("test metrics");
+            let sync = ContractSync::new(
+                test_domain(),
+                StoreResult {
+                    stored: 0,
+                    error: None,
+                    calls: None,
+                },
+                indexer.clone(),
+                ContractSyncMetrics::new(&metrics),
+                false,
+            );
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            tx.send(IndexingNotification {
+                tx_id: H512::zero(),
+                sequences: Vec::new(),
+            })
+            .await
+            .expect("enqueue transaction");
+            let mut task = Box::pin(sync.sync(
+                label,
+                SyncOptions::new(
+                    Some(Box::new(AttributedCursor {
+                        indexer: indexer.clone(),
+                        updated: false,
+                    })),
+                    Some(rx),
+                ),
+            ));
+            // Both RPC futures yield once before checking attribution.
+            assert!(futures::poll!(&mut task).is_pending());
+            assert!(futures::poll!(&mut task).is_pending());
+            assert_eq!(indexer.range_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(indexer.tx_calls.load(Ordering::SeqCst), 1);
+
+            tokio::time::advance(SLEEP_DURATION).await;
+            assert!(futures::poll!(&mut task).is_pending());
+            assert!(futures::poll!(&mut task).is_pending());
+            assert_eq!(indexer.range_calls.load(Ordering::SeqCst), 2);
+            drop(task);
+            assert_eq!(
+                hyperlane_metric::rpc_operation::current_rpc_operation(),
+                RpcOperation::Unattributed
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/main/hyperlane-metric/src/rpc_operation.rs
+++ b/rust/main/hyperlane-metric/src/rpc_operation.rs
@@ -17,6 +17,8 @@ pub enum RpcOperation {
     Unattributed,
     /// Contract event cursor and range synchronization.
     ContractSync,
+    /// Relayer gas-payment cursor, range, and transaction synchronization.
+    GasPaymentSync,
     /// Periodic agent balance, block, and gas metrics.
     AgentMetrics,
     /// Validator checkpoint correctness and submission reads.
@@ -39,6 +41,7 @@ impl RpcOperation {
         match self {
             Self::Unattributed => "unattributed",
             Self::ContractSync => "contract_sync",
+            Self::GasPaymentSync => "gas_payment_sync",
             Self::AgentMetrics => "agent_metrics",
             Self::ValidatorCheckpoint => "validator_checkpoint",
             Self::RelayerDelivery => "relayer_delivery",
@@ -83,6 +86,19 @@ mod tests {
         })
         .await;
 
+        assert_eq!(current_rpc_operation(), RpcOperation::Unattributed);
+    }
+
+    #[tokio::test]
+    async fn gas_sync_scope_survives_yields_and_restores_after_error() {
+        assert_eq!(RpcOperation::GasPaymentSync.as_str(), "gas_payment_sync");
+        let result = with_rpc_operation(RpcOperation::GasPaymentSync, async {
+            tokio::task::yield_now().await;
+            assert_eq!(current_rpc_operation(), RpcOperation::GasPaymentSync);
+            Err::<(), _>("initialization failed")
+        })
+        .await;
+        assert!(result.is_err());
         assert_eq!(current_rpc_operation(), RpcOperation::Unattributed);
     }
 }


### PR DESCRIPTION
Relayer gas-payment RPC reads share `operation="contract_sync"` with dispatch and Merkle indexing, obscuring the cost of retaining gas RPC polling alongside WebSocket ingestion. Attribute the existing gas cursor initialization, range and transaction paths to one fixed `gas_payment_sync` operation. Polling, authority and payment credits are unchanged.

The production fastpath window ending 2026-09-09 01:00 UTC contained 92,255 contract-sync blockNumber/getLogs calls over four hours. That is an upper bound across indexing types, not measured avoidable gas work. This change supplies the missing denominator before a gas handoff can be assessed; no saving is claimed.

Validation: 15 focused tests passed, including actual cursor/range/tx-ID paths, retry, async scope restoration and fixed mapping for unrelated labels. Strict metric/base library and relayer binary Clippy, both formatting scopes and commit hooks passed. Astra Medium independently approved the exact patch before push.

After an authorized canary:
```promql
sum by (namespace, hyperlane_context, chain, method) (
  increase(hyperlane_request_count{agent="relayer",operation="gas_payment_sync"}[4h])
)
```
For cross-version steady sync comparison, combine `contract_sync|gas_payment_sync` only in settled windows without cursor recreation. Initialization also moves from normally unattributed into the new bucket; compare all-operation physical totals for startup-spanning windows. A classification drop in the old bucket is not an efficiency improvement.

Canary one testnet relayer, then mainnet fastpath. Require expected bounded attribution, unchanged aggregate RPC behavior and no service-outcome regression; roll back the image on metric or service regression. No deployment/shared dashboard changes.

Part of the [next-wave tracker](https://gist.github.com/paulbalaji/2e32d1700a869af7eb73a4b94b80134a).
