### PR TITLE
fix(infra): persist PushGateway metrics across restarts

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -52,7 +52,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   scraper: 'b83bac5-20260909-225045',
   // monorepo services
   checkWarpDeploy: 'main',
-  validatorMonitor: '2c47a33-20260724-134609',
+  validatorMonitor: 'cfd4cae-20260911-102750',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
   warpMonitor: 'fc544bf-20260908-174702',

--- a/typescript/infra/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/infra/src/infrastructure/monitoring/prometheus.ts
@@ -107,6 +107,8 @@ async function getPrometheusConfig(
                 'prometheus_remote_storage_samples_failed_total',
                 'prometheus_remote_storage_samples_pending',
                 'prometheus_remote_storage_samples_total',
+                // PushGateway job freshness
+                'push_time_seconds',
                 // Application metrics
                 'ethereum.*',
                 'hyperlane.*',
@@ -130,7 +132,29 @@ async function getPrometheusConfig(
       resources: {
         requests: {
           cpu: '200m',
-          memory: '3Gi',
+          memory: '8Gi',
+        },
+        limits: {
+          memory: '12Gi',
+        },
+      },
+    },
+    'prometheus-pushgateway': {
+      extraArgs: [
+        '--persistence.file=/data/pushgateway.data',
+        '--persistence.interval=5m',
+      ],
+      persistentVolume: {
+        enabled: true,
+        size: '2Gi',
+      },
+      resources: {
+        requests: {
+          cpu: '50m',
+          memory: '64Mi',
+        },
+        limits: {
+          memory: '128Mi',
         },
       },
     },


### PR DESCRIPTION
## Summary

- persist PushGateway metrics on a 2 GiB PVC with five-minute snapshots
- size PushGateway and Prometheus memory from observed production usage
- export `push_time_seconds` so the validator-monitor heartbeat can measure freshness instead of retained-series presence
- roll validator-monitor to `cfd4cae-20260911-102750` (`sha256:555f04b673834bd522cf88a8119484d4555e1391a05f55717fda9a45044896ad`)

## Why

GKE evicted PushGateway at 09:51:44Z on 2026-09-11. The pod restarted seven seconds later, but its `emptyDir` had lost all 376 validator series. They returned only when the next validator-monitor run completed at 10:08:10Z, which fired the NoData heartbeat despite validators remaining healthy.

Persistence fixes that restart failure mode. The current count-based heartbeat would then retain stale data indefinitely, so this also sends PushGateway's existing `push_time_seconds` metric to Grafana for a real freshness check.

## Validation

- `pnpm turbo run build --filter=@hyperlane-xyz/infra`
- `pnpm exec oxlint -c oxlint.json typescript/infra/config/docker.ts typescript/infra/src/infrastructure/monitoring/prometheus.ts`
- rendered Helm diff against live release values
- full rendered manifest accepted by `kubectl apply --dry-run=server`
- monorepo image build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/34589316575
- PR CI passed at exact head `fd2b550c85d1367947524ebfe86953ab2a20238a`

## Rollout

- [x] deployed monitoring Helm revision 11
- [x] deployed validator-monitor Helm revision 4
- [x] ran the 11:00 UTC scheduled job on digest `sha256:555f04b673834bd522cf88a8119484d4555e1391a05f55717fda9a45044896ad`; exit 0, zero restarts
- [x] replaced the PushGateway pod and verified all 306 current validator series plus the original push timestamp survived on the PVC
- [x] changed Grafana heartbeat `cftdzc94e3fnkf` to alert after push freshness exceeds 60 minutes for 15 minutes
- [x] verified the scheduled push at 11:06:45 UTC reached Prometheus and Grafana evaluated the heartbeat Normal/health OK at 11:08:10 UTC

During the validator-monitor Helm upgrade, the release-owned generated Secret was deleted before ExternalSecret refreshed it. Recreating the ExternalSecret restored the 78-key target Secret; the new-image seed job then completed normally. This was a rollout-path issue, not part of the checkpoint heartbeat failure.
