### PR TITLE
feat(scraper): measure reconciliation page outcomes

### DIFF
--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -88,6 +88,8 @@ struct RawDispatchReconciliationMetrics {
     duration: HistogramVec,
     pending_retries: IntGaugeVec,
     retry_capacity_overflows: IntCounterVec,
+    page_results: IntCounterVec,
+    rows: IntCounterVec,
 }
 
 impl RawDispatchReconciliationMetrics {
@@ -121,11 +123,50 @@ impl RawDispatchReconciliationMetrics {
                 &["chain"],
             )
             .expect("failed to register raw dispatch reconciliation retry overflow metric");
+        let page_results = metrics
+            .new_int_counter(
+                "raw_message_dispatch_reconciliation_page_results",
+                "Completed raw dispatch reconciliation pages, including errors and panics",
+                &["chain", "kind", "result"],
+            )
+            .expect("failed to register raw dispatch reconciliation page result metric");
+        let rows = metrics
+            .new_int_counter(
+                "raw_message_dispatch_reconciliation_rows",
+                "Rows reported by successful reconciliation pages; stages overlap and exclude partial work from failed pages",
+                &["chain", "kind", "stage"],
+            )
+            .expect("failed to register raw dispatch reconciliation row metric");
         Self {
             operations,
             duration,
             pending_retries,
             retry_capacity_overflows,
+            page_results,
+            rows,
+        }
+    }
+
+    fn record_page(
+        &self,
+        chain: &str,
+        kind: &str,
+        result: Option<&RawDispatchReconciliationResult>,
+    ) {
+        self.page_results
+            .with_label_values(&[chain, kind, if result.is_some() { "ok" } else { "error" }])
+            .inc();
+        if let Some(result) = result {
+            for (stage, count) in [
+                ("candidate", result.candidate_count as u64),
+                ("attempted", result.attempted_count as u64),
+                ("skipped_backoff", result.skipped_backoff_count as u64),
+                ("stored", u64::from(result.stored_count)),
+            ] {
+                self.rows
+                    .with_label_values(&[chain, kind, stage])
+                    .inc_by(count);
+            }
         }
     }
 
@@ -800,6 +841,11 @@ impl Scraper {
                         .catch_unwind()
                         .await;
                         timer.observe_duration();
+                        reconciliation_metrics.record_page(
+                            &domain_name,
+                            RAW_DISPATCH_RETRY_PAGE_KIND,
+                            result.as_ref().ok().and_then(|page| page.as_ref().ok()),
+                        );
                         match result {
                             Ok(Ok(result)) => {
                                 stored_events_metric.inc_by(result.stored_count.into());
@@ -886,6 +932,11 @@ impl Scraper {
                         .catch_unwind()
                         .await;
                         timer.observe_duration();
+                        reconciliation_metrics.record_page(
+                            &domain_name,
+                            RAW_DISPATCH_DISCOVERY_PAGE_KIND,
+                            result.as_ref().ok().and_then(|page| page.as_ref().ok()),
+                        );
                         match result {
                             Ok(Ok(result)) => {
                                 stored_events_metric.inc_by(result.stored_count.into());
@@ -981,6 +1032,11 @@ impl Scraper {
                         .catch_unwind()
                         .await;
                         timer.observe_duration();
+                        reconciliation_metrics.record_page(
+                            &domain_name,
+                            RAW_DISPATCH_SWEEP_PAGE_KIND,
+                            result.as_ref().ok().and_then(|page| page.as_ref().ok()),
+                        );
                         match result {
                             Ok(Ok(result)) => {
                                 stored_events_metric.inc_by(result.stored_count.into());
@@ -1292,6 +1348,60 @@ mod test {
     use hyperlane_ethereum as h_eth;
 
     use super::*;
+
+    #[test]
+    fn reconciliation_page_metrics_distinguish_empty_success_and_failure() {
+        let core = CoreMetrics::new("scraper", 0, Registry::new()).expect("test registry");
+        let metrics = RawDispatchReconciliationMetrics::new(&core);
+        for kind in [
+            RAW_DISPATCH_RETRY_PAGE_KIND,
+            RAW_DISPATCH_DISCOVERY_PAGE_KIND,
+            RAW_DISPATCH_SWEEP_PAGE_KIND,
+        ] {
+            metrics.record_page(
+                "ethereum",
+                kind,
+                Some(&RawDispatchReconciliationResult {
+                    candidate_count: 5,
+                    attempted_count: 3,
+                    skipped_backoff_count: 2,
+                    stored_count: 1,
+                    ..Default::default()
+                }),
+            );
+            metrics.record_page("ethereum", kind, Some(&Default::default()));
+            // Failed pages can have partial work; do not fabricate row counts for them.
+            metrics.record_page("ethereum", kind, None);
+            assert_eq!(
+                metrics
+                    .page_results
+                    .with_label_values(&["ethereum", kind, "ok"])
+                    .get(),
+                2
+            );
+            assert_eq!(
+                metrics
+                    .page_results
+                    .with_label_values(&["ethereum", kind, "error"])
+                    .get(),
+                1
+            );
+            for (stage, expected) in [
+                ("candidate", 5),
+                ("attempted", 3),
+                ("skipped_backoff", 2),
+                ("stored", 1),
+            ] {
+                assert_eq!(
+                    metrics
+                        .rows
+                        .with_label_values(&["ethereum", kind, stage])
+                        .get(),
+                    expected
+                );
+            }
+        }
+    }
 
     async fn run_pending_tasks() {
         for _ in 0..10 {


### PR DESCRIPTION
Scraper reconciliation exports operation durations and a combined stored-event count, but not candidate/attempt/skip/store work by retry, discovery or sweep lane. Record the existing page result fields and distinguish completed successful pages—including empty pages—from errors or caught panics. Database queries, retry timing and completeness sweeps are unchanged.

The four-hour production window ending 2026-09-09 01:00 UTC accumulated 1,266.6 sweep span-seconds versus 1.85 discovery span-seconds. These include waiting and RPC work, not database CPU. Lane output counters provide the missing denominator before changing reconciliation architecture. A later read-only catalog probe confirmed the production reconciliation index already exists; this PR adds no index or migration.

Validation: four focused reconciliation tests passed, including existing scheduling/backoff checks and all three metric lanes with populated, empty and failed pages. Strict scraper binary Clippy, formatting and commit hooks passed. Astra Medium independently approved the exact diff before push.

New counters:
```promql
sum by (chain,kind,stage) (
  increase(hyperlane_raw_message_dispatch_reconciliation_rows[4h])
)
sum by (chain,kind,result) (
  increase(hyperlane_raw_message_dispatch_reconciliation_page_results[4h])
)
```
Stages overlap. Counts reflect successful-page results; partial work from failed pages is unknown. Stored work is not necessarily unique recovered rows under replay/concurrency. At most 18 added series per chain: three lanes × (two result values + four stages), independent of row/message identifiers. Compare only post-introduction settled windows and account for resets.

Canary testnet scraper, then mainnet. Reconcile counter deltas against sampled page logs; require unchanged fresh-event throughput, backlog and cursor lag. Roll back the image for incorrect counting/cardinality or service regression. No deployment or shared dashboard changes.

Part of the [next-wave tracker](https://gist.github.com/paulbalaji/2e32d1700a869af7eb73a4b94b80134a).
