### PR TITLE
chore(infra): bump mainnet3 scraper image to e116e17

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -49,7 +49,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   validator: '856576e-20260908-194828',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',
-  scraper: '856576e-20260908-194828',
+  scraper: 'e116e17-20260909-094417',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',


### PR DESCRIPTION
Bumps the mainnet3 scraper Docker image tag to `e116e17-20260909-094417`.

Requested by @Troy.

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M22V7AZ2WWQHEGX4ABV9BNMT