### PR TITLE
fix: stabilize Rust E2E image startup and completion checks

### DIFF
--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -443,17 +443,14 @@ pub fn lander_metrics_invariants_met(
         return Ok(false);
     }
 
-    // resubmissions are possible because it takes a while for the local
-    // solana validator to report a tx hash as included once broadcast
-    // but no more than 2 submissions are expected per message
-    if transaction_submissions > 2 * params.total_messages_expected {
-        log!(
-            "hyperlane_lander_transaction_submissions {} count, expected {}",
-            transaction_submissions,
-            params.total_messages_expected
-        );
-        return Ok(false);
-    }
+    // This counter includes rebroadcasts while inclusion is pending. Their count
+    // depends on node/indexer latency, not the number of delivered messages.
+    // Delivery counts and drained queues above enforce completion; retain the
+    // submission count as a diagnostic rather than a fixed retry budget.
+    log!(
+        "hyperlane_lander_transaction_submissions {} count",
+        transaction_submissions
+    );
 
     log!(
         "hyperlane_lander_mismatched_nonce {} count, expected {}",

--- a/rust/main/utils/run-locally/src/starknet/mod.rs
+++ b/rust/main/utils/run-locally/src/starknet/mod.rs
@@ -14,7 +14,10 @@ use crate::metrics::agent_balance_sum;
 use crate::program::Program;
 use crate::starknet::types::{AgentConfigOut, ValidatorConfig};
 use crate::starknet::utils::{STARKNET_ACCOUNT, STARKNET_KEY};
-use crate::utils::{as_task, concat_path, start_postgres, stop_child, AgentHandles, TaskHandle};
+use crate::utils::{
+    as_task, concat_path, prepare_docker_image, start_postgres, stop_child, AgentHandles,
+    TaskHandle,
+};
 use crate::{fetch_metric, AGENT_BIN_PATH};
 
 use self::cli::StarknetCLI;
@@ -311,6 +314,9 @@ fn run_locally() {
     let metrics_port_start = 9090u32;
     let domain_start = 23448593u32;
     let node_count = 2;
+
+    // Prepare once before launching both nodes, outside their readiness deadline.
+    prepare_docker_image(&format!("{STARKNET_DEVNET_IMAGE}:{STARKNET_DEVNET_TAG}"));
 
     let nodes = (0..node_count)
         .map(|i| {

--- a/rust/main/utils/run-locally/src/tron/mod.rs
+++ b/rust/main/utils/run-locally/src/tron/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     program::Program,
     server::{fetch_relayer_gas_payment_event_count, fetch_relayer_message_processed_count},
     utils::{
-        concat_path, get_workspace_path, make_static, start_postgres, stop_child,
-        wait_for_postgres, AgentHandles, TaskHandle,
+        concat_path, get_workspace_path, make_static, prepare_docker_image, start_postgres,
+        stop_child, wait_for_postgres, AgentHandles, TaskHandle,
     },
     wait_for_condition, AGENT_BIN_PATH, AGENT_LOGGING_DIR, RELAYER_METRICS_PORT,
     SCRAPER_METRICS_PORT,
@@ -265,6 +265,9 @@ fn run_locally() {
             .run()
             .join();
     }
+
+    // Keep image acquisition outside the node readiness deadline.
+    prepare_docker_image(TRE_IMAGE);
 
     // Start TRE docker container
     log!("Starting TRE docker container...");

--- a/rust/main/utils/run-locally/src/utils.rs
+++ b/rust/main/utils/run-locally/src/utils.rs
@@ -195,27 +195,28 @@ pub fn get_ts_infra_path() -> PathBuf {
 
 const POSTGRES_IMAGE: &str = "postgres:14";
 
-/// Start the test Postgres container after ensuring its image is available.
+/// Ensure a Docker image is available before starting readiness polling.
 ///
 /// `docker run` pulls a missing image in the foreground. If it is spawned and
 /// readiness polling starts immediately, a cold pull consumes the readiness
 /// timeout before the container exists. Pulling first keeps image acquisition
-/// separate from the bounded database startup check.
-pub fn start_postgres() -> AgentHandles {
+/// separate from the bounded startup check.
+pub fn prepare_docker_image(image: &str) {
     let image_available = Program::new("docker")
         .cmd("image")
         .cmd("inspect")
-        .cmd(POSTGRES_IMAGE)
+        .cmd(image)
         .run_to_success()
         .join();
     if !image_available {
-        log!("Pulling {}...", POSTGRES_IMAGE);
-        Program::new("docker")
-            .cmd("pull")
-            .cmd(POSTGRES_IMAGE)
-            .run()
-            .join();
+        log!("Pulling {}...", image);
+        Program::new("docker").cmd("pull").cmd(image).run().join();
     }
+}
+
+/// Start the test Postgres container after ensuring its image is available.
+pub fn start_postgres() -> AgentHandles {
+    prepare_docker_image(POSTGRES_IMAGE);
 
     Program::new("docker")
         .cmd("run")


### PR DESCRIPTION
Fixed two Rust E2E startup/completion flakes:

- Cold Docker pulls consumed Starknet's 60-second readiness deadline before either devnet started ([failed job](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34405425057/job/102647126778)). Reused Postgres image preparation for Starknet and Tron, which had the same asynchronous startup ordering. Starknet prepares the shared image once before launching both nodes; cached images are reused and pull failures propagate.
- Radix completed four message deliveries but timed out because ten transaction submissions exceeded the test's hardcoded eight-attempt cap ([failed job](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34333433004/job/102407139224)). Submission counts include legitimate rebroadcasts while inclusion is pending, so they remain diagnostic rather than gating completion.

Readiness deadlines, delivery counts, finalized transactions, drained queues, drop limits, nonce checks and the overall E2E deadline remain enforced. Production agent behavior is unchanged.

Validation: isolated harnesses compiled the actual Program/utils modules and invariant function. Cached-image, delayed-pull and failed-pull cases passed. The four-message/ten-submission regression failed before the change and passed afterward; unfinished queues, missing finalization, excess drops and nonce mismatch still failed as expected. Normal commit hooks and Rust formatting passed. Hosted validation passed at addacd7361: all seven Rust E2E jobs, Rust tests, Clippy and all 10 required checks are green.
