### PR TITLE
perf(rust): upgrade scraper websocket transport

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
  "http-body 0.4.6",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.8",
  "tracing",
 ]
@@ -5830,7 +5830,7 @@ dependencies = [
  "http 0.2.12",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -6338,7 +6338,7 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "tokio-metrics",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite 0.30.0",
  "tracing",
  "tracing-error",
  "tracing-futures",
@@ -9964,7 +9964,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "tokio-test",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite 0.30.0",
  "tower 0.5.2",
  "tower-http",
  "tracing",
@@ -11517,6 +11517,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -15752,7 +15763,7 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
@@ -16771,6 +16782,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.43",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tungstenite 0.30.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17202,7 +17229,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls 0.21.12",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.63",
  "url",
  "utf-8",
@@ -17222,10 +17249,28 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.63",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.2.0",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "rustls 0.23.43",
+ "rustls-pki-types",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -17559,7 +17604,7 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "tokio-test",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite 0.30.0",
  "tower 0.5.2",
  "tracing",
  "tracing-futures",
@@ -17840,6 +17885,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -186,7 +186,7 @@ time = "0.3"
 tiny-keccak = "2.0.2"
 tokio = { version = "1.42.0", features = ["parking_lot", "tracing"] }
 tokio-metrics = { version = "0.4.0" }
-tokio-tungstenite = { version = "0.20.1", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"] }
 tokio-test = "0.4"
 toml_edit = "0.19.14"
 tonic = "0.12.3"

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -3142,7 +3142,8 @@ mod tests {
             socket
                 .send(Message::Text(
                     serde_json::json!({"type":"ready","streamCursorVersions":{"gas_payment":3}})
-                        .to_string(),
+                        .to_string()
+                        .into(),
                 ))
                 .await
                 .expect("ready");
@@ -3153,16 +3154,18 @@ mod tests {
                 request["streams"][2]["cursors"][0]["afterStreamCursor"],
                 "0"
             );
-            socket.send(Message::Text(serde_json::json!({"type":"subscribed","streams":proxy_subscription_response(&request)}).to_string())).await.expect("ack");
+            socket.send(Message::Text(serde_json::json!({"type":"subscribed","streams":proxy_subscription_response(&request)}).to_string().into())).await.expect("ack");
             released.await.expect("release events");
             socket
-                .send(Message::Text(wire_event(gas_payment_event(1)).to_string()))
+                .send(Message::Text(
+                    wire_event(gas_payment_event(1)).to_string().into(),
+                ))
                 .await
                 .expect("historical payment");
             let mut invalid = gas_payment_event(2);
             invalid.data["tx_id"] = serde_json::Value::Null;
             socket
-                .send(Message::Text(wire_event(invalid).to_string()))
+                .send(Message::Text(wire_event(invalid).to_string().into()))
                 .await
                 .expect("invalid payment");
             let _ = socket.next().await;
@@ -3230,7 +3233,8 @@ mod tests {
                             serde_json::json!({
                                 "type": "ready", "streamCursorVersions": {"gas_payment": 3},
                             })
-                            .to_string(),
+                            .to_string()
+                            .into(),
                         ))
                         .await
                         .expect("ready");
@@ -3239,7 +3243,7 @@ mod tests {
                         serde_json::from_str(request.to_text().expect("text")).expect("JSON");
                     socket.send(Message::Text(serde_json::json!({
                     "type": "subscribed", "streams": proxy_subscription_response(&request),
-                }).to_string())).await.expect("ACK");
+                }).to_string().into())).await.expect("ACK");
                     // A healthy peer's replay must not cancel global RPC recovery.
                     socket
                         .send(Message::Text(
@@ -3248,7 +3252,8 @@ mod tests {
                                 "domain": 9, "address": scraper_address(H256::from_low_u64_be(3)),
                                 "streamCursor": "0", "legacyMaxStreamCursor": "0",
                             })
-                            .to_string(),
+                            .to_string()
+                            .into(),
                         ))
                         .await
                         .expect("healthy peer caught up");
@@ -3260,7 +3265,7 @@ mod tests {
                         row.data["tx_id"] = serde_json::Value::Null;
                     }
                     socket
