### PR TITLE
fix(scraper): inherit Ethereum reorg period

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
@@ -58,8 +58,6 @@ spec:
             name: {{ include "agent-common.fullname" . }}-scraper3-secret
         env:
         {{- include "agent-common.config-env-vars" (dict "config" .Values.hyperlane.scraper.config) | nindent 8 }}
-        - name: HYP_CHAINS_ETHEREUM_BLOCKS_REORGPERIOD
-          value: "1"
         resources:
           {{- toYaml .Values.hyperlane.scraper.resources | nindent 10 }}
         ports:


### PR DESCRIPTION
### Description

Remove the scraper's hardcoded Ethereum reorg-period override so it inherits the configured default of 15 blocks. Streaming events after only 1 block causes the standard Ethereum validator, which requires 15 blocks, to reject those events as not yet canonical and repeatedly reconnect or switch to RPC fallback.

We originally set this override to 1 in #8525 to increase Ethereum scraper indexing speed. Returning to the default is a temporary mitigation that trades that speed for alignment with the validator's confirmation window.

We plan to properly address this soon by reworking scraper reorg indexing into two channels: an unsafe channel publishing data before the reorg window has elapsed, and a safe channel publishing data after that window. This will let consumers choose low latency or confirmed data without one shared indexing delay. That redesign is outside this PR.

### Drive-by changes

None.

### Related issues

Original indexing-speed change: #8525.

### Backward compatibility

No configuration schema changes. After scraper redeployment, Ethereum events are published after 15 blocks instead of 1, increasing latency for scraper-backed consumers. No new Rust agent image is needed for this Helm-only change.

### Testing

- Verified Ethereum registry metadata and agent configuration both specify a 15-block reorg period.
- Verified the shared ConfigMap supplies the inherited setting.
- `git diff --check` passed.
- No Rust builds or tests run; change only removes the two-line Helm override.
