### PR TITLE
perf(sdk): adapt ethers polling to local RPCs and block time

### DIFF
--- a/.changeset/quick-loopback-confirmations.md
+++ b/.changeset/quick-loopback-confirmations.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Adjusted ethers v5 polling to the chain's estimated block time, bounded to 1–4 seconds, reducing confirmation detection latency on fast chains while bounding RPC traffic. Providers using only loopback RPC URLs used 100ms polling for local deployments and CLI E2E tests. Chains without a block-time estimate retained the four-second default.
+Adjusted ethers v5 polling to the chain's estimated block time, capped at four seconds, reducing confirmation detection latency on fast chains including those with sub-second blocks. Providers using only loopback RPC URLs used 100ms polling for local deployments and CLI E2E tests. Chains without a block-time estimate retained the four-second default.

--- a/.changeset/quick-loopback-confirmations.md
+++ b/.changeset/quick-loopback-confirmations.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Adjusted ethers v5 polling to the chain's estimated block time, bounded to 1–4 seconds, reducing confirmation detection latency on fast chains while bounding RPC traffic. Providers using only loopback RPC URLs used 100ms polling for local deployments and CLI E2E tests. Chains without a block-time estimate retained the four-second default.

--- a/typescript/sdk/src/providers/builders/ethersV5.test.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.test.ts
@@ -65,6 +65,9 @@ describe('ethers v5 provider builder polling', () => {
   for (const urls of [
     ['http://localhost:8545'],
     ['http://127.0.0.1:8596'],
+    ['http://127.0.0.2:8545'],
+    ['http://127.0.0.0:8545'],
+    ['http://127.255.255.255:8545'],
     ['http://[::1]:8545'],
     ['http://localhost:8545', 'http://127.0.0.1:8596'],
   ]) {
@@ -85,6 +88,10 @@ describe('ethers v5 provider builder polling', () => {
     ['https://rpc.example.com'],
     ['http://localhost:8545', 'https://rpc.example.com'],
     ['https://localhost.example.com'],
+    ['http://127.0.0.2.example.com:8545'],
+    ['http://126.255.255.255:8545'],
+    ['http://128.0.0.0:8545'],
+    ['http://127.0.0.2:8545', 'https://rpc.example.com'],
     ['http://192.168.1.1:8545'],
   ]) {
     it(`preserves default polling with remote RPCs: ${urls.join(', ')}`, () => {

--- a/typescript/sdk/src/providers/builders/ethersV5.test.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.test.ts
@@ -30,7 +30,10 @@ function pollingInterval(provider: providers.Provider): number {
 
 describe('ethers v5 provider builder polling', () => {
   for (const [blockTime, expectedInterval] of [
-    [0.25, 1000],
+    [0.0001, 1],
+    [0.1, 100],
+    [0.25, 250],
+    [0.45, 450],
     [2, 2000],
     [13, 4000],
     [0, 4000],
@@ -50,7 +53,7 @@ describe('ethers v5 provider builder polling', () => {
       'https://rpc.example.com',
     ]);
     config.blocks = { confirmations: 1, estimateBlockTime: 0.25 };
-    expect(pollingInterval(defaultProviderBuilder(config))).to.equal(1000);
+    expect(pollingInterval(defaultProviderBuilder(config))).to.equal(250);
   });
 
   it('prioritizes loopback polling over the block-time estimate', () => {

--- a/typescript/sdk/src/providers/builders/ethersV5.test.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
+import { providers } from 'ethers';
 
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { assert, ProtocolType } from '@hyperlane-xyz/utils';
 
 import type { ChainMetadata } from '../../metadata/chainMetadataTypes.js';
 
@@ -19,6 +20,14 @@ function metadata(urls: string[]): ChainMetadata {
   };
 }
 
+function pollingInterval(provider: providers.Provider): number {
+  assert(
+    provider instanceof providers.BaseProvider,
+    'Expected ethers BaseProvider',
+  );
+  return provider.pollingInterval;
+}
+
 describe('ethers v5 provider builder polling', () => {
   for (const [blockTime, expectedInterval] of [
     [0.25, 1000],
@@ -29,7 +38,7 @@ describe('ethers v5 provider builder polling', () => {
     it(`bounds remote polling for a ${blockTime}s block time`, () => {
       const config = metadata(['https://rpc.example.com']);
       config.blocks = { confirmations: 1, estimateBlockTime: blockTime };
-      expect(defaultProviderBuilder(config).pollingInterval).to.equal(
+      expect(pollingInterval(defaultProviderBuilder(config))).to.equal(
         expectedInterval,
       );
     });
@@ -41,13 +50,13 @@ describe('ethers v5 provider builder polling', () => {
       'https://rpc.example.com',
     ]);
     config.blocks = { confirmations: 1, estimateBlockTime: 0.25 };
-    expect(defaultProviderBuilder(config).pollingInterval).to.equal(1000);
+    expect(pollingInterval(defaultProviderBuilder(config))).to.equal(1000);
   });
 
   it('prioritizes loopback polling over the block-time estimate', () => {
     const config = metadata(['http://localhost:8545']);
     config.blocks = { confirmations: 1, estimateBlockTime: 13 };
-    expect(defaultProviderBuilder(config).pollingInterval).to.equal(100);
+    expect(pollingInterval(defaultProviderBuilder(config))).to.equal(100);
   });
 
   for (const urls of [
@@ -59,9 +68,11 @@ describe('ethers v5 provider builder polling', () => {
     it(`polls loopback RPCs quickly: ${urls.join(', ')}`, () => {
       // MultiProtocolProvider and MultiProvider use these respective builders.
       expect(
-        defaultEthersV5ProviderBuilder(metadata(urls)).provider.pollingInterval,
+        pollingInterval(
+          defaultEthersV5ProviderBuilder(metadata(urls)).provider,
+        ),
       ).to.equal(100);
-      expect(defaultProviderBuilder(metadata(urls)).pollingInterval).to.equal(
+      expect(pollingInterval(defaultProviderBuilder(metadata(urls)))).to.equal(
         100,
       );
     });
@@ -75,7 +86,9 @@ describe('ethers v5 provider builder polling', () => {
   ]) {
     it(`preserves default polling with remote RPCs: ${urls.join(', ')}`, () => {
       expect(
-        defaultEthersV5ProviderBuilder(metadata(urls)).provider.pollingInterval,
+        pollingInterval(
+          defaultEthersV5ProviderBuilder(metadata(urls)).provider,
+        ),
       ).to.equal(4000);
     });
   }

--- a/typescript/sdk/src/providers/builders/ethersV5.test.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import type { ChainMetadata } from '../../metadata/chainMetadataTypes.js';
+
+import {
+  defaultEthersV5ProviderBuilder,
+  defaultProviderBuilder,
+} from './ethersV5.js';
+
+function metadata(urls: string[]): ChainMetadata {
+  return {
+    name: 'local',
+    chainId: 31337,
+    domainId: 31337,
+    protocol: ProtocolType.Ethereum,
+    rpcUrls: urls.map((http) => ({ http })),
+  };
+}
+
+describe('ethers v5 provider builder polling', () => {
+  for (const [blockTime, expectedInterval] of [
+    [0.25, 1000],
+    [2, 2000],
+    [13, 4000],
+    [0, 4000],
+  ]) {
+    it(`bounds remote polling for a ${blockTime}s block time`, () => {
+      const config = metadata(['https://rpc.example.com']);
+      config.blocks = { confirmations: 1, estimateBlockTime: blockTime };
+      expect(defaultProviderBuilder(config).pollingInterval).to.equal(
+        expectedInterval,
+      );
+    });
+  }
+
+  it('uses remote bounds for mixed RPCs with a block-time estimate', () => {
+    const config = metadata([
+      'http://localhost:8545',
+      'https://rpc.example.com',
+    ]);
+    config.blocks = { confirmations: 1, estimateBlockTime: 0.25 };
+    expect(defaultProviderBuilder(config).pollingInterval).to.equal(1000);
+  });
+
+  it('prioritizes loopback polling over the block-time estimate', () => {
+    const config = metadata(['http://localhost:8545']);
+    config.blocks = { confirmations: 1, estimateBlockTime: 13 };
+    expect(defaultProviderBuilder(config).pollingInterval).to.equal(100);
+  });
+
+  for (const urls of [
+    ['http://localhost:8545'],
+    ['http://127.0.0.1:8596'],
+    ['http://[::1]:8545'],
+    ['http://localhost:8545', 'http://127.0.0.1:8596'],
+  ]) {
+    it(`polls loopback RPCs quickly: ${urls.join(', ')}`, () => {
+      // MultiProtocolProvider and MultiProvider use these respective builders.
+      expect(
+        defaultEthersV5ProviderBuilder(metadata(urls)).provider.pollingInterval,
+      ).to.equal(100);
+      expect(defaultProviderBuilder(metadata(urls)).pollingInterval).to.equal(
+        100,
+      );
+    });
+  }
+
+  for (const urls of [
+    ['https://rpc.example.com'],
+    ['http://localhost:8545', 'https://rpc.example.com'],
+    ['https://localhost.example.com'],
+    ['http://192.168.1.1:8545'],
+  ]) {
+    it(`preserves default polling with remote RPCs: ${urls.join(', ')}`, () => {
+      expect(
+        defaultEthersV5ProviderBuilder(metadata(urls)).provider.pollingInterval,
+      ).to.equal(4000);
+    });
+  }
+});

--- a/typescript/sdk/src/providers/builders/ethersV5.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.ts
@@ -16,7 +16,8 @@ const DEFAULT_RETRY_OPTIONS: SmartProviderOptions = {
 
 const LOCAL_POLLING_INTERVAL_MS = 100;
 const DEFAULT_POLLING_INTERVAL_MS = 4000;
-const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+const LOOPBACK_HOSTS = new Set(['localhost', '[::1]']);
+const IPV4_LOOPBACK_HOST = /^127(?:\.\d{1,3}){3}$/;
 
 export const defaultEthersV5ProviderBuilder: ProviderBuilderFn<
   EthersV5Provider
@@ -31,9 +32,11 @@ export const defaultEthersV5ProviderBuilder: ProviderBuilderFn<
   // subprocesses also avoid ethers' default four-second confirmation polling.
   if (
     metadata.rpcUrls.length > 0 &&
-    metadata.rpcUrls.every(({ http }) =>
-      LOOPBACK_HOSTS.has(new URL(http).hostname),
-    )
+    metadata.rpcUrls.every(({ http }) => {
+      // URL normalizes and validates IPv4 addresses before this check.
+      const { hostname } = new URL(http);
+      return LOOPBACK_HOSTS.has(hostname) || IPV4_LOOPBACK_HOST.test(hostname);
+    })
   ) {
     provider.pollingInterval = LOCAL_POLLING_INTERVAL_MS;
   } else if (metadata.blocks?.estimateBlockTime) {

--- a/typescript/sdk/src/providers/builders/ethersV5.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.ts
@@ -14,6 +14,11 @@ const DEFAULT_RETRY_OPTIONS: SmartProviderOptions = {
   baseRetryDelayMs: 250,
 };
 
+const LOCAL_POLLING_INTERVAL_MS = 100;
+const MIN_REMOTE_POLLING_INTERVAL_MS = 1000;
+const DEFAULT_POLLING_INTERVAL_MS = 4000;
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
 export const defaultEthersV5ProviderBuilder: ProviderBuilderFn<
   EthersV5Provider
 > = (metadata: ChainMetadata, retryOverride?: SmartProviderOptions) => {
@@ -23,6 +28,26 @@ export const defaultEthersV5ProviderBuilder: ProviderBuilderFn<
     undefined,
     retryOverride || DEFAULT_RETRY_OPTIONS,
   );
+  // Local dev chains mine immediately. Configure the shared builder so CLI
+  // subprocesses also avoid ethers' default four-second confirmation polling.
+  if (
+    metadata.rpcUrls.length > 0 &&
+    metadata.rpcUrls.every(({ http }) =>
+      LOOPBACK_HOSTS.has(new URL(http).hostname),
+    )
+  ) {
+    provider.pollingInterval = LOCAL_POLLING_INTERVAL_MS;
+  } else if (metadata.blocks?.estimateBlockTime) {
+    // Poll roughly once per block on fast chains, with a floor to bound RPC
+    // traffic and a ceiling that preserves ethers' latency on slower chains.
+    provider.pollingInterval = Math.min(
+      DEFAULT_POLLING_INTERVAL_MS,
+      Math.max(
+        MIN_REMOTE_POLLING_INTERVAL_MS,
+        Math.round(metadata.blocks.estimateBlockTime * 1000),
+      ),
+    );
+  }
   return { type: ProviderType.EthersV5, provider };
 };
 

--- a/typescript/sdk/src/providers/builders/ethersV5.ts
+++ b/typescript/sdk/src/providers/builders/ethersV5.ts
@@ -15,7 +15,6 @@ const DEFAULT_RETRY_OPTIONS: SmartProviderOptions = {
 };
 
 const LOCAL_POLLING_INTERVAL_MS = 100;
-const MIN_REMOTE_POLLING_INTERVAL_MS = 1000;
 const DEFAULT_POLLING_INTERVAL_MS = 4000;
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
 
@@ -38,14 +37,11 @@ export const defaultEthersV5ProviderBuilder: ProviderBuilderFn<
   ) {
     provider.pollingInterval = LOCAL_POLLING_INTERVAL_MS;
   } else if (metadata.blocks?.estimateBlockTime) {
-    // Poll roughly once per block on fast chains, with a floor to bound RPC
-    // traffic and a ceiling that preserves ethers' latency on slower chains.
+    // Follow the estimated block cadence, capped at ethers' default interval.
+    // Ethers requires a positive integer number of milliseconds.
     provider.pollingInterval = Math.min(
       DEFAULT_POLLING_INTERVAL_MS,
-      Math.max(
-        MIN_REMOTE_POLLING_INTERVAL_MS,
-        Math.round(metadata.blocks.estimateBlockTime * 1000),
-      ),
+      Math.max(1, Math.round(metadata.blocks.estimateBlockTime * 1000)),
     );
   }
   return { type: ProviderType.EthersV5, provider };


### PR DESCRIPTION
Stacked on #9616. Merge the setup-timeout fix first, then retarget this PR to main.

CLI core-deployment subprocesses retained ethers' four-second polling interval because #9529 configured only providers created by Ethereum test helpers. Configure the shared ethers v5 builder used by MultiProvider and MultiProtocolProvider so local CLI deployments also get fast confirmation polling, and fast production chains use their existing block-time metadata.

| RPC configuration | Estimated block time | Before | After | Active polling frequency change |
| --- | --- | --- | --- | --- |
| Loopback only (`localhost`, all IPv4 `127/8`, `::1`) | Any | 4,000ms | 100ms | 40x |
| Remote or mixed, fast blocks | 0.25s | 4,000ms | 250ms | 16x |
| Remote or mixed, 100ms blocks | 0.1s | 4,000ms | 100ms | 40x |
| Remote or mixed | 2s | 4,000ms | 2,000ms | 2x |
| Remote or mixed, slower blocks | 13s | 4,000ms | 4,000ms | Unchanged |
| Remote or mixed, no estimate | Missing | 4,000ms | 4,000ms | Unchanged |

Remote polling uses min(estimated block time, 4 seconds), converted to positive integer milliseconds. There is no one-second floor: sub-second metadata values retain sub-second polling. This increases active block/event and confirmation polling frequency for TypeScript SDK consumers, including the CLI; it does not change confirmation counts, finality policy, or Rust agents. Lower confirmation detection latency on fast chains is expected, not production-measured. Loopback RPC proxies are classified by their configured URL, as in the existing test helper. On-demand chains should use their intended active cadence, not idle-inclusive averages. Base retains its 2s sealed-block estimate; Flashblocks are a distinct preconfirmation mechanism.

Rebenchmarked on 2026-09-10 at SDK head `952f6d837d57cc74ae5b5a4eaf7369ded190a41f`, using the estimates proposed in [registry #1705](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1705) (`0e8a021caa75a0a88b07dfb19944c95ca711d6cc`). Verified the real shared provider builder selected the expected remote polling interval for all 15 updated chain estimates. These metadata changes require registry release/adoption by consumers; merging the SDK PR alone does not activate the proposed metadata.

| Chain | Old default | #9617, current registry | #9617 + registry #1705 | Local 3-transfer total, current → updated metadata |
| --- | ---: | ---: | ---: | ---: |
| avalanche | 4,000ms | 2000ms | 1000ms | 6021 → 3037ms |
| bsc | 4,000ms | 3000ms | 450ms | 9035 → 1388ms |
| hyperevm | 4,000ms | 2000ms | 1000ms | 6021 → 3037ms |
| monad | 4,000ms | 1000ms | 300ms | 3037 → 940ms |
| polygon | 4,000ms | 2000ms | 1500ms | 6021 → 4546ms |
| robinhood | 4,000ms | 1000ms | 100ms | 3037 → 641ms |
| sei | 4,000ms | 1000ms | 400ms | 3037 → 1236ms |
| somnia | 4,000ms | 1000ms | 100ms | 3037 → 641ms |
| taiko | 4,000ms | 4000ms | 2000ms | 12041 → 6021ms |
| xlayer | 4,000ms | 4000ms | 1000ms | 12041 → 3037ms |
| arbitrumsepolia | 4,000ms | 3000ms | 250ms | 9035 → 784ms |
| bsctestnet | 4,000ms | 3000ms | 450ms | 9035 → 1388ms |
| hyperliquidevmtestnet | 4,000ms | 2000ms | 1000ms | 6021 → 3037ms |
| polygonamoy | 4,000ms | 2000ms | 1000ms | 6021 → 3037ms |
| somniatestnet | 4,000ms | 1000ms | 100ms | 3037 → 641ms |

Controlled local benchmark (Node 24.13.0, Anvil 1.5.0): three sequential transfers per interval, automining disabled, explicitly mine each transaction 50ms after starting `tx.wait(1)`. Fresh provider per interval; elapsed time includes submission and confirmation. Intervals were explicitly set against the same local node to isolate polling cost. Each interval was measured once and reused for chains with that interval; these are not separate chain benchmarks or statistical estimates. The old 4s baseline took **12,041ms**; 450ms took **1,388ms** (8.7x faster), 300ms **940ms** (12.8x), and 100ms **641ms** (18.8x).

This exercises transactions mined after waiting begins. Already-mined transactions can return immediately at either interval. Results isolate local confirmation detection latency, not full CLI E2E timings, chain execution speed or production latency. Faster polling increases active RPC request frequency.

Validation:

- SDK dependency build passed (`pnpm exec turbo run build --filter=@hyperlane-xyz/sdk...`): 18 successful tasks, including a fresh SDK `tsc` build.
- 101 provider tests passed, including 24 polling tests for the full IPv4 loopback range, IPv6 loopback, adjacent non-loopback ranges, multiple local URLs, remote and mixed URLs, hostname lookalikes, missing estimates, sub-second estimates, integer-millisecond rounding, the four-second cap, and local precedence. SDK compilation passed after the sub-second update.
- Controlled local benchmark results are shown above.
- Focused lint, formatting, diff checks, and normal commit hooks passed.
- Hosted CI passed on the previous head. CI for the IPv4 loopback follow-up remains pending.

Included an SDK patch changeset.