-                        .send(Message::Text(wire_event(row).to_string()))
+                        .send(Message::Text(wire_event(row).to_string().into()))
                         .await
                         .expect("replayed row");
                     if cycle == 3 {
@@ -3268,7 +3273,7 @@ mod tests {
                         "type": "caught_up", "eventType": GAS_PAYMENT_EVENT_TYPE,
                         "domain": 5, "address": scraper_address(H256::from_low_u64_be(3)),
                         "streamCursor": "1", "legacyMaxStreamCursor": "0",
-                    }).to_string())).await.expect("recovered origin caught up");
+                    }).to_string().into())).await.expect("recovered origin caught up");
                     }
                     let _ = socket.next().await;
                 }
@@ -5766,7 +5771,7 @@ mod tests {
             let (stream, _) = listener.accept().await.expect("accept");
             let mut socket = accept_async(stream).await.expect("websocket");
             socket
-                .send(Message::Text(r#"{"type":"ready"}"#.to_owned()))
+                .send(Message::Text(r#"{"type":"ready"}"#.to_owned().into()))
                 .await
                 .expect("ready");
             let request = socket.next().await.expect("subscription").expect("read");
@@ -5777,7 +5782,8 @@ mod tests {
                     serde_json::json!({
                         "type": "subscribed", "streams": proxy_subscription_response(&request),
                     })
-                    .to_string(),
+                    .to_string()
+                    .into(),
                 ))
                 .await
                 .expect("subscribed");
@@ -5793,7 +5799,8 @@ mod tests {
             socket
                 .send(Message::Text(
                     wire_event(event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"payload")))
-                        .to_string(),
+                        .to_string()
+                        .into(),
                 ))
                 .await
                 .expect("event");
@@ -7318,7 +7325,9 @@ mod tests {
             let mut socket = accept_async(stream).await.expect("accept websocket");
             socket
                 .send(Message::Text(
-                    r#"{"streamCursorVersions":{"gas_payment":2},"type":"ready"}"#.to_owned(),
+                    r#"{"streamCursorVersions":{"gas_payment":2},"type":"ready"}"#
+                        .to_owned()
+                        .into(),
                 ))
                 .await
                 .expect("send v1 ready");
@@ -7343,12 +7352,15 @@ mod tests {
                         "streams": proxy_subscription_response(&request),
                         "type": "subscribed",
                     })
-                    .to_string(),
+                    .to_string()
+                    .into(),
                 ))
                 .await
                 .expect("send subscribed");
             socket
-                .send(Message::Text(wire_event(gas_payment_event(1)).to_string()))
+                .send(Message::Text(
+                    wire_event(gas_payment_event(1)).to_string().into(),
+                ))
                 .await
                 .expect("send unsolicited gas event");
             finish_rx.await.expect("finish server");

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -899,10 +899,7 @@ mod tests {
     };
     use prometheus::IntGauge;
     use tempfile::TempDir;
-    use tokio::{
-        net::TcpListener,
-        time::{interval, Instant},
-    };
+    use tokio::{net::TcpListener, time::interval};
     use tokio_tungstenite::{accept_async, tungstenite::Message};
 
     use super::*;
@@ -1028,7 +1025,7 @@ mod tests {
                     .remove("allowReplay");
             }
         }
-        Message::Text(ack.to_string())
+        Message::Text(ack.to_string().into())
     }
 
     #[test]
@@ -1225,7 +1222,7 @@ mod tests {
                 .send(Message::Text(format!(
                     r#"{{"type":"event","data":{{"block_number":12,"domain":1,"leaf_index":0,"merkle_tree_hook":"{hook}","message_id":"{:#x}"}},"domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#,
                     H256::from_low_u64_be(4)
-                )))
+                ).into()))
                 .await
                 .expect("send event before acknowledgement");
         });
