### PR TITLE
chore(infra): deploy ethereum validator WebSocket grace fix

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -46,7 +46,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: '736ace8-20260909-012244',
   relayerRC: '736ace8-20260909-012244',
   relayerFastPath: '736ace8-20260909-012244',
-  validator: '856576e-20260908-194828',
+  validator: '35522bf-20260909-074256',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',
   scraper: '856576e-20260908-194828',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -46,7 +46,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: '736ace8-20260909-012244',
   relayerRC: '736ace8-20260909-012244',
   relayerFastPath: '736ace8-20260909-012244',
-  validator: '35522bf-20260909-074256',
+  validator: 'e116e17-20260909-094417',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',
   scraper: '856576e-20260908-194828',


### PR DESCRIPTION
## Summary

- Bumps the mainnet3 `validator` Docker tag to `35522bf-20260909-074256` (built from `main` @ `35522bf`).
- This image includes #9597, which raises the WebSocket merkle-tree sync `PROGRESS_GRACE_PERIOD` from 75s to 5min.
- Purpose: stop the ethereum GCP validator from flapping between the scraper WebSocket source and RPC fallback. Ethereum's confirmation window (reorgPeriod × block time ≈ 180s) exceeded the old 75s grace, causing repeated fallback to RPC.

Only the `mainnetDockerTags.validator` line changes; `validatorRC`, `validatorFastPath`, `scraper`, and the testnet tags are untouched.

## Deploy scope

Intended for the mainnet3 hyperlane ethereum validator only:

```
cd typescript/infra && pnpm tsx scripts/agents/deploy-agents.ts \
  -e mainnet3 --context hyperlane --roles validator --chains ethereum --yes
```

## Test plan

- [ ] Deploy the ethereum validator with the new tag.
- [ ] Verify `hyperlane_merkle_tree_hook_sync_source_active{origin="ethereum"}` holds `source="websocket"` with no transitions to `rpc`.
- [ ] Confirm signing lag stays at 0 during/after cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)