### PR TITLE
fix(infra): lower USDC subtensor rebalancer targets

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
@@ -5,7 +5,7 @@ strategy:
     base:
       minAmount:
         min: 5000
-        target: 11250
+        target: 8750
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
@@ -23,7 +23,7 @@ strategy:
     polygon:
       minAmount:
         min: 5000
-        target: 11250
+        target: 8750
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
@@ -32,7 +32,7 @@ strategy:
     arbitrum:
       minAmount:
         min: 5000
-        target: 11250
+        target: 8750
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
@@ -41,7 +41,7 @@ strategy:
     unichain:
       minAmount:
         min: 5000
-        target: 11250
+        target: 8750
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000


### PR DESCRIPTION
## Summary

- lower the Base, Polygon, Arbitrum, and Unichain targets from 11,250 to 8,750 USDC
- keep the existing 5,000 USDC minimums and Ethereum's 45,000 USDC minimum/target unchanged
- reduce the aggregate target from 90,000 to 80,000 USDC

## Why

The rebalancer could not restart once configured targets exceeded current collateral. Collateral across the configured legs fell from 90,995.999697 to 89,211.999698 USDC over the preceding 48 hours, so the old 90,000 target had effectively no operating buffer.

The new total leaves 9,211.999698 USDC (10.3%) of aggregate buffer at the incident balance while preserving each chain's existing floor. Each spoke still refills 3,750 USDC above its floor.

## Validation

- pre-commit YAML sort, formatting, and gitleaks hooks passed
- server-side Helm dry-run rendered the expected 80,000 USDC target total
- deployed mainnet3 Helm revision 13 with the existing image and registry pin
- replacement pod is Ready with zero restarts on image digest `sha256:8d4752c03cfc79ddc47830d0b8a99a782299a80f33a7e72f5253165c9ea0c31c`
- strategy initialized and completed two consecutive production polling cycles with no runtime errors
