### PR TITLE
fix(igp): raise OP-stack L2 ($0.10) + katana ($0.06) min-USD floors

### DIFF
--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -304,10 +304,17 @@ function getMinUsdCost(local: ChainName, remote: ChainName): number {
     solanamainnet: 0.35,
     ethereum: 0.12,
     arbitrum: 0.09,
-    optimism: 0.05,
-    base: 0.05,
+    // OP-stack L2 floors ($0.05 -> $0.10). These destinations pay an L1
+    // data-availability cost that is NOT in the L2 execution gasPrice, so only
+    // this floor covers it. That DA cost scales with L1 ETH gas (up materially
+    // vs the tokenPrices/gasPrices snapshot) and with validator-signature
+    // calldata size, which grew after the Aug-29 multisig change (#9371). At
+    // $0.05 the true cost (~$0.067 on the worst lane) exceeded the quote and
+    // these lanes ran below break-even; $0.10 restores the +50% target margin.
+    optimism: 0.1,
+    base: 0.1,
     polygon: 0.05,
-    unichain: 0.05,
+    unichain: 0.1,
     eclipsemainnet: 0.22,
   };
 

--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -275,10 +275,14 @@ function getMinUsdCost(local: ChainName, remote: ChainName): number {
   // By default, min cost is 20 cents
   let minUsdCost = 0.2;
 
-  // Reduced min for messages to/from katana
+  // Break-even floor for messages to/from katana. Katana is polygoncdk with no
+  // getL1Fee predeploy, so tollkeeper models its delivery cost from a flat DA
+  // overhead plus the ~$0.03 per-message RPC cost; the prior $0.01 floor sat
+  // below that, running both katana lanes below break-even. $0.06 clears the
+  // modeled cost (~$0.05 base->katana, ~$0.041 katana->base) with headroom.
   const katanaRoute = local === 'katana' || remote === 'katana';
   if (katanaRoute) {
-    minUsdCost = 0.01;
+    minUsdCost = 0.06;
   }
 
   // For all SVM chains, min cost is 0.50 USD to cover rent needs


### PR DESCRIPTION
## Summary

Raises two sets of IGP **min-USD-cost floors** in `getMinUsdCost` (`typescript/infra/src/config/gas-oracle.ts`) for lanes the Tollkeeper "systemic lanes below break-even" alert flagged (PagerDuty Q17524NK2P78N8):

- **OP-stack L2 floors `$0.05 → $0.10`** for `base`, `optimism`, `unichain` (`remoteMinCostOverrides`). `polygon` left at `$0.05` (not an OP-stack DA case).
- **katana floor `$0.01 → $0.06`** (`katanaRoute` branch).

## OP-stack root cause

Affected-lane quotes are pinned by the **min-USD floor**, not the gas oracle (verified on-chain: `ethereum→base` ~$0.05–0.06 at typical gas, ~14× raw L2 execution rate). OP-stack L2 destinations pay an **L1 data-availability cost absent from the L2 execution `gasPrice`**, so only this floor covers it. DA rose on two axes: higher L1 ETH gas vs the config snapshot, and larger validator-signature calldata after the **Aug-29 multisig change (#9371)**. Worst lane true cost ≈ $0.067 > $0.05 floor ⇒ below break-even; `$0.10` ≈ 1.5× restores the +50% target.

## katana root cause

katana is `polygoncdk` with no OP-stack `getL1Fee` predeploy, so Tollkeeper models its delivery cost as a flat DA overhead (~$0.02) **plus the global `$0.03` per-message RPC cost**. The prior `$0.01` floor sat below that modeled cost, so both allowlisted katana lanes ran chronically below break-even (`base→katana` −74%, `katana→base` −76%, 50+ consecutive scans). `$0.06` clears the modeled cost (~$0.05 `base→katana`, ~$0.041 `katana→base`) with headroom.

## Scope / blast radius

The katana floor keys on `local === 'katana' || remote === 'katana'`, so it reprices **every katana-involved lane**, not just `base↔katana`:

- **~140 StorageGasOracle entries across ~79 chains**: 62 `katana→X` entries on katana's oracle + 78 `X→katana` entries (one per origin chain).
- All move a uniform **~6× gasPrice** (e.g. `base→katana` `12,606,417 → 75,638,498`; `katana→base` `13,061,083 → 78,366,495`; `tokenExchangeRate` unchanged). These were all pinned at the old `$0.01` floor, so all lift to `$0.06`.

This is a >50% raise across a systemic lane set — deliberately human-reviewed, not an autonomous rate-maintenance write. Approved by @Nam Chu Hoai.

## Modeled margin (before → after)

| Lane | Modeled cost | Quote before | Margin before | Quote after (floor) | Margin after |
| --- | --- | --- | --- | --- | --- |
| base→katana | ~$0.05 | ~$0.013 | −74% | $0.06 | ~+20% |
| katana→base | ~$0.041 | ~$0.010 | −76% | $0.06 | ~+46% |
| ethereum→base (repr. OP-stack) | ~$0.067 | ~$0.05 (floor) | below | $0.10 (floor) | +50% target |

## Test plan

- [ ] Dry-run the mainnet3 IGP config check; confirm base/optimism/unichain and all katana lanes quote ≥ break-even.
- [ ] After merge, apply on-chain via the mainnet3 StorageGasOracle update and verify on-chain quotes match config and Tollkeeper margins flip ≥ 0.

## Note

This PR (same branch) was previously closed unmerged on 2026-09-09 (OP-stack-only); reopened and expanded to include the katana floor per approval in the Haggis thread.

Source Haggis thread: (Tollkeeper IGP margins incident — PagerDuty Q17524NK2P78N8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
