### PR TITLE
fix(validator): raise WebSocket progress grace to 5min

### DIFF
--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -39,7 +39,11 @@ const REJECTED_STREAM_RETRY_DELAY: Duration = Duration::from_secs(300);
 const RETRY_JITTER_MS: u32 = 5_000;
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const PROGRESS_CHECK_INTERVAL: Duration = Duration::from_secs(30);
-const PROGRESS_GRACE_PERIOD: Duration = Duration::from_secs(75);
+// Must exceed the largest chain's scraper indexing delay (reorgPeriod * block time)
+// so the stream is not judged stale while the scraper is still confirming canonical
+// blocks. Ethereum's ~15-block, ~12s-block reorg window is ~180s; 5 minutes leaves
+// margin for replication lag and the probe interval, avoiding WebSocket/RPC flapping.
+const PROGRESS_GRACE_PERIOD: Duration = Duration::from_secs(300);
 const RPC_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 const CANONICAL_RETRY_DELAY: Duration = Duration::from_secs(1);
 const CANONICAL_FETCH_ATTEMPTS: usize = 3;


### PR DESCRIPTION
## Summary

Raises `PROGRESS_GRACE_PERIOD` in the validator merkle-tree-hook WebSocket sync from **75s to 300s (5 min)** to stop Ethereum from continuously flapping between the scraper WebSocket source and RPC fallback (introduced in #9324).

## Root cause

The cutover holds WebSocket only while the stream keeps pace with the canonical RPC merkle count; `check_stream_lag` bails back to RPC once the stream trails canonical for longer than `PROGRESS_GRACE_PERIOD`.

The scraper-proxy serves from the scraper3 read-only replica, and the scraper only indexes up to `head − reorgPeriod`. On Ethereum that confirmation window is ~15 blocks × ~12s ≈ **180s**, so after each new merkle insertion the validator's canonical RPC count stays ahead of the stream for ~180s — well past the 75s grace. Result: fallback → catch up in a lull → cut over → next insertion repeats, i.e. persistent flapping. Observed live: 2 of 4 Ethereum validator replicas oscillating (~20 source transitions/hr) while all other chains held.

It is specific to Ethereum because it has both slow blocks (~12s) and a large reorg window; higher-activity chains like base (~20s) and arbitrum (~1s) have confirmation delays comfortably under 75s and were unaffected. Signing was never at risk — canonical re-read gates every signature and RPC fallback kept checkpoint lag at 0.

## Change

- `PROGRESS_GRACE_PERIOD`: `75s → 300s`, with a comment explaining the constraint (must exceed the largest chain's `reorgPeriod × block time` plus replication/probe margin).

## Follow-ups (not in this PR)

- Consider a per-chain grace derived from `reorgPeriod × blockTime + buffer` instead of one global constant.
- Consider pointing the `live` streaming pool at the primary DB to remove replication lag.

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M22CVA6HFHF8ZGSQDHRHH7MC