### PR TITLE
test(sdk): isolate explorer tests from live services

### DIFF
--- a/.changeset/tidy-timelock-explorer-tests.md
+++ b/.changeset/tidy-timelock-explorer-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Replaced live Ethereum dependencies in timelock explorer tests with local contract events and mocked explorer responses to prevent external-service timing flakes.

--- a/.changeset/tidy-timelock-explorer-tests.md
+++ b/.changeset/tidy-timelock-explorer-tests.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Replaced live Ethereum dependencies in timelock explorer tests with local contract events and mocked explorer responses to prevent external-service timing flakes.
+Replaced live Ethereum dependencies in timelock and event-log explorer tests with local contract events and mocked explorer responses to prevent external-service timing flakes.

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.hardhat-test.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.hardhat-test.ts
@@ -10,11 +10,11 @@ import { ERC20Test, ERC20Test__factory } from '@hyperlane-xyz/core';
 import { assert } from '@hyperlane-xyz/utils';
 
 import {
-  KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
-  TestChainName,
-  ethereumTestChain,
-  test1,
-} from '../../consts/testChains.js';
+  EXPLORER_API_URL,
+  explorerLogsResponse,
+  explorerResultResponse,
+} from '../../block-explorer/testFixtures.js';
+import { TestChainName, test1 } from '../../consts/testChains.js';
 import { ExplorerFamily } from '../../metadata/chainMetadataTypes.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { randomAddress, randomInt } from '../../test/testUtils.js';
@@ -421,27 +421,89 @@ describe('EvmEventLogsReader', () => {
       await deployTestErc20();
 
       multiProvider = new MultiProvider({
-        ethereum: ethereumTestChain,
+        [TestChainName.test1]: {
+          ...test1,
+          blockExplorers: [
+            {
+              name: 'Test explorer',
+              url: EXPLORER_API_URL,
+              apiUrl: EXPLORER_API_URL,
+              family: ExplorerFamily.Routescan,
+            },
+          ],
+        },
       });
+      multiProvider.setProvider(TestChainName.test1, providerChainTest1);
       reader = EvmEventLogsReader.fromConfig(
         {
-          chain: ethereumTestChain.name,
+          chain: TestChainName.test1,
         },
         multiProvider,
       );
     });
 
     it('should get the expected number of events when fromBlock is not provided', async () => {
+      await (await testContract.mint(1)).wait();
+      const toBlock = await providerChainTest1.getBlockNumber();
+      const logs = await providerChainTest1.getLogs({
+        address: testContract.address,
+        fromBlock: deploymentBlockNumber,
+        toBlock,
+        topics: [transferTopic],
+      });
+      const rpcLogs = sinon
+        .stub(providerChainTest1, 'getLogs')
+        .rejects(new Error('Explorer tests must not fall back to RPC logs'));
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .callsFake(async (input) => {
+          const url = new URL(
+            input instanceof Request ? input.url : input.toString(),
+          );
+          expect(url.origin + url.pathname).to.equal(EXPLORER_API_URL);
+          if (url.searchParams.get('action') === 'getcontractcreation') {
+            expect(url.searchParams.get('contractaddresses')).to.equal(
+              testContract.address,
+            );
+            return explorerResultResponse({
+              contractAddress: testContract.address,
+              contractCreator: contractOwner.address,
+              txHash: testContract.deployTransaction.hash,
+              blockNumber: deploymentBlockNumber,
+            });
+          }
+          expect(url.searchParams.get('action')).to.equal('getLogs');
+          expect(url.searchParams.get('address')).to.equal(
+            testContract.address,
+          );
+          expect(url.searchParams.get('topic0')).to.equal(transferTopic);
+          expect(url.searchParams.get('fromBlock')).to.equal(
+            String(deploymentBlockNumber),
+          );
+          expect(url.searchParams.get('toBlock')).to.equal(String(toBlock));
+          return explorerLogsResponse(
+            logs.map((log) => ({
+              ...log,
+              blockNumber: ethers.utils.hexValue(log.blockNumber),
+              logIndex: ethers.utils.hexValue(log.logIndex),
+              transactionIndex: ethers.utils.hexValue(log.transactionIndex),
+            })),
+          );
+        });
       const res = await reader.getLogsByTopic({
-        contractAddress: KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
-        // CallExecuted signature
-        eventTopic:
-          '0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58',
+        contractAddress: testContract.address,
+        eventTopic: transferTopic,
         // Omitting from block to test getting contract deployment block from explorer
-        toBlock: 15_000_000,
+        toBlock,
       });
 
-      expect(res.length).to.equal(17);
+      expect(res).to.have.length(2);
+      expect(res.map((log) => log.transactionHash)).to.deep.equal(
+        logs.map((log) => log.transactionHash),
+      );
+      expect(res[0].blockNumber).to.equal(deploymentBlockNumber);
+      expect(fetchStub.callCount).to.equal(2);
+      expect(rpcLogs.called).to.be.false;
     });
   });
 

