### PR TITLE
fix(relayer): auto-clear critical_error gauge on cursor recovery

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -77,6 +77,7 @@ mod origin;
 
 const CURSOR_BUILDING_ERROR: &str = "Error building cursor for origin";
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
+const CURSOR_INSTANTIATION_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 const MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 const ADVANCED_LOG_META: bool = false;
 
@@ -836,6 +837,43 @@ impl Relayer {
         .await
     }
 
+    /// Instantiates a cursor, retrying indefinitely until it succeeds.
+    ///
+    /// A failed instantiation (e.g. a transient origin RPC outage during cursor
+    /// (re)creation) sets the per-chain `critical_error` gauge, and a subsequent
+    /// success clears it. This keeps the gauge tracking live indexing health
+    /// instead of latching until the next process restart: once the origin RPC
+    /// is operational again the cursor instantiation succeeds and the gauge is
+    /// reset without operator intervention.
+    async fn instantiate_cursor_until_success<T: 'static>(
+        origin: &HyperlaneDomain,
+        contract_sync: Arc<dyn ContractSyncer<T>>,
+        index_settings: IndexSettings,
+        chain_metrics: &ChainMetrics,
+    ) -> Box<dyn ContractSyncCursor<T>> {
+        let mut errored = false;
+        loop {
+            match Self::instantiate_cursor_with_retries(
+                contract_sync.clone(),
+                index_settings.clone(),
+            )
+            .await
+            {
+                Ok(cursor) => {
+                    if errored {
+                        chain_metrics.set_critical_error(origin.name(), false);
+                    }
+                    return cursor;
+                }
+                Err(err) => {
+                    errored = true;
+                    Self::record_critical_error(origin, chain_metrics, &err, CURSOR_BUILDING_ERROR);
+                    tokio::time::sleep(CURSOR_INSTANTIATION_RETRY_INTERVAL).await;
+                }
+            }
+        }
+    }
+
     fn run_rpc_sync_supervisor(
         &self,
         origin: &Origin,
@@ -972,15 +1010,13 @@ impl Relayer {
         index_settings: IndexSettings,
         chain_metrics: ChainMetrics,
     ) {
-        let cursor_instantiation_result =
-            Self::instantiate_cursor_with_retries(contract_sync.clone(), index_settings).await;
-        let cursor = match cursor_instantiation_result {
-            Ok(cursor) => cursor,
-            Err(err) => {
-                Self::record_critical_error(origin, &chain_metrics, &err, CURSOR_BUILDING_ERROR);
-                return;
-            }
-        };
+        let cursor = Self::instantiate_cursor_until_success(
+            origin,
+            contract_sync.clone(),
+            index_settings,
+            &chain_metrics,
+        )
+        .await;
         let label = "dispatched_messages";
         contract_sync.clone().sync(label, cursor.into()).await;
         info!(chain = origin.name(), label, "contract sync task exit");
@@ -1032,18 +1068,13 @@ impl Relayer {
         chain_metrics: ChainMetrics,
         tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
     ) {
-        let cursor = match Self::instantiate_cursor_with_retries(
+        let cursor = Self::instantiate_cursor_until_success(
+            origin,
             contract_sync.clone(),
-            index_settings.clone(),
+            index_settings,
+            &chain_metrics,
         )
-        .await
-        {
-            Ok(cursor) => cursor,
-            Err(err) => {
-                Self::record_critical_error(origin, &chain_metrics, &err, CURSOR_BUILDING_ERROR);
-                return;
-            }
-        };
+        .await;
         let label = "gas_payments";
         contract_sync
             .clone()
@@ -1091,16 +1122,13 @@ impl Relayer {
         chain_metrics: ChainMetrics,
         tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
     ) {
-        let cursor_instantiation_result =
-            Self::instantiate_cursor_with_retries(contract_sync.clone(), index_settings.clone())
-                .await;
-        let cursor = match cursor_instantiation_result {
-            Ok(cursor) => cursor,
-            Err(err) => {
-                Self::record_critical_error(origin, &chain_metrics, &err, CURSOR_BUILDING_ERROR);
-                return;
-            }
-        };
+        let cursor = Self::instantiate_cursor_until_success(
+            origin,
+            contract_sync.clone(),
+            index_settings,
+            &chain_metrics,
+        )
+        .await;
         let label = "merkle_tree_hook";
         contract_sync
             .clone()


### PR DESCRIPTION
## Summary

The per-chain `hyperlane_critical_error` gauge (which drives the high-urgency **"agent chain lost liveness"** page) was only reset at process boot via `reset_critical_errors`. When a **transient origin RPC outage** hit during cursor (re)instantiation, the sync task recorded the error and then **exited permanently** — so the gauge **latched until the next relayer restart**, generating a self-perpetuating high-urgency page with **zero live impact** (this is exactly the paradex 503 blip from 2026-09-09 that required a manual restart to clear).

This makes the three origin cursor-sync tasks (`message`, `gas_payment`, `merkle_tree`) **retry cursor instantiation in a loop** and **clear** the gauge once the cursor is successfully re-instantiated — mirroring the pattern the `message_db_loader` init already uses (`set_critical_error(.., false)` on successful init).

Because a successful cursor instantiation requires the origin RPC to actually serve requests, recovery now tracks live indexing health: **the gauge clears automatically once the RPC is operational again**, no operator restart needed.

## Changes

- New `instantiate_cursor_until_success` helper: retries `instantiate_cursor_with_retries` in an outer loop, records `critical_error` on each failure, and clears it on the first success (only if it had previously errored, to avoid touching the gauge on the happy path).
- Wired `message_sync_task`, `interchain_gas_payments_sync_task`, and `merkle_tree_hook_sync_task` to use it instead of recording the error and returning.
- Added `CURSOR_INSTANTIATION_RETRY_INTERVAL` (30s) between outer retries (each iteration already does 10 inner retries via `CURSOR_INSTANTIATION_ATTEMPTS`).

## Open design question — the "message queue == 0" recovery condition

Troy asked that the gauge recover only when **(a) the origin RPC is operational again AND (b) the message queue is down to zero (everything delivered)**.

This PR implements **(a)** cleanly. I did **not** hard-gate on **(b)**, and want a decision before adding it, because:

- `critical_error` is scoped to **origin indexing** (cursor building), while the message/submit queue is a **destination-delivery** concern — coupling the two is a semantic mismatch.
- Gating clear-on-recovery on queue-drain would risk the gauge **never clearing on a high-traffic origin** whose queue is rarely empty, reintroducing a stuck page.
- The indexing backlog created by the outage flushes automatically once the cursor is re-instantiated, so "everything delivered" follows from (a) without needing an explicit gate.

If we still want an explicit "not fully recovered until backlog drains" signal, I'd suggest a **separate, generously-thresholded consumer-lag / undelivered-count alert** rather than overloading `critical_error`. Happy to add that instead.

## Test plan

- [x] `cargo clippy -p relayer -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [ ] Reviewer: confirm the queue-drain decision above
- [ ] Optional: unit/integration coverage for the retry+clear loop

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M22BKBDEKWMFE4FBWTAKQC46