### PR TITLE
fix(starknet): read aggregation and pausable ISMs accurately

### DIFF
--- a/.changeset/starknet-ism-read.md
+++ b/.changeset/starknet-ism-read.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/provider-sdk': patch
+'@hyperlane-xyz/deploy-sdk': patch
+'@hyperlane-xyz/starknet-sdk': patch
+---
+
+Fixed Starknet core reads that mislabeled unsupported ISMs as test ISMs. Added read support for aggregation trees and pausable ISMs, preserved their nested configuration and pause state, and rejected unknown modules instead of reporting them as accept-all ISMs.

--- a/typescript/deploy-sdk/src/ism/generic-ism-writer.ts
+++ b/typescript/deploy-sdk/src/ism/generic-ism-writer.ts
@@ -16,6 +16,7 @@ import {
   IsmArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/ism';
 import { AnnotatedTx, TxReceipt } from '@hyperlane-xyz/provider-sdk/module';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { IsmReader } from './generic-ism.js';
 import { RoutingIsmWriter } from './routing-ism.js';
@@ -90,6 +91,11 @@ export class IsmWriter
     artifact: ArtifactNew<IsmArtifactConfig>,
   ): Promise<[DeployedIsmArtifact, TxReceipt[]]> {
     const { artifactState, config } = artifact;
+    assert(
+      config.type !== AltVM.IsmType.AGGREGATION &&
+        config.type !== AltVM.IsmType.PAUSABLE,
+      'Aggregation and pausable ISM artifacts currently support reading only',
+    );
 
     // Routing ISMs are composite - use RoutingIsmWriter for nested deployments
     if (config.type === AltVM.IsmType.ROUTING) {
@@ -111,6 +117,11 @@ export class IsmWriter
    */
   async update(artifact: DeployedIsmArtifact): Promise<AnnotatedTx[]> {
     const { artifactState, config, deployed } = artifact;
+    assert(
+      config.type !== AltVM.IsmType.AGGREGATION &&
+        config.type !== AltVM.IsmType.PAUSABLE,
+      'Aggregation and pausable ISM artifacts currently support reading only',
+    );
 
     // Only routing ISMs are mutable - support domain updates and owner changes
     if (config.type === AltVM.IsmType.ROUTING) {

--- a/typescript/deploy-sdk/src/ism/generic-ism.test.ts
+++ b/typescript/deploy-sdk/src/ism/generic-ism.test.ts
@@ -1,0 +1,172 @@
+import { expect } from 'chai';
+
+import { ProtocolType } from '@hyperlane-xyz/provider-sdk';
+import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import { ChainLookup } from '@hyperlane-xyz/provider-sdk/chain';
+import {
+  DeployedRawIsmArtifact,
+  IRawIsmArtifactManager,
+  IsmConfig,
+  ismArtifactToDerivedConfig,
+  ismConfigToArtifact,
+} from '@hyperlane-xyz/provider-sdk/ism';
+import { assert } from '@hyperlane-xyz/utils';
+
+import { IsmReader } from './generic-ism.js';
+
+const chainLookup: ChainLookup = {
+  getChainMetadata: () => ({
+    name: 'ethereum',
+    chainId: 1,
+    domainId: 1,
+    protocol: ProtocolType.Ethereum,
+  }),
+  getChainName: (domain) => (domain === 1 ? 'ethereum' : null),
+  getDomainId: (chain) => (chain === 'ethereum' ? 1 : null),
+  getKnownChainNames: () => ['ethereum'],
+};
+
+const reference = (address: string) => ({
+  artifactState: ArtifactState.UNDERIVED,
+  deployed: { address },
+});
+
+function fixture() {
+  const artifacts: Record<string, DeployedRawIsmArtifact> = {
+    aggregation: {
+      artifactState: ArtifactState.DEPLOYED,
+      deployed: { address: 'aggregation' },
+      config: {
+        type: 'staticAggregationIsm',
+        threshold: 2,
+        modules: [reference('routing'), reference('pausable')],
+      },
+    },
+    routing: {
+      artifactState: ArtifactState.DEPLOYED,
+      deployed: { address: 'routing' },
+      config: {
+        type: 'domainRoutingIsm',
+        owner: 'router-owner',
+        domains: { 1: reference('multisig') },
+      },
+    },
+    multisig: {
+      artifactState: ArtifactState.DEPLOYED,
+      deployed: { address: 'multisig' },
+      config: {
+        type: 'messageIdMultisigIsm',
+        threshold: 2,
+        validators: ['validator1', 'validator2', 'validator3'],
+      },
+    },
+    pausable: {
+      artifactState: ArtifactState.DEPLOYED,
+      deployed: { address: 'pausable' },
+      config: { type: 'pausableIsm', owner: 'pauser', paused: false },
+    },
+  };
+  const reads: string[] = [];
+  const manager: IRawIsmArtifactManager = {
+    readIsm: async (address) => {
+      reads.push(address);
+      const artifact = artifacts[address];
+      assert(artifact, `Unsupported ISM ${address}`);
+      return artifact;
+    },
+    createReader: () => {
+      throw new Error('Unexpected typed reader');
+    },
+    createWriter: () => {
+      throw new Error('Unexpected writer');
+    },
+  };
+  return { artifacts, reads, reader: new IsmReader(manager, chainLookup) };
+}
+
+describe('IsmReader aggregation', () => {
+  it('expands the Starknet aggregation → routing → multisig and pausable tree', async () => {
+    const { reader, reads } = fixture();
+    expect(await reader.deriveIsmConfig('aggregation')).to.deep.equal({
+      type: 'staticAggregationIsm',
+      address: 'aggregation',
+      threshold: 2,
+      modules: [
+        {
+          type: 'domainRoutingIsm',
+          address: 'routing',
+          owner: 'router-owner',
+          domains: {
+            ethereum: {
+              type: 'messageIdMultisigIsm',
+              address: 'multisig',
+              threshold: 2,
+              validators: ['validator1', 'validator2', 'validator3'],
+            },
+          },
+        },
+        {
+          type: 'pausableIsm',
+          address: 'pausable',
+          owner: 'pauser',
+          paused: false,
+        },
+      ],
+    });
+    expect(reads).to.deep.equal([
+      'aggregation',
+      'routing',
+      'multisig',
+      'pausable',
+    ]);
+  });
+
+  it('propagates unsupported children instead of partially reporting a tree', async () => {
+    const { reader, artifacts } = fixture();
+    delete artifacts.pausable;
+    const result = await reader
+      .read('aggregation')
+      .catch((error: unknown) => error);
+    expect(String(result)).to.match(/Unsupported ISM pausable/);
+  });
+
+  it('converts nested aggregation config references without losing their addresses', () => {
+    const config: IsmConfig = {
+      type: 'staticAggregationIsm',
+      threshold: 1,
+      modules: ['existing-module'],
+    };
+    const artifact = ismConfigToArtifact(config, chainLookup);
+    expect(
+      ismArtifactToDerivedConfig(
+        {
+          ...artifact,
+          artifactState: ArtifactState.DEPLOYED,
+          deployed: { address: 'root' },
+        },
+        chainLookup,
+      ),
+    ).to.deep.equal({ ...config, address: 'root' });
+  });
+
+  it('rejects a NEW aggregation child when deriving deployed configuration', () => {
+    const artifact = ismConfigToArtifact(
+      {
+        type: 'staticAggregationIsm',
+        threshold: 1,
+        modules: [{ type: 'testIsm' }],
+      },
+      chainLookup,
+    );
+    expect(() =>
+      ismArtifactToDerivedConfig(
+        {
+          ...artifact,
+          artifactState: ArtifactState.DEPLOYED,
+          deployed: { address: 'root' },
+        },
+        chainLookup,
+      ),
+    ).to.throw(/nested ISM is NEW/);
+  });
+});

--- a/typescript/deploy-sdk/src/ism/generic-ism.ts
+++ b/typescript/deploy-sdk/src/ism/generic-ism.ts
@@ -74,6 +74,18 @@ export class IsmReader implements ArtifactReader<
       return this.expandRoutingIsm({ artifactState, config, deployed });
     }
 
+    if (config.type === AltVM.IsmType.AGGREGATION) {
+      const modules: DeployedIsmArtifact[] = [];
+      for (const module of config.modules) {
+        modules.push(
+          isArtifactDeployed(module)
+            ? module
+            : await this.read(module.deployed.address),
+        );
+      }
+      return { artifactState, config: { ...config, modules }, deployed };
+    }
+
     // For non-routing ISMs, the raw and expanded configs are identical
     return {
       artifactState,

--- a/typescript/deploy-sdk/src/ism/routing-ism.ts
+++ b/typescript/deploy-sdk/src/ism/routing-ism.ts
@@ -21,7 +21,7 @@ import {
   RoutingIsmArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/ism';
 import { AnnotatedTx, TxReceipt } from '@hyperlane-xyz/provider-sdk/module';
-import { Logger, rootLogger } from '@hyperlane-xyz/utils';
+import { Logger, assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { IsmReader } from './generic-ism.js';
 
@@ -146,6 +146,11 @@ export class RoutingIsmWriter implements ArtifactWriter<
 
       if (isArtifactDeployed(domainIsmConfig)) {
         const { artifactState, config, deployed } = domainIsmConfig;
+        assert(
+          config.type !== AltVM.IsmType.AGGREGATION &&
+            config.type !== AltVM.IsmType.PAUSABLE,
+          'Aggregation and pausable ISM artifacts currently support reading only',
+        );
 
         const domainIsmWriter = this.artifactManager.createWriter(
           domainIsmConfig.config.type,
@@ -211,6 +216,11 @@ export class RoutingIsmWriter implements ArtifactWriter<
     artifact: ArtifactNew<IsmArtifactConfig>,
   ): Promise<[DeployedIsmArtifact, TxReceipt[]]> {
     const { config, artifactState } = artifact;
+    assert(
+      config.type !== AltVM.IsmType.AGGREGATION &&
+        config.type !== AltVM.IsmType.PAUSABLE,
+      'Aggregation and pausable ISM artifacts currently support reading only',
+    );
     if (config.type === AltVM.IsmType.ROUTING) {
       return this.create({
         config,

--- a/typescript/provider-sdk/src/ism.ts
+++ b/typescript/provider-sdk/src/ism.ts
@@ -36,6 +36,8 @@ export const IsmType = {
   MESSAGE_ID_MULTISIG: 'messageIdMultisigIsm',
   TEST_ISM: 'testIsm',
   COMPOSITE: 'compositeIsm',
+  AGGREGATION: 'staticAggregationIsm',
+  PAUSABLE: 'pausableIsm',
 } as const;
 
 export type IsmType = (typeof IsmType)[keyof typeof IsmType];
@@ -46,6 +48,8 @@ export interface IsmConfigs {
   [IsmType.MESSAGE_ID_MULTISIG]: MultisigIsmConfig;
   [IsmType.TEST_ISM]: TestIsmConfig;
   [IsmType.COMPOSITE]: CompositeIsmConfig;
+  [IsmType.AGGREGATION]: AggregationIsmConfig;
+  [IsmType.PAUSABLE]: PausableIsmConfig;
 }
 
 export type IsmConfig = IsmConfigs[IsmType];
@@ -67,6 +71,18 @@ export interface MultisigIsmConfig {
 
 export interface TestIsmConfig {
   type: typeof IsmType.TEST_ISM;
+}
+
+export interface AggregationIsmConfig {
+  type: typeof IsmType.AGGREGATION;
+  modules: (IsmConfig | string)[];
+  threshold: number;
+}
+
+export interface PausableIsmConfig {
+  type: typeof IsmType.PAUSABLE;
+  owner: string;
+  paused: boolean;
 }
 
 export interface DomainRoutingIsmConfig {
@@ -159,6 +175,8 @@ export interface IsmArtifactConfigs {
   [IsmType.MESSAGE_ID_MULTISIG]: MultisigIsmConfig;
   [IsmType.TEST_ISM]: TestIsmConfig;
   [IsmType.COMPOSITE]: CompositeIsmArtifactConfig;
+  [IsmType.AGGREGATION]: AggregationIsmArtifactConfig;
+  [IsmType.PAUSABLE]: PausableIsmConfig;
 }
 
 /**
@@ -190,6 +208,15 @@ export interface RoutingIsmArtifactConfig {
   owner: string;
   domains: Record<number, Artifact<IsmArtifactConfig, DeployedIsmAddress>>;
 }
+
+export interface AggregationIsmArtifactConfig {
+  type: typeof IsmType.AGGREGATION;
+  modules: Artifact<IsmArtifactConfig, DeployedIsmAddress>[];
+  threshold: number;
+}
+
+export type RawAggregationIsmArtifactConfig =
+  ConfigOnChain<AggregationIsmArtifactConfig>;
 
 export type RawRoutingIsmArtifactConfig =
   ConfigOnChain<RoutingIsmArtifactConfig>;
@@ -248,6 +275,8 @@ export interface RawIsmArtifactConfigs {
   [IsmType.MESSAGE_ID_MULTISIG]: MultisigIsmConfig;
   [IsmType.TEST_ISM]: TestIsmConfig;
   [IsmType.COMPOSITE]: CompositeIsmArtifactConfig;
+  [IsmType.AGGREGATION]: RawAggregationIsmArtifactConfig;
+  [IsmType.PAUSABLE]: PausableIsmConfig;
 }
 
 /**
@@ -298,6 +327,11 @@ export function shouldDeployNewIsm(
   actual: IsmArtifactConfig,
   expected: IsmArtifactConfig,
 ): boolean {
+  assert(
+    expected.type !== IsmType.AGGREGATION && expected.type !== IsmType.PAUSABLE,
+    'Aggregation and pausable ISM artifacts currently support reading only',
+  );
+
   // Type changed - must deploy new
   if (actual.type !== expected.type) return true;
 
@@ -329,6 +363,12 @@ export function mergeIsmArtifacts(
   currentArtifact: DeployedIsmArtifact | undefined,
   expectedArtifact: ArtifactNew<IsmArtifactConfig> | DeployedIsmArtifact,
 ): ArtifactNew<IsmArtifactConfig> | DeployedIsmArtifact {
+  assert(
+    expectedArtifact.config.type !== IsmType.AGGREGATION &&
+      expectedArtifact.config.type !== IsmType.PAUSABLE,
+    'Aggregation and pausable ISM artifacts currently support reading only',
+  );
+
   const expectedConfig = expectedArtifact.config;
 
   // No current ISM - return expected as-is
@@ -449,6 +489,10 @@ export function altVMIsmTypeToProviderSdkType(
       return IsmType.MESSAGE_ID_MULTISIG;
     case AltVMIsmType.ROUTING:
       return IsmType.ROUTING;
+    case AltVMIsmType.AGGREGATION:
+      return IsmType.AGGREGATION;
+    case AltVMIsmType.PAUSABLE:
+      return IsmType.PAUSABLE;
     case AltVMIsmType.COMPOSITE:
       return IsmType.COMPOSITE;
     default:
@@ -634,6 +678,13 @@ function assertIsmConfigSupportedAsMailboxDefault(
   context: string,
 ): void {
   switch (config.type) {
+    case IsmType.AGGREGATION:
+      for (const module of config.modules) {
+        if (!isArtifactUnderived(module)) {
+          assertIsmConfigSupportedAsMailboxDefault(module.config, context);
+        }
+      }
+      return;
     case IsmType.ROUTING:
       for (const domainIsm of Object.values(config.domains)) {
         if (!isArtifactUnderived(domainIsm)) {
@@ -646,6 +697,7 @@ function assertIsmConfigSupportedAsMailboxDefault(
       return;
     case IsmType.MERKLE_ROOT_MULTISIG:
     case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.PAUSABLE:
     case IsmType.TEST_ISM:
       return;
     default:
@@ -674,6 +726,12 @@ function ismArtifactHasExplicitRateLimitedRecipient(
   config: IsmArtifactConfig,
 ): boolean {
   switch (config.type) {
+    case IsmType.AGGREGATION:
+      return config.modules.some(
+        (module) =>
+          isArtifactNew(module) &&
+          ismArtifactHasExplicitRateLimitedRecipient(module.config),
+      );
     case IsmType.ROUTING:
       return Object.values(config.domains).some(
         (domainIsm) =>
@@ -689,6 +747,7 @@ function ismArtifactHasExplicitRateLimitedRecipient(
       );
     case IsmType.MERKLE_ROOT_MULTISIG:
     case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.PAUSABLE:
     case IsmType.TEST_ISM:
       return false;
     default:
@@ -785,6 +844,13 @@ function assertIsmConfigRecipientsMatch(
   context: string,
 ): void {
   switch (config.type) {
+    case IsmType.AGGREGATION:
+      for (const module of config.modules) {
+        if (!isArtifactUnderived(module)) {
+          assertIsmConfigRecipientsMatch(module.config, warpRouter, context);
+        }
+      }
+      return;
     case IsmType.ROUTING:
       for (const domainIsm of Object.values(config.domains)) {
         if (!isArtifactUnderived(domainIsm)) {
@@ -797,6 +863,7 @@ function assertIsmConfigRecipientsMatch(
       return;
     case IsmType.MERKLE_ROOT_MULTISIG:
     case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.PAUSABLE:
     case IsmType.TEST_ISM:
       return;
     default:
@@ -809,6 +876,16 @@ function assertNoNewIsmDescendants(
   context: string,
 ): void {
   switch (config.type) {
+    case IsmType.AGGREGATION:
+      for (const module of config.modules) {
+        assert(
+          !isArtifactNew(module),
+          `A DEPLOYED ISM used while creating ${context} cannot contain a NEW aggregation module.`,
+        );
+        if (isArtifactDeployed(module))
+          assertNoNewIsmDescendants(module.config, context);
+      }
+      return;
     case IsmType.ROUTING:
       for (const [domainId, domainIsm] of Object.entries(config.domains)) {
         assert(
@@ -823,6 +900,7 @@ function assertNoNewIsmDescendants(
     case IsmType.COMPOSITE:
     case IsmType.MERKLE_ROOT_MULTISIG:
     case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.PAUSABLE:
     case IsmType.TEST_ISM:
       return;
     default:
@@ -1052,6 +1130,13 @@ export function resolveRateLimitedIsmRecipients(
   context: string,
 ): IsmArtifactConfig {
   switch (config.type) {
+    case IsmType.AGGREGATION:
+      return {
+        ...config,
+        modules: config.modules.map((module) =>
+          resolveIsmArtifactRecipients(module, warpRouter, context),
+        ),
+      };
     case IsmType.ROUTING: {
       const domains: RoutingIsmArtifactConfig['domains'] = {};
       for (const [domainId, domainIsm] of Object.entries(config.domains)) {
@@ -1077,6 +1162,7 @@ export function resolveRateLimitedIsmRecipients(
     }
     case IsmType.MERKLE_ROOT_MULTISIG:
     case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.PAUSABLE:
     case IsmType.TEST_ISM:
       return config;
     default:
@@ -1092,6 +1178,21 @@ export function ismArtifactToDerivedConfig(
   const address = artifact.deployed.address;
 
   switch (config.type) {
+    case IsmType.AGGREGATION:
+      return {
+        type: config.type,
+        threshold: config.threshold,
+        address,
+        modules: config.modules.map((module) => {
+          if (isArtifactDeployed(module))
+            return ismArtifactToDerivedConfig(module, chainLookup);
+          assert(
+            isArtifactUnderived(module),
+            'Cannot convert aggregation ISM to derived config: nested ISM is NEW and has no address',
+          );
+          return module.deployed.address;
+        }),
+      };
     case IsmType.ROUTING: {
       // For routing ISMs, convert domain IDs back to chain names
       // and convert nested artifacts to IsmConfig or address strings
@@ -1139,6 +1240,7 @@ export function ismArtifactToDerivedConfig(
         address,
       };
 
+    case IsmType.PAUSABLE:
     case IsmType.TEST_ISM:
       // Test ISMs have identical structure between Artifact and Config APIs
       return {
@@ -1195,6 +1297,24 @@ export function ismConfigToArtifact(
   config: IsmConfig,
   chainLookup: ChainLookup,
 ): ArtifactNew<IsmArtifactConfig> {
+  if (config.type === IsmType.AGGREGATION) {
+    return {
+      artifactState: ArtifactState.NEW,
+      config: {
+        type: config.type,
+        threshold: config.threshold,
+        modules: config.modules.map((module) =>
+          typeof module === 'string'
+            ? {
+                artifactState: ArtifactState.UNDERIVED,
+                deployed: { address: module },
+              }
+            : ismConfigToArtifact(module, chainLookup),
+        ),
+      },
+    };
+  }
+
   // Handle routing ISMs - need to convert chain names to domain IDs
   if (config.type === IsmType.ROUTING) {
     const domains: Record<

--- a/typescript/starknet-sdk/src/contracts.ts
+++ b/typescript/starknet-sdk/src/contracts.ts
@@ -106,6 +106,8 @@ export enum StarknetContractName {
   MESSAGE_ID_MULTISIG_ISM = 'messageid_multisig_ism',
   MERKLE_ROOT_MULTISIG_ISM = 'merkleroot_multisig_ism',
   ROUTING_ISM = 'domain_routing_ism',
+  AGGREGATION_ISM = 'aggregation',
+  PAUSABLE_ISM = 'pausable_ism',
   NOOP_ISM = 'noop_ism',
   HOOK = 'hook',
   MERKLE_TREE_HOOK = 'merkle_tree_hook',

--- a/typescript/starknet-sdk/src/ism/aggregation-ism-artifact-reader.ts
+++ b/typescript/starknet-sdk/src/ism/aggregation-ism-artifact-reader.ts
@@ -1,0 +1,72 @@
+import {
+  ArtifactState,
+  type ArtifactDeployed,
+  type ArtifactReader,
+} from '@hyperlane-xyz/provider-sdk/artifact';
+import {
+  type DeployedIsmAddress,
+  type RawIsmArtifactConfigs,
+} from '@hyperlane-xyz/provider-sdk/ism';
+
+import { StarknetProvider } from '../clients/provider.js';
+import { getAggregationIsmConfig, getPausableIsmConfig } from './ism-query.js';
+
+export class StarknetAggregationIsmReader implements ArtifactReader<
+  RawIsmArtifactConfigs['staticAggregationIsm'],
+  DeployedIsmAddress
+> {
+  constructor(private readonly provider: StarknetProvider) {}
+
+  async read(
+    address: string,
+  ): Promise<
+    ArtifactDeployed<
+      RawIsmArtifactConfigs['staticAggregationIsm'],
+      DeployedIsmAddress
+    >
+  > {
+    const config = await getAggregationIsmConfig(
+      this.provider.getRawProvider(),
+      address,
+    );
+    return {
+      artifactState: ArtifactState.DEPLOYED,
+      config: {
+        type: 'staticAggregationIsm',
+        threshold: config.threshold,
+        modules: config.modules.map((address) => ({
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address },
+        })),
+      },
+      deployed: { address: config.address },
+    };
+  }
+}
+
+export class StarknetPausableIsmReader implements ArtifactReader<
+  RawIsmArtifactConfigs['pausableIsm'],
+  DeployedIsmAddress
+> {
+  constructor(private readonly provider: StarknetProvider) {}
+
+  async read(
+    address: string,
+  ): Promise<
+    ArtifactDeployed<RawIsmArtifactConfigs['pausableIsm'], DeployedIsmAddress>
+  > {
+    const config = await getPausableIsmConfig(
+      this.provider.getRawProvider(),
+      address,
+    );
+    return {
+      artifactState: ArtifactState.DEPLOYED,
+      config: {
+        type: 'pausableIsm',
+        owner: config.owner,
+        paused: config.paused,
+      },
+      deployed: { address: config.address },
+    };
+  }
+}

--- a/typescript/starknet-sdk/src/ism/ism-artifact-manager.ts
+++ b/typescript/starknet-sdk/src/ism/ism-artifact-manager.ts
@@ -22,6 +22,10 @@ import { StarknetProvider } from '../clients/provider.js';
 import { StarknetSigner } from '../clients/signer.js';
 import { getIsmType } from './ism-query.js';
 import {
+  StarknetAggregationIsmReader,
+  StarknetPausableIsmReader,
+} from './aggregation-ism-artifact-reader.js';
+import {
   StarknetRoutingIsmReader,
   StarknetRoutingIsmWriter,
 } from './domain-routing-ism-artifact-manager.js';
@@ -54,9 +58,10 @@ export class StarknetIsmArtifactManager implements IRawIsmArtifactManager {
 
   async readIsm(address: string): Promise<DeployedRawIsmArtifact> {
     const type = await getIsmType(this.provider.getRawProvider(), address);
-    if (type === AltVM.IsmType.CUSTOM) {
-      return this.createReader(AltVM.IsmType.TEST_ISM).read(address);
-    }
+    assert(
+      type !== AltVM.IsmType.CUSTOM,
+      `Unsupported Starknet ISM at ${address}; refusing to report it as testIsm`,
+    );
     const reader = this.createReader(altVMIsmTypeToProviderSdkType(type));
     return reader.read(address);
   }
@@ -70,6 +75,9 @@ export class StarknetIsmArtifactManager implements IRawIsmArtifactManager {
         DeployedIsmAddress
       >;
     }> = {
+      staticAggregationIsm: () =>
+        new StarknetAggregationIsmReader(this.provider),
+      pausableIsm: () => new StarknetPausableIsmReader(this.provider),
       testIsm: () => new StarknetTestIsmReader(this.provider),
       merkleRootMultisigIsm: () =>
         new StarknetMerkleRootMultisigIsmReader(this.provider),

--- a/typescript/starknet-sdk/src/ism/ism-query.ts
+++ b/typescript/starknet-sdk/src/ism/ism-query.ts
@@ -1,6 +1,7 @@
 import { type RpcProvider } from 'starknet';
 
 import { AltVM } from '@hyperlane-xyz/provider-sdk';
+import { getContractClassHash } from '@hyperlane-xyz/starknet-core/runtime';
 import { assert } from '@hyperlane-xyz/utils';
 
 import {
@@ -16,14 +17,7 @@ import {
 
 function parseIsmVariant(variant: string): AltVM.IsmType {
   const upper = variant.toUpperCase();
-  if (
-    upper.includes('TEST') ||
-    upper.includes('NOOP') ||
-    upper.includes('NULL') ||
-    upper.includes('UNUSED')
-  ) {
-    return AltVM.IsmType.TEST_ISM;
-  }
+  if (upper === 'AGGREGATION') return AltVM.IsmType.AGGREGATION;
   if (upper.includes('MERKLE_ROOT_MULTISIG')) {
     return AltVM.IsmType.MERKLE_ROOT_MULTISIG;
   }
@@ -47,7 +41,27 @@ export async function getIsmType(
       provider,
     );
     const moduleType = await callContract(ism, 'module_type');
-    return parseIsmVariant(extractEnumVariant(moduleType));
+    const variant = extractEnumVariant(moduleType).toUpperCase();
+    if (variant === 'NULL') {
+      // NULL is shared by pausable and noop ISMs; it does not mean accept-all.
+      const pausable = getStarknetContract(
+        StarknetContractName.PAUSABLE_ISM,
+        ismAddress,
+        provider,
+      );
+      try {
+        await callContract(pausable, 'is_paused');
+        return AltVM.IsmType.PAUSABLE;
+      } catch (error) {
+        if (!isProbeMiss(error)) throw error;
+      }
+      const classHash = await provider.getClassHashAt(ismAddress);
+      return BigInt(classHash) ===
+        BigInt(getContractClassHash(StarknetContractName.NOOP_ISM))
+        ? AltVM.IsmType.TEST_ISM
+        : AltVM.IsmType.CUSTOM;
+    }
+    return parseIsmVariant(variant);
   } catch (error) {
     if (!isProbeMiss(error)) throw error;
     return AltVM.IsmType.CUSTOM;
@@ -143,4 +157,54 @@ export async function getRoutingIsmConfig(
 
 export function getNoopIsmConfig(ismAddress: string): { address: string } {
   return { address: normalizeStarknetAddressSafe(ismAddress) };
+}
+
+export async function getAggregationIsmConfig(
+  provider: RpcProvider,
+  ismAddress: string,
+): Promise<{
+  address: string;
+  modules: string[];
+  threshold: number;
+}> {
+  const ism = getStarknetContract(
+    StarknetContractName.AGGREGATION_ISM,
+    ismAddress,
+    provider,
+  );
+  const [modules, threshold] = await Promise.all([
+    callContract(ism, 'get_modules'),
+    callContract(ism, 'get_threshold'),
+  ]);
+  assert(Array.isArray(modules), 'Expected Starknet aggregation modules array');
+  return {
+    address: normalizeStarknetAddressSafe(ismAddress),
+    modules: modules.map(normalizeStarknetAddressSafe),
+    threshold: toNumber(threshold),
+  };
+}
+
+export async function getPausableIsmConfig(
+  provider: RpcProvider,
+  ismAddress: string,
+): Promise<{
+  address: string;
+  owner: string;
+  paused: boolean;
+}> {
+  const ism = getStarknetContract(
+    StarknetContractName.PAUSABLE_ISM,
+    ismAddress,
+    provider,
+  );
+  const [owner, paused] = await Promise.all([
+    callContract(ism, 'owner'),
+    callContract(ism, 'is_paused'),
+  ]);
+  assert(typeof paused === 'boolean', 'Expected Starknet paused boolean');
+  return {
+    address: normalizeStarknetAddressSafe(ismAddress),
+    owner: normalizeStarknetAddressSafe(owner),
+    paused,
+  };
 }

--- a/typescript/starknet-sdk/src/ism/ism-reader.test.ts
+++ b/typescript/starknet-sdk/src/ism/ism-reader.test.ts
@@ -1,0 +1,151 @@
+import { expect } from 'chai';
+import { RpcProvider } from 'starknet';
+
+import { AltVM, ProtocolType } from '@hyperlane-xyz/provider-sdk';
+import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import { getContractClassHash } from '@hyperlane-xyz/starknet-core/runtime';
+
+import { normalizeStarknetAddressSafe } from '../contracts.js';
+import { StarknetIsmArtifactManager } from './ism-artifact-manager.js';
+import { getIsmType } from './ism-query.js';
+
+async function rejection(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return String(error);
+  }
+  throw new Error('Expected rejection');
+}
+
+const address = normalizeStarknetAddressSafe;
+const metadata = {
+  name: 'starknet',
+  protocol: ProtocolType.Starknet,
+  chainId: 'SN_MAIN',
+  domainId: 358974494,
+  rpcUrls: [{ http: 'http://localhost:9545' }],
+};
+
+describe('Starknet ISM reading', () => {
+  // Saved only for restoring the prototype; never invoked without a receiver.
+  // oxlint-disable-next-line typescript/unbound-method
+  const originalCall = RpcProvider.prototype.callContract;
+  // oxlint-disable-next-line typescript/unbound-method
+  const originalClassHash = RpcProvider.prototype.getClassHashAt;
+  afterEach(() => {
+    RpcProvider.prototype.callContract = originalCall;
+    RpcProvider.prototype.getClassHashAt = originalClassHash;
+  });
+
+  it('reads aggregation modules and threshold instead of reporting testIsm', async () => {
+    RpcProvider.prototype.callContract = async (call) => {
+      switch (call.entrypoint) {
+        case 'module_type':
+          return ['0x2', '0x1'];
+        case 'get_modules':
+          return ['0x2', '0x2', '0x3'];
+        case 'get_threshold':
+          return ['0x2'];
+        default:
+          throw new Error(`Unexpected call ${call.entrypoint}`);
+      }
+    };
+    const result = await new StarknetIsmArtifactManager(metadata).readIsm(
+      '0x1',
+    );
+    expect(result).to.deep.equal({
+      artifactState: ArtifactState.DEPLOYED,
+      config: {
+        type: 'staticAggregationIsm',
+        threshold: 2,
+        modules: ['0x2', '0x3'].map((a) => ({
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: address(a) },
+        })),
+      },
+      deployed: { address: address('0x1') },
+    });
+  });
+
+  for (const paused of [false, true]) {
+    it(`reads NULL pausable ISM with paused=${paused}`, async () => {
+      RpcProvider.prototype.callContract = async (call) => {
+        switch (call.entrypoint) {
+          case 'module_type':
+            return ['0x6'];
+          case 'is_paused':
+            return [paused ? '0x1' : '0x0'];
+          case 'owner':
+            return ['0x123'];
+          default:
+            throw new Error(`Unexpected call ${call.entrypoint}`);
+        }
+      };
+      expect(
+        await new StarknetIsmArtifactManager(metadata).readIsm('0x3'),
+      ).to.deep.equal({
+        artifactState: ArtifactState.DEPLOYED,
+        config: { type: 'pausableIsm', owner: address('0x123'), paused },
+        deployed: { address: address('0x3') },
+      });
+    });
+  }
+
+  it('recognizes the published noop class and rejects other NULL modules', async () => {
+    RpcProvider.prototype.callContract = async (call) => {
+      if (call.entrypoint === 'module_type') return ['0x6'];
+      throw new Error('Entry point not found in contract');
+    };
+    RpcProvider.prototype.getClassHashAt = async () =>
+      getContractClassHash('noop_ism');
+    const manager = new StarknetIsmArtifactManager(metadata);
+    expect((await manager.readIsm('0x4')).config.type).to.equal('testIsm');
+    RpcProvider.prototype.getClassHashAt = async () => '0x1234';
+    expect(await rejection(manager.readIsm('0x4'))).to.match(
+      /Unsupported Starknet ISM/,
+    );
+    expect(
+      await rejection(manager.createReader('testIsm').read('0x4')),
+    ).to.match(/Expected a verified Starknet noop/);
+  });
+
+  it('rejects unsupported module types rather than fabricating a testIsm', async () => {
+    RpcProvider.prototype.callContract = async () => ['0x7', '0x123'];
+    expect(
+      await rejection(new StarknetIsmArtifactManager(metadata).readIsm('0x4')),
+    ).to.match(/Unsupported Starknet ISM/);
+  });
+
+  it('propagates RPC failures while probing a NULL module', async () => {
+    RpcProvider.prototype.callContract = async (call) => {
+      if (call.entrypoint === 'module_type') return ['0x6'];
+      throw new Error('RPC unavailable');
+    };
+    expect(
+      await rejection(
+        getIsmType(
+          new RpcProvider({ nodeUrl: 'http://localhost:9545' }),
+          '0x4',
+        ),
+      ),
+    ).to.match(/RPC unavailable/);
+  });
+
+  it('continues to recognize routing and multisig module types', async () => {
+    for (const [discriminant, expected] of [
+      ['0x1', AltVM.IsmType.ROUTING],
+      ['0x4', AltVM.IsmType.MERKLE_ROOT_MULTISIG],
+      ['0x5', AltVM.IsmType.MESSAGE_ID_MULTISIG],
+    ] as const) {
+      RpcProvider.prototype.callContract = async () => [discriminant, '0x1'];
+      expect(
+        await getIsmType(
+          new RpcProvider({ nodeUrl: 'http://localhost:9545' }),
+          '0x1',
+        ),
+      ).to.equal(expected);
+      RpcProvider.prototype.callContract = originalCall;
+    }
+  });
+});

--- a/typescript/starknet-sdk/src/ism/test-ism-artifact-manager.ts
+++ b/typescript/starknet-sdk/src/ism/test-ism-artifact-manager.ts
@@ -18,7 +18,7 @@ import { assert } from '@hyperlane-xyz/utils';
 
 import { StarknetProvider } from '../clients/provider.js';
 import { StarknetSigner } from '../clients/signer.js';
-import { getNoopIsmConfig } from './ism-query.js';
+import { getIsmType, getNoopIsmConfig } from './ism-query.js';
 import { getCreateNoopIsmTx } from './ism-tx.js';
 
 export class StarknetTestIsmReader implements ArtifactReader<
@@ -32,6 +32,11 @@ export class StarknetTestIsmReader implements ArtifactReader<
   ): Promise<
     ArtifactDeployed<RawIsmArtifactConfigs['testIsm'], DeployedIsmAddress>
   > {
+    assert(
+      (await getIsmType(this.provider.getRawProvider(), address)) ===
+        AltVM.IsmType.TEST_ISM,
+      `Expected a verified Starknet noop ISM at ${address}`,
+    );
     const noop = getNoopIsmConfig(address);
     return {
       artifactState: ArtifactState.DEPLOYED,


### PR DESCRIPTION
### Description

`hyperlane core read --chain starknet` reported the mainnet mailbox's aggregation ISM as `testIsm`: aggregation was classified as `CUSTOM`, then silently passed to the TestISM reader. The reader now expands aggregation modules recursively and reports the routing tree and pausable ISM, including its owner and pause state.

NULL modules are distinguished by probing pausable state or verifying the published noop class hash. Unsupported modules fail explicitly instead of being labeled accept-all. Shared artifact types and conversions support these reads; aggregation/pausable deployment and updates remain unsupported and fail explicitly.

### Drive-by changes

None.

### Related issues

Discovered while validating the validator rotation in #9317.

### Backward compatibility

Existing routing and multisig reads retain their behavior. Unknown ISMs that previously produced an incorrect `testIsm` config now return an error. No on-chain changes are required.

### Testing

- Ran the exact CLI core-read command against Starknet mainnet using the local HTTP registry. Confirmed the default ISM is a 2-of-2 aggregation with all 138 routing domains expanded and an unpaused pausable module; no `testIsm` labels remain.
- Provider SDK: 173 tests passed. Starknet SDK: 58 tests passed, including seven new classification/read regressions.
- Deploy SDK: 108 tests passed, including four new aggregation expansion/conversion regressions. Its existing Sealevel `AltVMFileSubmitter` test failed (expected two instructions, received zero); the package's full build also reports its unrelated `AnnotatedSvmTransaction.version` type error. Production-source compilation passed with tests excluded.
- CLI type-check, provider/Starknet builds, lint, formatting, and pre-commit hooks passed.