@@ -1633,28 +1630,28 @@ mod tests {
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"event","data":{{"block_number":12,"domain":1,"leaf_index":1,"merkle_tree_hook":"{hook}","message_id":"{first_message_id}"}},"domain":1,"eventType":"merkle_tree_insertion","sequence":"1"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send backfill event");
             continue_rx.await.expect("continue backfill");
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"event","data":{{"block_number":13,"domain":1,"leaf_index":2,"merkle_tree_hook":"{hook}","message_id":"{second_message_id}"}},"domain":1,"eventType":"merkle_tree_insertion","sequence":"2"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send final backfill event");
             caught_up_rx.await.expect("send caught-up marker");
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook}","domain":1,"eventType":"merkle_tree_insertion","sequence":"1"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send caught-up marker");
             live_rx.await.expect("send live event");
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"event","data":{{"block_number":14,"domain":1,"leaf_index":3,"merkle_tree_hook":"{hook}","message_id":"{third_message_id}"}},"domain":1,"eventType":"merkle_tree_insertion","sequence":"3"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send live event");
             pending::<()>().await;
@@ -1863,7 +1860,7 @@ mod tests {
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send caught-up message");
             pending::<()>().await;
@@ -1957,7 +1954,7 @@ mod tests {
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send caught-up message");
             rollback_rx.await.expect("roll back on-chain count");
@@ -2076,14 +2073,14 @@ mod tests {
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send caught-up message");
             advance_rx.await.expect("advance on-chain count");
             server_count.store(2, Ordering::SeqCst);
             let duplicate = Message::Text(format!(
                 r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
-            ));
+            ).into());
             let mut markers = interval(Duration::from_millis(1));
             loop {
                 markers.tick().await;
@@ -2194,7 +2191,7 @@ mod tests {
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send caught-up message");
             retreat_rx.await.expect("retreat on-chain count");
@@ -2307,7 +2304,7 @@ mod tests {
             socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
-                )))
+                ).into()))
                 .await
                 .expect("send caught-up message");
             advance_rx.await.expect("advance on-chain count");

