### PR TITLE
test(cli): allow cross-chain core setup its full timeout budget

### DIFF
--- a/typescript/cli/src/tests/cross-chain/warp/warp-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/cross-chain/warp/warp-apply.e2e-test.ts
@@ -29,6 +29,7 @@ import {
   CORE_ADDRESSES_PATH_BY_PROTOCOL,
   CORE_READ_CONFIG_PATH_BY_PROTOCOL,
   CROSS_CHAIN_CORE_CONFIG_PATH_BY_PROTOCOL,
+  CROSS_CHAIN_E2E_TEST_TIMEOUT,
   DEFAULT_E2E_TEST_TIMEOUT,
   HYP_KEY_BY_PROTOCOL,
   REGISTRY_PATH,
@@ -111,6 +112,9 @@ describe('hyperlane warp apply e2e tests', async function () {
   let evmNodeInstance: StartedTestContainer;
 
   before(async function () {
+    // Container startup and both core deployments share this hook's budget.
+    this.timeout(CROSS_CHAIN_E2E_TEST_TIMEOUT);
+
     [cosmosNodeInstance, evmNodeInstance] = await Promise.all([
       runCosmosNode(TEST_CHAIN_METADATA_BY_PROTOCOL.cosmosnative.CHAIN_NAME_1),
       runEvmNode(TEST_CHAIN_METADATA_BY_PROTOCOL.ethereum.CHAIN_NAME_2),

--- a/typescript/cli/src/tests/cross-chain/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/cross-chain/warp/warp-deploy.e2e-test.ts
@@ -30,6 +30,7 @@ import {
   CORE_ADDRESSES_PATH_BY_PROTOCOL,
   CORE_READ_CONFIG_PATH_BY_PROTOCOL,
   CROSS_CHAIN_CORE_CONFIG_PATH_BY_PROTOCOL,
+  CROSS_CHAIN_E2E_TEST_TIMEOUT,
   DEFAULT_E2E_TEST_TIMEOUT,
   HYP_KEY_BY_PROTOCOL,
   REGISTRY_PATH,
@@ -94,6 +95,9 @@ describe('hyperlane warp deploy e2e tests', async function () {
   let evmNodeInstance: StartedTestContainer;
 
   before(async function () {
+    // Container startup and both core deployments share this hook's budget.
+    this.timeout(CROSS_CHAIN_E2E_TEST_TIMEOUT);
+
     [cosmosNodeInstance, evmNodeInstance] = await Promise.all([
       runCosmosNode(TEST_CHAIN_METADATA_BY_PROTOCOL.cosmosnative.CHAIN_NAME_1),
       runEvmNode(TEST_CHAIN_METADATA_BY_PROTOCOL.ethereum.CHAIN_NAME_2),


### PR DESCRIPTION
The cross-chain `warp-deploy` setup hook exhausted its inherited 200-second timeout while core deployment was still progressing in [this CI job](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34492374156/job/102922356866?pr=9317). Setup began at 15:00:23; core deployment began at 15:01:59 after roughly 96 seconds of setup. EVM confirmations then advanced at roughly four-second intervals until Mocha timed out at 15:03:43. Teardown stopped Anvil, producing the subsequent connection-refused errors while the outstanding CLI command waited another five minutes.

Give the `warp-deploy` and `warp-apply` setup hooks the existing 300-second cross-chain timeout. Both start Cosmos and EVM containers and deploy both cores in a single hook. Individual tests retain their 200-second timeout. This adds setup headroom for cold CI starts; it does not cancel outstanding CLI processes on a future timeout or change provider polling.

Validation: focused lint, formatting, diff checks, and normal commit hooks passed. Local `CLI_E2E_TEST=warp-deploy pnpm -C typescript/cli test:cross-chain:e2e` could not load the unbuilt Radix SDK testing export in the fresh worktree. Hosted cross-chain `warp-deploy` and `warp-apply` E2E results remain pending; this draft is not a claim of repeated-run flake elimination.

Tests only; no published runtime change.
