### PR TITLE
chore(infra): roll out Solana v1 compatible agents

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '736ace8-20260909-012244',
+  relayer: 'b83bac5-20260909-225045',
   relayerRC: '736ace8-20260909-012244',
   relayerFastPath: '736ace8-20260909-012244',
-  validator: '856576e-20260908-194828',
+  validator: 'b83bac5-20260909-225045',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',
-  scraper: 'e116e17-20260909-094417',
+  scraper: 'b83bac5-20260909-225045',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '736ace8-20260909-012244',
+  relayer: 'b83bac5-20260909-225045',
   relayerRC: '736ace8-20260909-012244',
   relayerFastPath: '736ace8-20260909-012244',
-  validator: '856576e-20260908-194828',
+  validator: 'b83bac5-20260909-225045',
   validatorRC: '856576e-20260908-194828',
   validatorFastPath: '856576e-20260908-194828',
-  scraper: '856576e-20260908-194828',
+  scraper: 'b83bac5-20260909-225045',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
   scraperProxy: 'fc544bf-20260908-174702',


### PR DESCRIPTION
Pinned regular relayers, validators, and scrapers in mainnet3/testnet4 to `b83bac5-20260909-225045`, built from main after the complete Solana Agave compatibility stack merged (#9577, #9578, #9582, #9579).

Live rollout scope: existing solanamainnet validator instances in both namespaces, solanadevnet/solanatestnet validators, and regular mainnet/testnet relayers and scrapers. Validator deployment is scoped to these three chains despite the shared default tag. Fastpath and RC tags are unchanged.

Validation: infra typecheck, formatting, and commit hooks passed. Helm dry-runs preserved existing configuration and signer setup, adding Solana v1 read support. All eight scoped workloads were deployed and verified Ready, with zero container restarts, matching image digest, and Solana maxSupportedTransactionVersion=1. Existing service accounts and signer configuration were preserved. All required PR checks passed.

Runtime evidence: both mainnet validators advanced from checkpoint 388478 to 388479; mainnet and devnet relayer/scraper indexing progressed; Solana critical-error gauges were zero. Devnet validator observed/processed checkpoint 14 and testnet checkpoint 875 matched. Solana testnet remained at finalized height 440004500 during observation, so new-block progress there is not confirmed. No v1 sending was enabled or on-chain programs upgraded.

Image build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34414179270
Verified digest: `sha256:271630a17b446c433703ffc68677c563f3ca08b77281d9f337b77136d94042ed`.
