### PR TITLE
perf(relayer): cache empty pending message index lookups

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -2,7 +2,10 @@ use std::{
     cmp::max,
     collections::{BTreeSet, HashMap, HashSet},
     fmt::{Debug, Formatter},
-    sync::{atomic::AtomicBool, Arc},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -64,6 +67,7 @@ pub struct MessageDbLoader {
     destination_iterators: Vec<DestinationIndexIterator>,
     next_destination: usize,
     destination_scan_pending: bool,
+    index_generation: Arc<AtomicU64>,
     max_retries: u32,
     index_notifications: Option<Receiver<IndexingNotification>>,
 }
@@ -80,6 +84,7 @@ struct DestinationIndexIterator {
     destination: u32,
     destination_label: Arc<str>,
     high_nonce: Option<u32>,
+    empty_high: Option<(u32, u64)>,
     low_nonce: Option<u32>,
     next_direction: IndexDirection,
     reconsider_nonces: BTreeSet<u32>,
@@ -93,6 +98,7 @@ impl DestinationIndexIterator {
             destination,
             destination_label: destination.to_string().into(),
             high_nonce: Some(highest_seen_nonce.unwrap_or_default()),
+            empty_high: None,
             low_nonce: highest_seen_nonce.and_then(|nonce| nonce.checked_sub(1)),
             next_direction: IndexDirection::High,
             reconsider_nonces: BTreeSet::new(),
@@ -105,6 +111,7 @@ impl DestinationIndexIterator {
         &mut self,
         db: &HyperlaneRocksDB,
         metrics: &MessageDbLoaderMetrics,
+        generation: u64,
     ) -> Result<Option<(IndexDirection, u32, H256)>> {
         if self.low_nonce.is_none() && self.low_range_reopen_pending {
             self.low_range_reopen_pending = false;
@@ -142,6 +149,11 @@ impl DestinationIndexIterator {
             let Some(nonce) = nonce else {
                 continue;
             };
+            // Only cache an empty query at this exact frontier. Mutation
+            // invalidation never changes cursor, notification or replay order.
+            if direction == IndexDirection::High && self.empty_high == Some((nonce, generation)) {
+                continue;
+            }
             metrics
                 .logical_db_reads
                 .with_label_values(&[metrics.origin.as_str(), "destination_index", "index"])
@@ -158,6 +170,9 @@ impl DestinationIndexIterator {
             if let Some((nonce, message_id)) = entry {
                 return Ok(Some((direction, nonce, message_id)));
             }
+            if direction == IndexDirection::High {
+                self.empty_high = Some((nonce, generation));
+            }
             if direction == IndexDirection::Low {
                 self.low_nonce = None;
                 if self.low_range_reopen_pending {
@@ -168,7 +183,7 @@ impl DestinationIndexIterator {
             }
         }
         if reopened_low_range {
-            return self.peek(db, metrics);
+            return self.peek(db, metrics, generation);
         }
         Ok(None)
     }
@@ -516,6 +531,7 @@ impl MessageDbLoader {
         max_retries: u32,
         cancellation: &AtomicBool,
     ) -> Result<Self> {
+        let index_generation = db.pending_message_index_generation();
         let migration_start_sequence = db.latest_sequence_number();
         let migration_complete = {
             let _timer = metrics
@@ -553,6 +569,7 @@ impl MessageDbLoader {
             destination_iterators,
             next_destination: 0,
             destination_scan_pending: true,
+            index_generation,
             max_retries,
             index_notifications: None,
         })
@@ -744,7 +761,11 @@ impl MessageDbLoader {
             return Ok(false);
         }
         let Some((direction, nonce, indexed_message_id)) =
-            self.destination_iterators[iterator_index].peek(&self.db, &self.metrics)?
+            self.destination_iterators[iterator_index].peek(
+                &self.db,
+                &self.metrics,
+                self.index_generation.load(Ordering::Acquire),
+            )?
         else {
             if self.migration_iterator.is_none() {
                 self.metrics

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1366,7 +1366,15 @@ async fn alternating_cursor_does_not_starve_low_backlog() {
         let metrics = dummy_message_loader_metrics();
         let mut directions = Vec::new();
         for new_high_nonce in 5..9 {
-            let (direction, nonce, _) = iterator.peek(&db, &metrics).unwrap().unwrap();
+            let (direction, nonce, _) = iterator
+                .peek(
+                    &db,
+                    &metrics,
+                    db.pending_message_index_generation()
+                        .load(Ordering::Acquire),
+                )
+                .unwrap()
+                .unwrap();
             directions.push(direction);
             iterator.advance(direction, nonce);
             add_db_entry(
@@ -2087,6 +2095,197 @@ async fn standalone_cleanup_forces_restart_recovery_of_replacement() {
         assert_eq!(
             only_operation(receiver.try_recv().expect("replacement")).id(),
             replacement.id()
+        );
+    })
+    .await;
+}
+
+async fn drain_benchmark_records(loader: &mut MessageDbLoader, uncached: bool) {
+    for _ in 0..10_000 {
+        if uncached {
+            for iterator in &mut loader.destination_iterators {
+                iterator.empty_high = None;
+            }
+        }
+        let before = loader_phase_counter(&loader.metrics.records_examined, "destination_index");
+        loader.tick().await.unwrap();
+        if loader_phase_counter(&loader.metrics.records_examined, "destination_index") == before {
+            return;
+        }
+    }
+    panic!("fixture did not finish scanning retained records");
+}
+
+#[tokio::test(start_paused = true)]
+#[ignore = "74x74 steady loader benchmark; run explicitly with --ignored --nocapture"]
+async fn benchmark_pending_index_idle_generation() {
+    const ORIGINS: u32 = 74;
+    const DESTINATIONS: u32 = 74;
+    const TICKS: u32 = 60;
+    for scenario in ["empty", "sparse", "all_populated", "unrelated_writes"] {
+        test_utils::run_test_db(|raw_db| async move {
+            let mut loaders = Vec::new();
+            let mut receivers = Vec::new();
+            for origin_id in 0..ORIGINS {
+                let origin = dummy_domain(origin_id, &format!("idle_bench_{origin_id}"));
+                let db = HyperlaneRocksDB::new(&origin, raw_db.clone());
+                let mut channels = HashMap::new();
+                for destination in 1000..1000 + DESTINATIONS {
+                    let (sender, receiver) = mpsc::channel(1);
+                    channels.insert(destination, sender);
+                    receivers.push(receiver);
+                    if scenario == "all_populated" || (scenario == "sparse" && destination == 1000) {
+                        db.store_message(&HyperlaneMessage { origin: origin_id, destination, nonce: destination, ..Default::default() }, 1).unwrap();
+                    }
+                }
+                let mut loader = MessageDbLoader::new(db, Default::default(), Default::default(), Default::default(),
+                    dummy_message_loader_metrics(), channels, HashMap::new(), vec![].into(), DEFAULT_MAX_MESSAGE_RETRIES).unwrap();
+                finish_legacy_migration(&mut loader).await;
+                drain_benchmark_records(&mut loader, false).await;
+                // Observe cleanup/repair mutations performed during initial scan.
+                loader.tick().await.unwrap();
+                drain_benchmark_records(&mut loader, false).await;
+                loaders.push(loader);
+            }
+            for force_baseline in [true, false] {
+                let before: f64 = loaders.iter().map(|l| loader_phase_counter(&l.metrics.logical_db_reads, "destination_index")).sum();
+                let started = Instant::now();
+                for tick in 0..TICKS {
+                    for loader in &mut loaders {
+                        if scenario == "unrelated_writes" {
+                            loader.db.store_value_by_key("gas_benchmark_", &tick, &tick).unwrap();
+                        }
+                        if force_baseline { for iterator in &mut loader.destination_iterators { iterator.empty_high = None; } }
+                        loader.tick().await.unwrap();
+                    }
+                }
+                let reads: f64 = loaders.iter().map(|l| loader_phase_counter(&l.metrics.logical_db_reads, "destination_index")).sum::<f64>() - before;
+                println!("pending_index_idle scenario={scenario} baseline={force_baseline} origins={ORIGINS} destinations={DESTINATIONS} ticks={TICKS} reads={reads} wall_seconds={:.6}", started.elapsed().as_secs_f64());
+                if force_baseline { assert_eq!(reads, f64::from(ORIGINS * DESTINATIONS * TICKS)); }
+                else { assert_eq!(reads, 0.0); }
+            }
+            drop(receivers);
+        }).await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn active_index_changes_do_not_rescan_retained_history() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let db = HyperlaneRocksDB::new(&origin, raw_db);
+        let mut channels = HashMap::new();
+        let mut receivers = Vec::new();
+        for destination in [10, 20] {
+            let (sender, receiver) = mpsc::channel(1);
+            channels.insert(destination, sender);
+            receivers.push(receiver);
+        }
+        for nonce in 0..200 {
+            db.store_message(&HyperlaneMessage { origin: 0, destination: if nonce % 2 == 0 { 10 } else { 20 }, nonce, ..Default::default() }, 1).unwrap();
+        }
+        // Missing context retains every row after inspecting it once.
+        let mut loader = MessageDbLoader::new(db.clone(), Default::default(), Default::default(), Default::default(),
+            dummy_message_loader_metrics(), channels, HashMap::new(), vec![].into(), DEFAULT_MAX_MESSAGE_RETRIES).unwrap();
+        finish_legacy_migration(&mut loader).await;
+        drain_benchmark_records(&mut loader, false).await;
+        for baseline in [true, false] {
+            let high = if baseline { 200 } else { 201 };
+            let before = loader_phase_counter(&loader.metrics.records_examined, "destination_index");
+            let before_reads = loader_phase_counter(&loader.metrics.logical_db_reads, "destination_index");
+            db.store_message(&HyperlaneMessage { origin: 0, destination: 10, nonce: high, ..Default::default() }, 1).unwrap();
+            loader.apply_index_notification(IndexingNotification { tx_id: H512::zero(), sequences: vec![Some(high)] }).unwrap();
+
+            drain_benchmark_records(&mut loader, baseline).await;
+            let records = loader_phase_counter(&loader.metrics.records_examined, "destination_index") - before;
+            let reads = loader_phase_counter(&loader.metrics.logical_db_reads, "destination_index") - before_reads;
+            assert_eq!(records, 1.0, "a high insert must not rewalk retained low rows");
+            println!("pending_index_active operation=high_insert baseline={baseline} retained=200 records={records} reads={reads}");
+
+            let before = loader_phase_counter(&loader.metrics.records_examined, "destination_index");
+            let old = db.retrieve_message_by_nonce(if baseline { 0 } else { 2 }).unwrap().unwrap();
+            db.store_message_processed(&old).unwrap();
+            loader.destination_scan_pending = true;
+
+            drain_benchmark_records(&mut loader, baseline).await;
+            let records = loader_phase_counter(&loader.metrics.records_examined, "destination_index") - before;
+            assert_eq!(records, 0.0, "cleanup must not rewalk retained low rows");
+            println!("pending_index_active operation=cleanup baseline={baseline} retained=200 records={records}");
+        }
+        drop(receivers);
+    }).await;
+}
+
+#[tokio::test]
+async fn empty_high_cache_tracks_frontier_and_independent_index_writes() {
+    test_utils::run_test_db(|raw_db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, raw_db.clone());
+        let writer = HyperlaneRocksDB::new(&origin, raw_db);
+        let generation = db.pending_message_index_generation();
+        let metrics = dummy_message_loader_metrics();
+        let mut iterator = DestinationIndexIterator::new(destination.id(), Some(20));
+        iterator.low_nonce = None;
+        // A retained lower entry must not defeat an empty-frontier cache.
+        writer
+            .store_message(&dummy_hyperlane_message(&destination, 10), 1)
+            .unwrap();
+        assert!(iterator
+            .peek(&db, &metrics, generation.load(Ordering::Acquire))
+            .unwrap()
+            .is_none());
+        let before = loader_phase_counter(&metrics.logical_db_reads, "destination_index");
+        assert!(iterator
+            .peek(&db, &metrics, generation.load(Ordering::Acquire))
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            loader_phase_counter(&metrics.logical_db_reads, "destination_index"),
+            before
+        );
+
+        writer
+            .store_message(&dummy_hyperlane_message(&destination, 20), 1)
+            .unwrap();
+        assert_eq!(
+            iterator
+                .peek(&db, &metrics, generation.load(Ordering::Acquire))
+                .unwrap()
+                .unwrap()
+                .1,
+            20
+        );
+        iterator.advance(IndexDirection::High, 20);
+        assert!(iterator
+            .peek(&db, &metrics, generation.load(Ordering::Acquire))
+            .unwrap()
+            .is_none());
+        let before = loader_phase_counter(&metrics.logical_db_reads, "destination_index");
+        iterator.high_nonce = Some(30);
+        assert!(iterator
+            .peek(&db, &metrics, generation.load(Ordering::Acquire))
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            loader_phase_counter(&metrics.logical_db_reads, "destination_index"),
+            before + 1.0
+        );
+
+        // Clearing/repopulating the same-count index invalidates cached emptiness.
+        writer
+            .delete_pending_message_index_by_nonce(destination.id(), 20)
+            .unwrap();
+        writer
+            .store_message(&dummy_hyperlane_message(&destination, 30), 1)
+            .unwrap();
+        assert_eq!(
+            iterator
+                .peek(&db, &metrics, generation.load(Ordering::Acquire))
+                .unwrap()
+                .unwrap()
+                .1,
+            30
         );
     })
     .await;

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -1,7 +1,7 @@
 use std::{
     ops::Add,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -285,6 +285,14 @@ impl HyperlaneRocksDB {
     /// Keeping that conservative boundary also detects legacy writes during migration.
     pub fn mark_pending_message_index_migration_complete(&self, sequence: u64) -> DbResult<()> {
         self.store_value_by_key(PENDING_MESSAGE_INDEX_MIGRATION_COMPLETE, &false, &sequence)
+    }
+
+    /// Shared live invalidation for cached empty pending-index lookups. Raw and
+    /// typed writes through independently constructed handles also invalidate it.
+    /// A database reopen creates a fresh counter and must rebuild reader caches.
+    pub fn pending_message_index_generation(&self) -> Arc<AtomicU64> {
+        self.1
+            .watch_prefix(PENDING_MESSAGE_BY_DESTINATION.as_bytes())
     }
 
     /// Add an unprocessed message to its destination range.
@@ -689,6 +697,91 @@ mod pending_index_tests {
     use crate::db::rocks::test_utils::run_test_db;
 
     #[tokio::test]
+    #[ignore = "pending-index subscription write overhead benchmark"]
+    async fn benchmark_pending_generation_write_overhead() {
+        run_test_db(|raw_db| async move {
+            const WRITES: u32 = 10_000;
+            let value = vec![1; 256];
+            for watched in [false, true] {
+                if watched {
+                    for index in 0..74 {
+                        let domain = HyperlaneDomain::new_test_domain(&format!("writer_bench_{index}"));
+                        HyperlaneRocksDB::new(&domain, raw_db.clone()).pending_message_index_generation();
+                    }
+                }
+                for related in [false, true] {
+                    let prefix = if related { "writer_bench_0_pending_message_by_destination_v1_" } else { "unrelated_" };
+                    let started = std::time::Instant::now();
+                    for index in 0..WRITES {
+                        raw_db.store(format!("{prefix}{index}").as_bytes(), &value).unwrap();
+                    }
+                    println!("pending_index_write watched={watched} related={related} writes={WRITES} wall_seconds={:.6}", started.elapsed().as_secs_f64());
+                }
+            }
+        }).await;
+    }
+
+    #[tokio::test]
+    async fn pending_generation_covers_independent_handles_and_raw_write_forms() {
+        run_test_db(|raw_db| async move {
+            let origin = HyperlaneDomain::new_test_domain("origin");
+            let reader = HyperlaneRocksDB::new(&origin, raw_db.clone());
+            let writer = HyperlaneRocksDB::new(&origin, raw_db.clone());
+            let generation = reader.pending_message_index_generation();
+            assert!(Arc::ptr_eq(
+                &generation,
+                &writer.pending_message_index_generation()
+            ));
+            let other =
+                HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("other"), raw_db.clone());
+            other.store_message(&message(0, 10), 1).unwrap();
+            writer
+                .store_value_by_key("unrelated_", &0u32, &1u32)
+                .unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 0);
+
+            writer.store_message(&message(0, 10), 1).unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 1);
+            writer.store_message_processed(&message(0, 10)).unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 2);
+            writer.store_pending_message_index(&message(0, 10)).unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 3);
+            writer.delete_pending_message_index_by_nonce(10, 0).unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 4);
+
+            let prefix = b"origin_pending_message_by_destination_v1_";
+            let key = [prefix.as_slice(), b"raw"].concat();
+            raw_db.store_batch([(key.clone(), vec![1])]).unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 5);
+            raw_db.delete(&key).unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 6);
+
+            // A range tombstone must not hide subsequent puts from mutation
+            // tracking (the RocksDB batch iterator only handles put/delete).
+            let mut batch = raw_db.batch();
+            batch.delete_range(b"unrelated_a", b"unrelated_z");
+            batch.store(&key, &[2]);
+            batch.commit().unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 7);
+            let mut batch = writer.batch();
+            batch.delete_prefix(PENDING_MESSAGE_BY_DESTINATION).unwrap();
+            batch.commit().unwrap();
+            assert_eq!(generation.load(Ordering::Acquire), 8);
+            assert_eq!(raw_db.retrieve(&key).unwrap(), None);
+
+            // Registration after a batch was assembled still observes commit.
+            let mut batch = raw_db.batch();
+            let late_key = b"late_pending_message_by_destination_v1_raw";
+            batch.store(late_key, &[1]);
+            let late = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("late"), raw_db);
+            let late_generation = late.pending_message_index_generation();
+            batch.commit().unwrap();
+            assert_eq!(late_generation.load(Ordering::Acquire), 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn highest_message_nonce_ignores_overlapping_message_keys() {
         run_test_db(|raw_db| async move {
             let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
@@ -919,7 +1012,7 @@ mod pending_index_tests {
         options.create_if_missing(true);
         {
             let rocks = std::sync::Arc::new(rocksdb::DB::open(&options, dir.path()).unwrap());
-            let db = HyperlaneRocksDB::new(&domain, DB(rocks.clone()));
+            let db = HyperlaneRocksDB::new(&domain, DB(rocks.clone(), Default::default()));
             db.mark_pending_message_index_migration_complete(db.latest_sequence_number())
                 .unwrap();
             db.store_message(&message(0, 10), 1).unwrap();

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -1,14 +1,16 @@
 use std::{
+    collections::HashMap,
     fs,
     io::ErrorKind,
     path::Path,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
 };
 
 use super::error::DbError;
+use parking_lot::RwLock;
 use rocksdb::{Direction, IteratorMode, Options, WriteBatch, WriteBatchIterator, DB as Rocks};
 use tracing::info;
 
@@ -83,12 +85,50 @@ fn remove_archived_wal_files(db_path: &Path) -> Result<()> {
 
 #[derive(Debug, Clone)]
 /// A KV Store
-pub struct DB(Arc<Rocks>);
+pub struct DB(Arc<Rocks>, Arc<RwLock<PrefixGenerations>>);
+
+// Stored on the shared DB so independent TypedDB/domain handles invalidate the
+// same pending-index empty-result cache. No state survives a database reopen.
+type PrefixGenerations = HashMap<Vec<u8>, Arc<AtomicU64>>;
+
+struct BatchKeys(Vec<Vec<u8>>);
+impl WriteBatchIterator for BatchKeys {
+    fn put(&mut self, key: &[u8], _value: &[u8]) {
+        self.0.push(key.to_vec());
+    }
+    fn delete(&mut self, key: &[u8]) {
+        self.0.push(key.to_vec());
+    }
+}
+
+struct ChangedPrefixes<'a> {
+    generations: &'a PrefixGenerations,
+    changed: Vec<Arc<AtomicU64>>,
+}
+impl ChangedPrefixes<'_> {
+    fn record(&mut self, key: &[u8]) {
+        for (prefix, generation) in self.generations {
+            if key.starts_with(prefix) && !self.changed.iter().any(|g| Arc::ptr_eq(g, generation)) {
+                self.changed.push(generation.clone());
+            }
+        }
+    }
+}
+impl WriteBatchIterator for ChangedPrefixes<'_> {
+    fn put(&mut self, key: &[u8], _value: &[u8]) {
+        self.record(key);
+    }
+    fn delete(&mut self, key: &[u8]) {
+        self.record(key);
+    }
+}
 
 /// A set of writes committed atomically to RocksDB.
 pub struct DbBatch {
     db: DB,
     writes: WriteBatch,
+    deleted_ranges: Vec<(Vec<u8>, Vec<u8>)>,
+    changed_keys: Vec<Vec<u8>>,
 }
 
 struct PrefixWriteDetector<'a> {
@@ -153,7 +193,7 @@ impl WriteBatchIterator for PendingIndexWriteDetector<'_> {
 
 impl From<Rocks> for DB {
     fn from(rocks: Rocks) -> Self {
-        Self(Arc::new(rocks))
+        Self(Arc::new(rocks), Default::default())
     }
 }
 
@@ -243,7 +283,14 @@ impl DB {
 
     /// Store a value in the DB
     pub fn store(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        Ok(self.0.put(key, value)?)
+        let generations = self.1.read();
+        self.0.put(key, value)?;
+        for (prefix, generation) in generations.iter() {
+            if key.starts_with(prefix) {
+                generation.fetch_add(1, Ordering::Release);
+            }
+        }
+        Ok(())
     }
 
     /// Atomically store multiple key-value pairs in the DB.
@@ -252,7 +299,7 @@ impl DB {
         for (key, value) in entries {
             batch.put(key, value);
         }
-        Ok(self.0.write(batch)?)
+        self.commit_batch(batch, &[], &[])
     }
 
     /// Atomically store and delete multiple keys.
@@ -268,7 +315,7 @@ impl DB {
         for key in deletions {
             batch.delete(key);
         }
-        Ok(self.0.write(batch)?)
+        self.commit_batch(batch, &[], &[])
     }
 
     pub(crate) fn retrieve_at_or_after(&self, key: &[u8]) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
@@ -325,7 +372,14 @@ impl DB {
 
     /// Delete a value from the DB
     pub fn delete(&self, key: &[u8]) -> Result<()> {
-        Ok(self.0.delete(key)?)
+        let generations = self.1.read();
+        self.0.delete(key)?;
+        for (prefix, generation) in generations.iter() {
+            if key.starts_with(prefix) {
+                generation.fetch_add(1, Ordering::Release);
+            }
+        }
+        Ok(())
     }
 
     /// Retrieve all values stored under a key prefix.
@@ -456,11 +510,57 @@ impl DB {
         Ok(false)
     }
 
+    pub(crate) fn watch_prefix(&self, prefix: Vec<u8>) -> Arc<AtomicU64> {
+        self.1.write().entry(prefix).or_default().clone()
+    }
+
+    fn commit_batch(
+        &self,
+        writes: WriteBatch,
+        deleted_ranges: &[(Vec<u8>, Vec<u8>)],
+        changed_keys: &[Vec<u8>],
+    ) -> Result<()> {
+        // Registration and commit/publication are ordered, including batches
+        // assembled before a reader subscribed.
+        let generations = self.1.read();
+        if generations.is_empty() {
+            return Ok(self.0.write(writes)?);
+        }
+        let mut changes = ChangedPrefixes {
+            generations: &generations,
+            changed: Vec::new(),
+        };
+        if deleted_ranges.is_empty() {
+            writes.iterate(&mut changes);
+        } else {
+            for key in changed_keys {
+                changes.record(key);
+            }
+        }
+        for (start, end) in deleted_ranges {
+            for (prefix, generation) in generations.iter() {
+                if ((prefix.as_slice() >= start.as_slice() && prefix.as_slice() < end.as_slice())
+                    || start.starts_with(prefix))
+                    && !changes.changed.iter().any(|g| Arc::ptr_eq(g, generation))
+                {
+                    changes.changed.push(generation.clone());
+                }
+            }
+        }
+        self.0.write(writes)?;
+        for generation in changes.changed {
+            generation.fetch_add(1, Ordering::Release);
+        }
+        Ok(())
+    }
+
     /// Start an atomic write batch.
     pub fn batch(&self) -> DbBatch {
         DbBatch {
             db: self.clone(),
             writes: WriteBatch::default(),
+            deleted_ranges: Vec::new(),
+            changed_keys: Vec::new(),
         }
     }
 }
@@ -469,21 +569,36 @@ impl DbBatch {
     /// Store a raw key/value pair in this batch.
     pub fn store(&mut self, key: &[u8], value: &[u8]) {
         self.writes.put(key, value);
+        if !self.deleted_ranges.is_empty() {
+            self.changed_keys.push(key.to_vec());
+        }
     }
 
     /// Delete a raw key in this batch.
     pub fn delete(&mut self, key: &[u8]) {
         self.writes.delete(key);
+        if !self.deleted_ranges.is_empty() {
+            self.changed_keys.push(key.to_vec());
+        }
     }
 
     /// Delete a raw key range in this batch.
     pub fn delete_range(&mut self, start: &[u8], end: &[u8]) {
+        if self.deleted_ranges.is_empty() {
+            // The RocksDB iterator cannot traverse range tombstones. Copy keys
+            // only for these uncommon batches, before adding the first range.
+            let mut keys = BatchKeys(Vec::new());
+            self.writes.iterate(&mut keys);
+            self.changed_keys = keys.0;
+        }
         self.writes.delete_range(start, end);
+        self.deleted_ranges.push((start.to_vec(), end.to_vec()));
     }
 
     /// Atomically commit this batch.
     pub fn commit(self) -> Result<()> {
-        Ok(self.db.0.write(self.writes)?)
+        self.db
+            .commit_batch(self.writes, &self.deleted_ranges, &self.changed_keys)
     }
 }
 

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::AtomicBool;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64},
+    Arc,
+};
 
 use hyperlane_core::{Decode, Encode, HyperlaneDomain};
 
@@ -185,6 +188,10 @@ impl TypedDB {
             .into_iter()
             .map(|value| V::read_from_slice(&value).map_err(Into::into))
             .collect()
+    }
+
+    pub(crate) fn watch_prefix(&self, prefix: &[u8]) -> Arc<AtomicU64> {
+        self.db.watch_prefix(self.prefixed_key(prefix, &[]))
     }
 
     /// Return the latest sequence number for the underlying RocksDB.


### PR DESCRIPTION
Relayer loaders repeat RocksDB seeks after a directional pending-message query has already returned empty. Cache that result only at the same nonce and origin pending-index mutation generation. Raw shared DB generations cover independent typed handles, puts/deletes, atomic batches and range tombstones. Nonempty/low/reconsider queries and existing scheduling, notifications, capacity, migration and restart behavior remain unchanged.

The production window ending 2026-09-09 01:00 UTC recorded 78.74m loader index reads over four hours for 751 records examined. Actual fleet savings depend on repeated empty lookups between pending-index mutations; no production CPU or throughput improvement is claimed.

Validation:
- 38 loader tests, 27 storage tests and the 74×74 benchmark passed. Existing migration, low-range notification and full-channel fairness regressions remain covered.
- Four warm local scenarios—empty, sparse retained, all prefixes populated and unrelated writes—reduced repeated index seeks from 328,560 to zero over 60 polls after priming. Baseline clears this cache before each tick in the same modified debug binary; these are iterator seeks, not physical disk reads.
- Active retained-history fixture: inserting a high nonce examines one record/six DB reads in both modes; cleanup examines no retained records. Writer microbenchmark showed ~3.46 μs/write overhead in one fixed-order run, with substantial noise; canary must measure it.
- Strict production-library Clippy, formatting and commit hooks passed. All-target Clippy remains blocked by test-module lints. Astra Medium independently approved the final diff before push.

One coherent change with no durable schema or new discovery guarantee. Canary one testnet relayer, then mainnet fastpath, then standard. Require reduced actual index reads without increased writer CPU, dispatch-to-admission delay, oldest work or ingress unfairness. Compare settled matched traffic and exact image lineage. Roll back the image for any discovery or queue-age regression; preserve the existing DB.

Part of the [next-wave tracker](https://gist.github.com/paulbalaji/2e32d1700a869af7eb73a4b94b80134a).
