### PR TITLE
chore(infra): update scraper proxy image tags

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: 'fc544bf-20260908-174702',
   warpMonitor: 'fc544bf-20260908-174702',
   rebalancer: 'fc544bf-20260908-174702',
-  scraperProxy: 'fc544bf-20260908-174702',
+  scraperProxy: '7762855-20260911-015136',
   feeQuoting: '12d899d-20260325-184337',
 };
 
@@ -72,5 +72,5 @@ export const testnetDockerTags: BaseDockerTags = {
   scraper: 'b83bac5-20260909-225045',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
-  scraperProxy: 'fc544bf-20260908-174702',
+  scraperProxy: '7762855-20260911-015136',
 };


### PR DESCRIPTION
## Problem

The testnet4 and mainnet3 scraper proxies now run the latest successful `main` image, but the infra defaults still reference the previous tag and would revert either deployment.

## Change

Update both scraper-proxy tags to `7762855-20260911-015136` (`sha256:8be176fb4774d428b2bd101e6c6641d27a57a312b949a3a2f458e173fe56448e`).

## Validation

- Commit hooks: gitleaks, oxlint, oxfmt
- `git diff --check`
- testnet4: deployment Ready, 1/1 updated, zero pod restarts
- mainnet3: deployment Ready, 1/1 updated, zero pod restarts; listener ready and no post-rollout send, database, or GraphQL errors
