### PR TITLE
perf(scraper-proxy): share encoded websocket broadcasts

### DIFF
--- a/.changeset/encoded-scraper-websockets.md
+++ b/.changeset/encoded-scraper-websockets.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/scraper-proxy': patch
+---
+
+Reduced WebSocket broadcast CPU by sharing encoded JSON across Explorer clients and live agent subscribers. Preserved text frames, per-subscriber cursor validation and gas-payment metadata, and outbound buffer limits.

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -21,7 +21,7 @@ const historyHook = '\\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 const pacedHook = '\\xffffffffffffffffffffffffffffffffffffffff';
 const gasPaymaster = '\\x1111111111111111111111111111111111111111';
 const msgId = `\\x${'01'.repeat(32)}`;
-const msgBody = 'x'.repeat(300);
+const msgBody = 'é🚀'.repeat(50);
 const rows = new Map([
   ['1', row(hookB)],
   ['2', row(hookA)],
@@ -626,6 +626,133 @@ void it('drains live events arriving while the pending buffer is sent', async (c
   assert.deepEqual(eventSequences(messages), ['0', '1', '2', '3']);
   socket.close();
   await new Promise<void>((resolve) => socket.once('close', resolve));
+});
+
+void it('checks each cursor before sharing a live agent frame', async () => {
+  const sockets = [new WebSocket(url), new WebSocket(url)];
+  const received = sockets.map((socket) => {
+    const messages: Record<string, unknown>[] = [];
+    socket.on('message', (data, isBinary) => {
+      assert.equal(isBinary, false);
+      messages.push(parseRecord(rawData(data)));
+    });
+    return messages;
+  });
+  try {
+    await Promise.all(received.map((messages) => waitFor(messages, 'ready')));
+    for (const [index, socket] of sockets.entries()) {
+      socket.send(
+        JSON.stringify({
+          type: 'subscribe',
+          streams: [
+            {
+              eventType: 'merkle_tree_insertion',
+              ...(index === 0
+                ? {}
+                : {
+                    cursors: [
+                      { address: hookA, afterSequence: '0', domain: 1 },
+                    ],
+                  }),
+            },
+          ],
+        }),
+      );
+    }
+    await Promise.all(
+      received.map((messages) => waitFor(messages, 'subscribed')),
+    );
+    await waitFor(received[1], 'caught_up');
+    rows.set('8100', row(hookA, 1));
+    notify('scraper_event', notification('8100'));
+    await Promise.all(
+      received.map((messages) =>
+        waitUntil(() => eventSequences(messages).length === 1),
+      ),
+    );
+    assert.deepEqual(eventSequences(received[0]), ['1']);
+    assert.deepEqual(eventSequences(received[1]), ['1']);
+    notify('scraper_event', notification('8100'));
+    await waitUntil(() => eventSequences(received[0]).length === 2);
+    assert.deepEqual(eventSequences(received[1]), ['1']);
+    rows.set('8101', row(hookA, 3));
+    const closed = new Promise<number>((resolve) =>
+      sockets[1].once('close', resolve),
+    );
+    notify('scraper_event', notification('8101'));
+    assert.equal(await closed, 1013);
+    await waitUntil(() => eventSequences(received[0]).length === 3);
+    assert.deepEqual(eventSequences(received[0]), ['1', '1', '3']);
+  } finally {
+    rows.delete('8100');
+    rows.delete('8101');
+    for (const socket of sockets) socket.terminate();
+    await waitUntil(() => events.metricsSnapshot().connections.agent === 0);
+  }
+});
+
+void it('keeps gas cursor boundaries specific to each subscriber', async () => {
+  gasPaymentRows.clear();
+  const payment = {
+    id: '14',
+    domain: 1,
+    interchain_gas_paymaster: gasPaymaster,
+  };
+  gasPaymentRows.set('14', payment);
+  const sockets = [new WebSocket(url), new WebSocket(url)];
+  const received = sockets.map((socket) => {
+    const messages: Record<string, unknown>[] = [];
+    socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+    return messages;
+  });
+  try {
+    await Promise.all(received.map((messages) => waitFor(messages, 'ready')));
+    for (const [index, socket] of sockets.entries()) {
+      socket.send(
+        JSON.stringify({
+          type: 'subscribe',
+          streams: [
+            {
+              eventType: 'gas_payment',
+              ...(index === 0
+                ? {}
+                : {
+                    streamCursorVersion: 3,
+                    cursors: [
+                      {
+                        address: gasPaymaster,
+                        afterStreamCursor: '14',
+                        domain: 1,
+                      },
+                    ],
+                  }),
+            },
+          ],
+        }),
+      );
+    }
+    await Promise.all(
+      received.map((messages) => waitFor(messages, 'subscribed')),
+    );
+    await waitFor(received[1], 'caught_up');
+    gasPaymentRows.set('30', {
+      ...payment,
+      id: '30',
+      scraper_stream_cursor: '15',
+    });
+    notify('scraper_event', gasPaymentNotification('30'));
+    const [legacy, cursored] = await Promise.all(
+      received.map((messages) => waitFor(messages, 'event')),
+    );
+    assert.equal(legacy.streamCursor, '15');
+    assert.equal(cursored.streamCursor, '15');
+    assert.equal(legacy.legacyMaxStreamCursor, undefined);
+    assert.equal(cursored.legacyMaxStreamCursor, '14');
+  } finally {
+    gasPaymentRows.clear();
+    for (const socket of sockets) socket.terminate();
+    await waitUntil(() => events.metricsSnapshot().connections.agent === 0);
+  }
 });
 
 void it('accepts a legacy non-cursored live gas payment subscription', async () => {
@@ -1821,6 +1948,69 @@ void it('releases a peer-closed Explorer queue immediately', async (context) => 
   for (const complete of completions.splice(0)) complete();
 });
 
+void it('broadcasts UTF-8 text with byte-accurate queue accounting', async (context) => {
+  const sockets = [new WebSocket(messagesUrl), new WebSocket(messagesUrl)];
+  const received = sockets.map((socket) => {
+    const messages: Record<string, unknown>[] = [];
+    socket.on('message', (data, isBinary) => {
+      assert.equal(isBinary, false);
+      messages.push(parseRecord(rawData(data)));
+    });
+    return messages;
+  });
+  await Promise.all(received.map((messages) => waitFor(messages, 'ready')));
+  const completions = delayServerSendCompletions(context);
+  const messageIds = ['06', '07'].map((byte) => `\\x${byte.repeat(32)}`);
+  const expected = messageIds.map((messageId) => ({
+    data: {
+      id: '42',
+      is_delivered: false,
+      msg_body: msgBody,
+      msg_id: messageId,
+      origin_domain_id: 1,
+    },
+    type: 'message_upsert',
+  }));
+  const firstText = JSON.stringify(expected[0]);
+  const firstBytes = Buffer.byteLength(firstText);
+  assert(firstBytes > firstText.length);
+
+  try {
+    for (const messageId of messageIds) {
+      notify(
+        'scraper_explorer_event',
+        JSON.stringify({ messageId: messageId.slice(2) }),
+      );
+    }
+    await waitUntil(() => completions.length === 2);
+    assert.equal(events.metricsSnapshot().outboundPendingBytes, 2 * firstBytes);
+    assert.equal(events.metricsSnapshot().explorerPendingMessages, 2);
+    assert.equal(
+      events.metricsSnapshot().explorerPendingBytes,
+      2 * Buffer.byteLength(JSON.stringify(expected[1])),
+    );
+    for (const complete of completions.splice(0)) complete();
+    await waitUntil(() => completions.length === 2);
+    for (const messages of received) {
+      await waitUntil(
+        () =>
+          messages.filter(({ type }) => type === 'message_upsert').length === 2,
+      );
+      assert.deepEqual(
+        messages.filter(({ type }) => type === 'message_upsert'),
+        expected,
+      );
+    }
+    for (const complete of completions.splice(0)) complete();
+    assert.equal(events.metricsSnapshot().outboundPendingBytes, 0);
+    assert.equal(events.metricsSnapshot().explorerPendingBytes, 0);
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    for (const socket of sockets) socket.terminate();
+    await waitUntil(() => events.metricsSnapshot().connections.messages === 0);
+  }
+});
+
 void it('reports an active send failure once', async (context) => {
   const socket = new WebSocket(messagesUrl);
   const messages: Record<string, unknown>[] = [];
@@ -2049,7 +2239,10 @@ function delayServerSendCompletions(
     ): void {
       const completion =
         typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
-      const message = typeof data === 'string' ? parseRecord(data) : undefined;
+      const message =
+        typeof data === 'string' || Buffer.isBuffer(data)
+          ? parseRecord(data.toString())
+          : undefined;
       const delay =
         completion &&
         (message?.type === 'event' ||
@@ -2088,7 +2281,10 @@ function delayFirstExplorerSocket(context: TestContext): Array<() => void> {
     ): void {
       const completion =
         typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
-      const message = typeof data === 'string' ? parseRecord(data) : undefined;
+      const message =
+        typeof data === 'string' || Buffer.isBuffer(data)
+          ? parseRecord(data.toString())
+          : undefined;
       if (
         !selectedDelayedSocket &&
         completion &&

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -114,7 +114,7 @@ type Limits = {
   maxExplorerClients: number;
   maxTotalBufferedBytes: number;
 };
-type SerializedMessage = { bytes: number; text: string };
+type SerializedMessage = Buffer;
 export type EventDatabase = Pick<DbService, 'listen' | 'queryLive'>;
 
 function stream(
@@ -813,11 +813,24 @@ export class EventWebSocketServer {
   private publish(eventType: EventType, row: Row): void {
     const domain = rowDomain(row, STREAMS[eventType].domain);
     const key = rowCursorKey(eventType, domain, row);
+    let serialized: SerializedMessage | undefined;
     for (const [socket, client] of this.clients) {
       const subscription = client.subscriptions.get(eventType);
       if (!subscription || !matches(subscription, domain, key)) continue;
       if (!subscription.catchingUp) {
-        this.deliver(socket, eventType, subscription, row);
+        const message = this.eventForDelivery(
+          socket,
+          eventType,
+          subscription,
+          row,
+        );
+        if (!message) continue;
+        // Gas payment envelopes include each subscriber's legacy cursor boundary.
+        const payload =
+          eventType === 'gas_payment'
+            ? serialize(message)
+            : (serialized ??= serialize(message));
+        this.sendSerialized(socket, payload);
       } else if (
         !subscription.waiting &&
         subscription.pending.push(row) > MAX_PENDING_EVENTS
@@ -826,17 +839,6 @@ export class EventWebSocketServer {
         socket.close(1013, 'Event catch-up buffer exceeded');
       }
     }
-  }
-
-  private deliver(
-    socket: WebSocket,
-    eventType: EventType,
-    subscription: Subscription,
-    row: Row,
-  ): boolean {
-    const message = this.eventForDelivery(socket, eventType, subscription, row);
-    if (message === false) return false;
-    return message === undefined || this.send(socket, message);
   }
 
   private async deliverAndWait(
@@ -1237,7 +1239,10 @@ export class EventWebSocketServer {
     client: ExplorerClient,
     messages: SerializedMessage[],
   ): void {
-    const bytes = messages.reduce((total, message) => total + message.bytes, 0);
+    const bytes = messages.reduce(
+      (total, message) => total + message.length,
+      0,
+    );
     if (
       client.queue.length + messages.length > MAX_EXPLORER_PENDING_MESSAGES ||
       client.queuedBytes + bytes > MAX_EXPLORER_PENDING_BYTES
@@ -1260,7 +1265,7 @@ export class EventWebSocketServer {
       while (this.explorerClients.get(socket) === client) {
         const message = client.queue.shift();
         if (!message) return;
-        client.queuedBytes = Math.max(0, client.queuedBytes - message.bytes);
+        client.queuedBytes = Math.max(0, client.queuedBytes - message.length);
         if (!(await this.sendSerializedAndWait(socket, message))) return;
       }
     } finally {
@@ -1383,22 +1388,22 @@ export class EventWebSocketServer {
     )
       return false;
     if (
-      socket.bufferedAmount + message.bytes > this.limits.maxBufferedBytes ||
-      this.pendingBytes + message.bytes > this.limits.maxTotalBufferedBytes
+      socket.bufferedAmount + message.length > this.limits.maxBufferedBytes ||
+      this.pendingBytes + message.length > this.limits.maxTotalBufferedBytes
     ) {
       websocketSendFailures.inc({ reason: 'buffer_limit' });
       this.failSocket(socket, 'outbound buffer limit exceeded');
       return false;
     }
-    this.pendingBytes += message.bytes;
+    this.pendingBytes += message.length;
     try {
-      socket.send(message.text, (error) => {
-        this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
+      socket.send(message, { binary: false }, (error) => {
+        this.pendingBytes = Math.max(0, this.pendingBytes - message.length);
         completed?.(!error);
         if (error) this.failSend(socket, error.message);
       });
     } catch (error) {
-      this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
+      this.pendingBytes = Math.max(0, this.pendingBytes - message.length);
       completed?.(false);
       this.failSend(socket, formatError(error));
       return false;
@@ -1455,8 +1460,8 @@ export class EventWebSocketServer {
 }
 
 function serialize(message: Record<string, unknown>): SerializedMessage {
-  const text = JSON.stringify(message);
-  return { bytes: Buffer.byteLength(text), text };
+  // Explorer broadcasts share this payload; encode UTF-8 once for every recipient.
+  return Buffer.from(JSON.stringify(message));
 }
 
 function subscriptionResponse(request: StreamRequest): Record<string, unknown> {


### PR DESCRIPTION
### Description

Encode shared WebSocket broadcasts once instead of repeating JSON serialization and UTF-8 encoding for every recipient. Keep `ws`; send the shared Buffer explicitly as a text frame.

Live non-gas events share serialization after each subscriber's cursor checks. Gas-payment envelopes stay per subscriber because their legacy cursor boundaries can differ. Send callbacks, queue limits, heartbeat handling and RPC fallback semantics are preserved.

### Benchmarks

Before -> after, medians of three runs. Apple M3 Pro, macOS 26.6.2, Node 24.13.0, locked `ws 8.21.3`. Separate server/client processes; every text frame received and checked in order. Competing builds were paused.

| Workload | Server CPU ms | Sampled RSS MiB | Received frames/s | Batch completion ms |
| --- | ---: | ---: | ---: | ---: |
| Agent: 5 recipients, 5,000 events | 252.7 -> 224.8 (-11%) | 209.3 -> 206.5 | 91,484 -> 100,955 | 273.3 -> 247.6 |
| Agent: 10 recipients, 5,000 events | 394.6 -> 331.6 (-16%) | 267.8 -> 230.3 | 124,788 -> 146,841 | 400.7 -> 340.5 |
| Agent: 16 recipients, 5,000 events | 642.2 -> 538.3 (-16%) | 324.8 -> 317.5 | 142,934 -> 172,538 | 559.7 -> 463.7 |
| Explorer transport: 100 recipients | 984.6 -> 338.7 (-66%) | 83.3 -> 78.9 | 104,658 -> 127,133 | 955.5 -> 786.6 |
| Explorer transport: 1,000 recipients | 958.1 -> 741.3 (-23%) | 105.0 -> 116.4 | 215,915 -> 287,798 | 926.3 -> 694.9 |

The agent cases run the actual `EventWebSocketServer`, including cursor handling and the 100 ms batching delay, with an in-memory DB and output limits raised to 16/128 MiB. They measure CPU cost with buffer headroom, not production burst/replay capacity. Explorer cases model shared payloads: 100 recipients receive 1,000 ~8 KiB events; 1,000 recipients receive 200 ~1 KiB events.

Memory is sampled at batch completion, not peak RSS. It increases in the 1,000-socket case. Batch completion is not per-message p99 latency, and none of these figures are deployed savings.

`uWebSockets.js 20.70.0` was faster in synthetic sends, but fails to load in our Node 26 Alpine runtime on both amd64 and arm64 and needs different listener/backpressure integration. `bufferutil 4.1.0` did not provide a compelling benefit for predominantly unmasked server frames. The measured improvement does not require either dependency. Benchmark code and raw results are kept outside this PR.

### Validator growth

Sizing snapshot: 2026-09-10 12:20 UTC. The live proxy had 143 WS validators and two relayers; the default multisig constants add 201 third-party validator-chain instances on currently scraped chains:

| | Current | With modeled third-party adoption |
| --- | ---: | ---: |
| Agent connections | 145 | 346 (+139%) |
| Validator event deliveries/day | ~25,500 | ~74,444 (+192%) |

The default configs contain 296 validator-chain memberships across 93 entries: 280 on 77 mainnets, 15 on testnets, and one AW-only entry without registry metadata. Of 204 mainnet third-party memberships, 201 are on enabled scraper chains; Nesa (one) and Radix (two) need scraper coverage first. Count each validator-chain instance as a connection.

Projected deliveries use each chain's trailing-24h indexed insertion count multiplied by its current/additional validators. This counter includes possible reprocessing; it estimates event fan-out, not measured future CPU or bandwidth. Existing deployed AW copies are retained, and custom ISM sets/redundant third-party instances are outside this cohort.

| Chain | Current WS validators | Added validators | Indexed insertions/day | Added deliveries/day |
| --- | ---: | ---: | ---: | ---: |
| Optimism | 2 | 5 | 2,106 | 10,532 |
| Base | 2 | 4 | 2,145 | 8,582 |
| Ethereum | 2 | 9 | 816 | 7,341 |
| Arbitrum | 2 | 4 | 1,709 | 6,837 |
| Unichain | 2 | 4 | 1,502 | 6,008 |

The live proxy averaged 0.0093 CPU cores over one hour, with 138 MiB RSS and no buffer/queue overflows in 24h. That snapshot supports the smaller implementation. The current 200-agent limit is still insufficient for 346 connections; reachable external access, admission and simultaneous catch-up need a separate capacity rollout. Current catch-up concurrency is two. This PR does not expose the private endpoint or activate third-party clients.

### Testing

- 102 scraper-proxy tests passed, including Unicode/text-frame accounting, per-client duplicate/gap checks and gas legacy-boundary isolation.
- TypeScript build, lint, NCC bundle/schema copy/post-bundle patch and commit hooks passed.
- Independent implementation review and benchmark/capacity arithmetic checks passed.

No runtime dependency, lockfile, listener or deployment change. Companion Rust upgrade: #9613.