--- a/rust/main/hyperlane-base/src/scraper_websocket/client.rs
+++ b/rust/main/hyperlane-base/src/scraper_websocket/client.rs
@@ -247,7 +247,7 @@ impl ScraperWebSocket {
     /// Send the agent's cursor subscription after receiving `Ready`.
     pub async fn subscribe(&mut self, subscription: String) -> Result<()> {
         self.socket
-            .send(Message::Text(subscription))
+            .send(Message::Text(subscription.into()))
             .await
             .context("Subscribing to scraper WebSocket")
     }
@@ -380,7 +380,7 @@ pub(super) mod tests {
     async fn heartbeat_is_serviced_without_hiding_protocol_messages() {
         let (mut client, mut server) = connection(Duration::from_secs(5)).await;
         server
-            .send(Message::Ping(vec![1, 2, 3]))
+            .send(Message::Ping(vec![1, 2, 3].into()))
             .await
             .expect("ping");
         server
@@ -396,7 +396,7 @@ pub(super) mod tests {
             .expect("pong deadline")
             .expect("pong frame")
             .expect("pong");
-        assert_eq!(pong, Message::Pong(vec![1, 2, 3]));
+        assert_eq!(pong, Message::Pong(vec![1, 2, 3].into()));
         client
             .subscribe(r#"{"type":"subscribe","streams":[]}"#.into())
             .await
@@ -417,6 +417,57 @@ pub(super) mod tests {
         ));
         server.send(Message::Close(None)).await.expect("close");
         assert!(client.recv::<serde_json::Value>().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancelled_partial_ping_preserves_fragmented_message_and_pong() {
+        use tokio::io::AsyncWriteExt;
+
+        let (mut client, mut server) = connection(Duration::from_secs(5)).await;
+        let ready = br#"{"type":"ready"}"#;
+        // A non-final text frame, followed by a ping interrupted mid-payload.
+        let mut partial = vec![0x01, 8];
+        partial.extend_from_slice(&ready[..8]);
+        partial.extend_from_slice(&[0x89, 3, b'a']);
+        server
+            .get_mut()
+            .write_all(&partial)
+            .await
+            .expect("partial frames");
+        assert!(timeout(
+            Duration::from_millis(20),
+            client.recv::<serde_json::Value>()
+        )
+        .await
+        .is_err());
+
+        let mut remaining = vec![
+            b'b',
+            b'c',
+            0x80,
+            u8::try_from(ready[8..].len()).expect("short frame"),
+        ];
+        remaining.extend_from_slice(&ready[8..]);
+        server
+            .get_mut()
+            .write_all(&remaining)
+            .await
+            .expect("remaining frames");
+        assert!(matches!(
+            timeout(Duration::from_secs(1), client.recv::<serde_json::Value>())
+                .await
+                .expect("resume deadline")
+                .expect("fragmented ready"),
+            Some(ServerMessage::Ready { .. })
+        ));
+        assert_eq!(
+            timeout(Duration::from_secs(1), server.next())
+                .await
+                .expect("pong deadline")
+                .expect("pong frame")
+                .expect("pong"),
+            Message::Pong(b"abc".to_vec().into())
+        );
     }
 
     #[tokio::test]

--- a/rust/main/hyperlane-base/src/scraper_websocket/session.rs
+++ b/rust/main/hyperlane-base/src/scraper_websocket/session.rs
@@ -228,7 +228,7 @@ mod tests {
                 .expect("subscribe");
             server.next().await.expect("request").expect("read request");
             let domain = if matching { 1 } else { 2 };
-            server.send(Message::Text(format!(r#"{{"type":"subscribed","streams":[{{"domains":[{domain}],"eventType":"merkle_tree_insertion"}}]}}"#))).await.expect("ack");
+            server.send(Message::Text(format!(r#"{{"type":"subscribed","streams":[{{"domains":[{domain}],"eventType":"merkle_tree_insertion"}}]}}"#).into())).await.expect("ack");
             let result = session
                 .next::<Value>(false, || stream::empty().boxed())
                 .await;


### PR DESCRIPTION
### Description

Upgrade the shared scraper client from `tokio-tungstenite 0.20.1` to `0.30.0`. This improves JSON receive throughput without replacing the session implementation used by relayers and validators. The code change is the dependency bump, payload constructor updates and an interrupted-frame regression test.

### Benchmarks

Same unmasked JSON envelopes over loopback, including deserialization. Apple M3 Pro, macOS 26.6.2, Rust 1.88 release build. Six measured runs per case after warm-up; candidate order shuffled and competing builds paused.

| Payload / batch | Before: messages/s | After: messages/s | Throughput change | Batch completion, before -> after |
| --- | ---: | ---: | ---: | ---: |
| 620 B / 100,000 messages | 495,620 | 548,831 | +10.7% | 201.8 -> 182.2 ms |
| 1,388 B / 100,000 messages | 415,047 | 482,124 | +16.2% | 240.9 -> 207.4 ms |
| 16,748 B / 20,000 messages | 126,097 | 169,815 | +34.7% | 158.6 -> 117.8 ms |

Fragmented-message throughput improved 6–26%. These timings include the local producer and receiver; batch completion is not per-message p99 latency. Isolated CPU and peak RSS were not measured. The new default read buffer is 128 KiB per connection, so this is not a claim of lower memory use. Each agent uses one scraper connection.

`tokio-websockets 0.12.3` was within -7% to +3% of the chosen version on parsed-message cases; its latest release also requires a newer compiler. `fastwebsockets 0.10.0` failed the interrupted-read pattern our sessions use. Neither justifies replacing the existing transport. Benchmark code and raw results are kept outside this PR.

### Compatibility and testing

Wire format, canonical checks, heartbeat handling and RPC fallback are unchanged. Existing WebPKI TLS support and the startup rustls provider are retained. No toolchain or deployment change.

- `cargo check -p hyperlane-base -p relayer -p validator --tests --locked` passed.
- 123 focused workspace tests passed: 24 shared-client/session, 78 relayer, 21 validator. Coverage includes canceled reads, fragmented ping/pong recovery, cursor gaps and RPC handoff.
- Repository formatting and commit hooks passed.
- `cargo clippy -p hyperlane-base -p relayer -p validator --locked -- -D warnings` passed. CI remains a separate gate.

Companion TS optimization and validator capacity estimate: #9614.