--- a/typescript/sdk/src/timelock/evm/EvmTimelockReader.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockReader.hardhat-test.ts
@@ -4,12 +4,16 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'ethers';
 import hre from 'hardhat';
+import sinon from 'sinon';
 
 import { TimelockController__factory } from '@hyperlane-xyz/core';
 import { assert, deepCopy, normalizeAddressEvm } from '@hyperlane-xyz/utils';
 
 import {
-  KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
+  EXPLORER_API_URL,
+  explorerResponse,
+} from '../../block-explorer/testFixtures.js';
+import {
   TestChainName,
   ethereumTestChain,
   test1,
@@ -1025,17 +1029,108 @@ describe(EvmTimelockReader.name, () => {
 
   describe(`${EvmTimelockReader.name} (Block Explorer)`, () => {
     let reader: EvmTimelockReader;
-    let multiProvider: MultiProvider;
+    let sandbox: sinon.SinonSandbox;
+    let operationIds: string[];
+    let explorerFetch: sinon.SinonStub;
+    let rpcGetLogs: sinon.SinonStub;
 
     beforeEach(async () => {
+      sandbox = sinon.createSandbox();
+      const timelock = await deployTestTimelock();
+      operationIds = [];
+      for (let i = 0; i < 3; i++) {
+        const salt = ethers.utils.formatBytes32String(`explorer-${i}`);
+        const args = [
+          [executor.address],
+          [0],
+          ['0x'],
+          EMPTY_BYTES_32,
+          salt,
+        ] satisfies [string[], number[], string[], string, string];
+        await (
+          await timelock.connect(proposer).scheduleBatch(...args, 0)
+        ).wait();
+        operationIds.push(await timelock.hashOperationBatch(...args));
+        if (i === 0)
+          await (
+            await timelock.connect(proposer).cancel(operationIds[i])
+          ).wait();
+        if (i === 1)
+          await (await timelock.connect(executor).executeBatch(...args)).wait();
+      }
+
+      const explorerUrl = EXPLORER_API_URL;
       multiProvider = new MultiProvider({
-        ethereum: ethereumTestChain,
+        [TestChainName.test1]: {
+          ...test1,
+          blockExplorers: ethereumTestChain.blockExplorers
+            ?.slice(0, 1)
+            .map((explorer) => ({
+              ...explorer,
+              apiUrl: explorerUrl,
+              url: 'https://explorer.test',
+            })),
+        },
       });
+      multiProvider.setProvider(TestChainName.test1, providerChainTest1);
+      const fixtureLogs = await providerChainTest1.getLogs({
+        address: timelock.address,
+        fromBlock: timelock.deployTransaction.blockNumber,
+        toBlock: 'latest',
+      });
+      rpcGetLogs = sandbox
+        .stub(providerChainTest1, 'getLogs')
+        .rejects(new Error('Explorer tests must not fall back to RPC logs'));
+      // Exercise the explorer HTTP/decoding path using real local events.
+      // No public RPC or explorer is involved in this Hardhat suite.
+      explorerFetch = sandbox
+        .stub(globalThis, 'fetch')
+        .callsFake(async (input) => {
+          const url = new URL(
+            input instanceof Request ? input.url : input.toString(),
+          );
+          expect(url.origin + url.pathname).to.equal(explorerUrl);
+          let result: unknown;
+          if (url.searchParams.get('action') === 'getcontractcreation') {
+            result = [
+              {
+                contractAddress: timelock.address,
+                contractCreator: contractOwner.address,
+                txHash: timelock.deployTransaction.hash,
+                blockNumber: timelock.deployTransaction.blockNumber,
+              },
+            ];
+          } else {
+            expect(url.searchParams.get('action')).to.equal('getLogs');
+            expect(url.searchParams.get('address')).to.equal(timelock.address);
+            const topic = url.searchParams.get('topic0');
+            assert(topic, 'Expected an event topic');
+            const logs = fixtureLogs.filter(
+              (log) =>
+                log.topics[0] === topic &&
+                log.blockNumber >= Number(url.searchParams.get('fromBlock')) &&
+                log.blockNumber <= Number(url.searchParams.get('toBlock')),
+            );
+            result = logs.map((log) => ({
+              ...log,
+              blockNumber: ethers.utils.hexValue(log.blockNumber),
+              logIndex: ethers.utils.hexValue(log.logIndex),
+              transactionIndex: ethers.utils.hexValue(log.transactionIndex),
+            }));
+          }
+          return explorerResponse({ status: '1', message: 'OK', result });
+        });
       reader = EvmTimelockReader.fromConfig({
-        chain: ethereumTestChain.name,
-        timelockAddress: KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
+        chain: TestChainName.test1,
+        timelockAddress,
         multiProvider,
       });
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      expect(explorerFetch.called).to.be.true;
+      expect(rpcGetLogs.called).to.be.false;
     });
 
     describe(`${EvmTimelockReader.prototype.getScheduledOperations.name}`, () => {
@@ -1044,7 +1139,7 @@ describe(EvmTimelockReader.name, () => {
           await reader.getScheduledOperations();
 
         // Should find some scheduled transactions on this timelock
-        expect(Object.keys(scheduledTxs).length).to.be.greaterThan(0);
+        expect(Object.keys(scheduledTxs)).to.have.members(operationIds);
 
         // Validate structure of returned transactions
         for (const [txId, tx] of Object.entries(scheduledTxs)) {
@@ -1064,6 +1159,7 @@ describe(EvmTimelockReader.name, () => {
         const cancelledIds = await reader.getCancelledOperationIds();
 
         expect(cancelledIds).to.be.instanceOf(Set);
+        expect([...cancelledIds]).to.deep.equal([operationIds[0]]);
         for (const id of cancelledIds) {
           expect(ZBytes32String.safeParse(id).success).to.be.true;
         }
@@ -1075,7 +1171,7 @@ describe(EvmTimelockReader.name, () => {
         const executedIds = await reader.getExecutedOperationIds();
 
         // Should find some executed transactions on this timelock
-        expect(executedIds.size).to.be.greaterThan(0);
+        expect([...executedIds]).to.deep.equal([operationIds[1]]);
         for (const id of executedIds) {
           expect(ZBytes32String.safeParse(id).success).to.be.true;
         }
@@ -1085,6 +1181,7 @@ describe(EvmTimelockReader.name, () => {
     describe(`${EvmTimelockReader.prototype.getScheduledExecutableTransactions.name}`, () => {
       it('should retrieve scheduled executable transactions from block explorer API', async () => {
         const executableTxs = await reader.getScheduledExecutableTransactions();
+        expect(Object.keys(executableTxs)).to.deep.equal([operationIds[2]]);
 
         for (const [txId, executableTx] of Object.entries(executableTxs)) {
           expect(executableTx.id).to.equal(txId);


### PR DESCRIPTION
Stacked on #9617; this diff is test-only and can also be cherry-picked independently.

The [failed pnpm-test-run job](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34499093452/job/102945277950) timed out after 40 seconds in `EvmTimelockReader (Block Explorer) / getCancelledOperationIds`, with 318 tests passing. The suite queried a real Ethereum timelock through public RPC and Routescan, despite running inside the default Hardhat suite. The log does not identify the individual stalled upstream request. This is separate from confirmation polling: the failing method reads logs, not transaction confirmations.

Replaced those live dependencies with a locally deployed timelock, three real scheduled operations (one cancelled, one executed, one pending), and mocked explorer HTTP responses populated from its events. The real explorer request construction, response decoding, log validation and timelock parsing still run. RPC-log fallback is explicitly rejected and checked, so explorer failures cannot silently pass via RPC. All four tests now assert exact operation IDs, including nonempty executable results.

| Validation | Result |
| --- | --- |
| Full EvmTimelockReader + EvmEventLogsReader Hardhat files together | 57 passed |
| Event-log explorer case, five consecutive fresh-process runs | 5/5 passed |
| Explorer subset, five consecutive fresh-process runs | 20/20 passed |
| SDK TypeScript build | Passed |
| Normal commit hooks and diff check | Passed |
| Hosted CI | Pending |

Commands: `pnpm -C typescript/sdk build`; from `typescript/sdk`, `NODE_OPTIONS='--import tsx/esm' pnpm exec hardhat --config hardhat.config.cts test src/timelock/evm/EvmTimelockReader.hardhat-test.ts`. Repeated runs used `--grep 'Block Explorer' --no-compile`.

Also fixed the [retry failure](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34499093452/job/102948862661): `EvmEventLogsReader / getLogsByTopic (block explorer)` hit the same 40s timeout while requesting historical Ethereum events. It now uses a local ERC20 deployment and mint, asserts the explorer deployment-block lookup determines `fromBlock`, verifies the requested address/topic/range and returned transaction hashes, and rejects RPC-log fallback. The combined command additionally includes `src/rpc/evm/EvmEventLogsReader.hardhat-test.ts`; the new case was repeated with `--grep 'getLogsByTopic \(block explorer\)' --no-compile`.

No production code or timeout changes. Empty changeset: no package release required for test-only changes. Live public-explorer availability is no longer tested by these five default-suite cases.
