### PR TITLE
fix(solidity): prevent message ID hook replay

### DIFF
--- a/.changeset/tough-hooks-replay.md
+++ b/.changeset/tough-hooks-replay.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+Newly deployed message ID authentication hooks were protected against repeated post-dispatch bridge authorizations for the Mailbox's latest message.

--- a/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
+++ b/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
@@ -22,6 +22,7 @@ import {MailboxClient} from "../../client/MailboxClient.sol";
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 
 /**
  * @title AbstractMessageIdAuthHook
@@ -42,6 +43,23 @@ abstract contract AbstractMessageIdAuthHook is
     bytes32 public immutable ism;
     // Domain of chain on which the ISM is deployed
     uint32 public immutable destinationDomain;
+
+    // ============ Storage ============
+
+    // `_isLatestDispatched` limits the replay window to the Mailbox's current
+    // latest message ID. Once the Mailbox dispatches another message, the
+    // previous ID can no longer pass that check. The checked Mailbox nonce also
+    // makes every successive latest ID unique, so storing only the latest
+    // successfully consumed ID prevents replay without an unbounded mapping.
+    // Unstructured storage preserves external inheritor layouts.
+    bytes32 private constant LAST_PROCESSED_MESSAGE_ID_SLOT =
+        bytes32(
+            uint256(
+                keccak256(
+                    "hyperlane.storage.AbstractMessageIdAuthHook.lastProcessedMessageId"
+                )
+            ) - 1
+        );
 
     // ============ Constructor ============
 
@@ -86,10 +104,8 @@ abstract contract AbstractMessageIdAuthHook is
         bytes calldata message
     ) internal virtual override {
         bytes32 id = message.id();
-        require(
-            _isLatestDispatched(id),
-            "AbstractMessageIdAuthHook: message not latest dispatched"
-        );
+
+        _validateAndConsumeMessageId(id);
         require(
             message.destination() == destinationDomain,
             "AbstractMessageIdAuthHook: invalid destination domain"
@@ -102,6 +118,24 @@ abstract contract AbstractMessageIdAuthHook is
         _sendMessageId(metadata, message);
 
         _refund(metadata, message, address(this).balance);
+    }
+
+    /// @dev Validates that the message is the Mailbox's latest dispatch and
+    /// records it as consumed before the external bridge interaction.
+    function _validateAndConsumeMessageId(bytes32 id) internal {
+        require(
+            _isLatestDispatched(id),
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        bytes32 lastProcessedMessageId = StorageSlot
+            .getBytes32Slot(LAST_PROCESSED_MESSAGE_ID_SLOT)
+            .value;
+        require(
+            id != lastProcessedMessageId,
+            "AbstractMessageIdAuthHook: message already processed"
+        );
+
+        StorageSlot.getBytes32Slot(LAST_PROCESSED_MESSAGE_ID_SLOT).value = id;
     }
 
     /**

--- a/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
+++ b/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
@@ -104,8 +104,19 @@ abstract contract AbstractMessageIdAuthHook is
         bytes calldata message
     ) internal virtual override {
         bytes32 id = message.id();
+        require(
+            _isLatestDispatched(id),
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        bytes32 lastProcessedMessageId = StorageSlot
+            .getBytes32Slot(LAST_PROCESSED_MESSAGE_ID_SLOT)
+            .value;
+        require(
+            id != lastProcessedMessageId,
+            "AbstractMessageIdAuthHook: message already processed"
+        );
+        StorageSlot.getBytes32Slot(LAST_PROCESSED_MESSAGE_ID_SLOT).value = id;
 
-        _validateAndConsumeMessageId(id);
         require(
             message.destination() == destinationDomain,
             "AbstractMessageIdAuthHook: invalid destination domain"
@@ -118,24 +129,6 @@ abstract contract AbstractMessageIdAuthHook is
         _sendMessageId(metadata, message);
 
         _refund(metadata, message, address(this).balance);
-    }
-
-    /// @dev Validates that the message is the Mailbox's latest dispatch and
-    /// records it as consumed before the external bridge interaction.
-    function _validateAndConsumeMessageId(bytes32 id) internal {
-        require(
-            _isLatestDispatched(id),
-            "AbstractMessageIdAuthHook: message not latest dispatched"
-        );
-        bytes32 lastProcessedMessageId = StorageSlot
-            .getBytes32Slot(LAST_PROCESSED_MESSAGE_ID_SLOT)
-            .value;
-        require(
-            id != lastProcessedMessageId,
-            "AbstractMessageIdAuthHook: message already processed"
-        );
-
-        StorageSlot.getBytes32Slot(LAST_PROCESSED_MESSAGE_ID_SLOT).value = id;
     }
 
     /**

--- a/solidity/test/hooks/OPL2ToL1Hook.t.sol
+++ b/solidity/test/hooks/OPL2ToL1Hook.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {OPL2ToL1Hook} from "../../contracts/hooks/OPL2ToL1Hook.sol";
+import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
+import {ICrossDomainMessenger} from "../../contracts/interfaces/optimism/ICrossDomainMessenger.sol";
+import {AbstractMessageIdAuthorizedIsm} from "../../contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {MockOptimismMessenger} from "../../contracts/mock/MockOptimism.sol";
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
+import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
+
+contract OPL2ToL1HookTest is Test {
+    using TypeCasts for address;
+
+    uint32 internal constant ORIGIN_DOMAIN = 10;
+    uint32 internal constant DESTINATION_DOMAIN = 1;
+    uint256 internal constant MSG_VALUE = 1 ether;
+
+    TestMailbox internal mailbox;
+    MockOptimismMessenger internal messenger;
+    TestPostDispatchHook internal childHook;
+    OPL2ToL1Hook internal hook;
+    bytes internal message;
+    bool internal reenterOnRefund;
+    bool internal replayBlocked;
+
+    function setUp() public {
+        mailbox = new TestMailbox(ORIGIN_DOMAIN);
+        messenger = new MockOptimismMessenger();
+        childHook = new TestPostDispatchHook();
+        hook = new OPL2ToL1Hook(
+            address(mailbox),
+            DESTINATION_DOMAIN,
+            address(0xBEEF).addressToBytes32(),
+            address(messenger),
+            address(childHook)
+        );
+        message = mailbox.buildOutboundMessage(
+            DESTINATION_DOMAIN,
+            address(new TestRecipient()).addressToBytes32(),
+            "test"
+        );
+    }
+
+    function test_postDispatch_revertWhen_valueMessageReplayedWithoutValue()
+        public
+    {
+        bytes memory metadata = StandardHookMetadata.formatMetadata(
+            MSG_VALUE,
+            0,
+            address(this),
+            ""
+        );
+        bytes32 messageId = Message.id(message);
+        bytes memory payload = abi.encodeCall(
+            AbstractMessageIdAuthorizedIsm.preVerifyMessage,
+            (messageId, MSG_VALUE)
+        );
+        mailbox.updateLatestDispatchedId(messageId);
+        vm.deal(address(this), MSG_VALUE);
+        vm.expectCall(
+            address(messenger),
+            MSG_VALUE,
+            abi.encodeCall(
+                ICrossDomainMessenger.sendMessage,
+                (address(0xBEEF), payload, hook.MIN_GAS_LIMIT())
+            )
+        );
+
+        hook.postDispatch{value: MSG_VALUE}(metadata, message);
+
+        assertTrue(childHook.messageDispatched(messageId));
+        assertEq(address(messenger).balance, MSG_VALUE);
+
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
+        hook.postDispatch("", message);
+        assertEq(address(messenger).balance, MSG_VALUE);
+    }
+
+    function test_postDispatch_allowsNextMessage() public {
+        bytes32 messageId = Message.id(message);
+        mailbox.updateLatestDispatchedId(messageId);
+        hook.postDispatch("", message);
+
+        bytes memory nextMessage = mailbox.buildOutboundMessage(
+            DESTINATION_DOMAIN,
+            address(new TestRecipient()).addressToBytes32(),
+            "next message"
+        );
+        bytes32 nextMessageId = Message.id(nextMessage);
+        mailbox.updateLatestDispatchedId(nextMessageId);
+        hook.postDispatch("", nextMessage);
+
+        assertTrue(childHook.messageDispatched(messageId));
+        assertTrue(childHook.messageDispatched(nextMessageId));
+    }
+
+    function test_postDispatch_blocksReentrantReplayFromRefund() public {
+        bytes memory metadata = StandardHookMetadata.formatMetadata(
+            MSG_VALUE,
+            0,
+            address(this),
+            ""
+        );
+        bytes32 messageId = Message.id(message);
+        mailbox.updateLatestDispatchedId(messageId);
+        vm.deal(address(this), MSG_VALUE + 1);
+        reenterOnRefund = true;
+
+        hook.postDispatch{value: MSG_VALUE + 1}(metadata, message);
+
+        assertTrue(replayBlocked);
+        assertEq(address(messenger).balance, MSG_VALUE);
+    }
+
+    function test_postDispatch_allowsRetryAfterBridgeRevert() public {
+        bytes memory callData = abi.encodeWithSelector(
+            ICrossDomainMessenger.sendMessage.selector
+        );
+        mailbox.updateLatestDispatchedId(Message.id(message));
+        vm.mockCallRevert(address(messenger), callData, "bridge unavailable");
+
+        vm.expectRevert("bridge unavailable");
+        hook.postDispatch("", message);
+
+        vm.clearMockedCalls();
+        hook.postDispatch("", message);
+    }
+
+    receive() external payable {
+        if (!reenterOnRefund) return;
+        reenterOnRefund = false;
+
+        try hook.postDispatch("", message) {
+            revert("replay succeeded");
+        } catch Error(string memory reason) {
+            assertEq(
+                reason,
+                "AbstractMessageIdAuthHook: message already processed"
+            );
+            replayBlocked = true;
+        }
+    }
+}

--- a/solidity/test/hooks/OPL2ToL1HookFork.t.sol
+++ b/solidity/test/hooks/OPL2ToL1HookFork.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {OPL2ToL1Hook} from "../../contracts/hooks/OPL2ToL1Hook.sol";
+import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
+import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
+
+contract OPL2ToL1HookForkTest is Test {
+    using TypeCasts for address;
+
+    uint32 internal constant OPTIMISM_DOMAIN = 10;
+    uint32 internal constant MAINNET_DOMAIN = 1;
+    uint256 internal constant FORK_BLOCK = 124_000_000;
+    uint256 internal constant MSG_VALUE = 1 ether;
+
+    address internal constant L2_MESSENGER_ADDRESS =
+        0x4200000000000000000000000000000000000007;
+
+    TestMailbox internal mailbox;
+    OPL2ToL1Hook internal hook;
+    bytes internal message;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("optimism"), FORK_BLOCK);
+
+        mailbox = new TestMailbox(OPTIMISM_DOMAIN);
+        hook = new OPL2ToL1Hook(
+            address(mailbox),
+            MAINNET_DOMAIN,
+            address(0xBEEF).addressToBytes32(),
+            L2_MESSENGER_ADDRESS,
+            address(new TestPostDispatchHook())
+        );
+        message = mailbox.buildOutboundMessage(
+            MAINNET_DOMAIN,
+            address(new TestRecipient()).addressToBytes32(),
+            "test"
+        );
+    }
+
+    function testFork_postDispatch_revertWhen_valueMessageReplayedWithoutValue()
+        public
+    {
+        bytes memory metadata = StandardHookMetadata.overrideMsgValue(
+            MSG_VALUE
+        );
+        mailbox.updateLatestDispatchedId(Message.id(message));
+        vm.deal(address(this), MSG_VALUE);
+
+        hook.postDispatch{value: MSG_VALUE}(metadata, message);
+
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
+        hook.postDispatch("", message);
+    }
+}

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -76,6 +76,32 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         hook.postDispatch{value: quote}(igpMetadata, encodedMessage);
     }
 
+    function test_postDispatch_revertWhen_valueMessageReplayedWithoutValue()
+        public
+    {
+        bytes memory metadata = StandardHookMetadata.overrideMsgValue(
+            MSG_VALUE
+        );
+        originMailbox.updateLatestDispatchedId(messageId);
+        vm.expectCall(
+            L2_ARBSYS_ADDRESS,
+            MSG_VALUE,
+            abi.encodeCall(
+                MockArbSys.sendTxToL1,
+                (address(ism), _encodeHookData(messageId, MSG_VALUE))
+            )
+        );
+
+        uint256 quote = hook.quoteDispatch(metadata, encodedMessage);
+        vm.deal(address(this), quote);
+        hook.postDispatch{value: quote}(metadata, encodedMessage);
+
+        uint256 replayQuote = hook.quoteDispatch("", encodedMessage);
+        vm.deal(address(this), replayQuote);
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
+        hook.postDispatch{value: replayQuote}("", encodedMessage);
+    }
+
     /* ============ helper functions ============ */
 
     function _expectOriginExternalBridgeCall(

--- a/solidity/test/isms/CCIPIsm.t.sol
+++ b/solidity/test/isms/CCIPIsm.t.sol
@@ -166,6 +166,29 @@ contract CCIPIsmTest is Test {
         );
     }
 
+    function testFork_postDispatch_RevertWhen_Replayed() public {
+        deployAll();
+
+        vm.selectFork(mainnetFork);
+        l1Mailbox.updateLatestDispatchedId(messageId);
+        uint256 quotedFee = ccipHookMainnet.quoteDispatch(
+            testMetadata,
+            encodedMessage
+        );
+        vm.deal(address(this), quotedFee * 2);
+
+        ccipHookMainnet.postDispatch{value: quotedFee}(
+            testMetadata,
+            encodedMessage
+        );
+
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
+        ccipHookMainnet.postDispatch{value: quotedFee}(
+            testMetadata,
+            encodedMessage
+        );
+    }
+
     function testFork_postDispatch_RevertWhen_NotEnoughValueSent() public {
         deployAll();
 

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -101,6 +101,67 @@ abstract contract ExternalBridgeTest is Test {
         hook.postDispatch{value: quote}(testMetadata, encodedMessage);
     }
 
+    function test_postDispatch_revertWhen_replayedWithDifferentMsgValue()
+        public
+    {
+        bytes memory encodedHookData = _encodeHookData(messageId, 0);
+        originMailbox.updateLatestDispatchedId(messageId);
+        _expectOriginExternalBridgeCall(encodedHookData);
+
+        uint256 quote = hook.quoteDispatch(testMetadata, encodedMessage);
+        hook.postDispatch{value: quote}(testMetadata, encodedMessage);
+
+        bytes memory replayMetadata = StandardHookMetadata.overrideMsgValue(
+            MSG_VALUE
+        );
+        uint256 replayQuote = hook.quoteDispatch(
+            replayMetadata,
+            encodedMessage
+        );
+        vm.deal(address(this), replayQuote);
+
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
+        hook.postDispatch{value: replayQuote}(replayMetadata, encodedMessage);
+    }
+
+    function test_postDispatch_revertWhen_replayedInLaterBlock() public {
+        bytes memory encodedHookData = _encodeHookData(messageId, 0);
+        originMailbox.updateLatestDispatchedId(messageId);
+        _expectOriginExternalBridgeCall(encodedHookData);
+
+        uint256 quote = hook.quoteDispatch(testMetadata, encodedMessage);
+        hook.postDispatch{value: quote}(testMetadata, encodedMessage);
+
+        vm.roll(block.number + 1);
+
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
+        hook.postDispatch{value: quote}(testMetadata, encodedMessage);
+    }
+
+    function test_postDispatch_allowsNextMessage() public {
+        originMailbox.updateLatestDispatchedId(messageId);
+        _expectOriginExternalBridgeCall(_encodeHookData(messageId, 0));
+        uint256 quote = hook.quoteDispatch(testMetadata, encodedMessage);
+        hook.postDispatch{value: quote}(testMetadata, encodedMessage);
+
+        bytes memory nextMessage = originMailbox.buildOutboundMessage(
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(testRecipient)),
+            "next message"
+        );
+        bytes32 nextMessageId = Message.id(nextMessage);
+        originMailbox.updateLatestDispatchedId(nextMessageId);
+        _expectOriginExternalBridgeCall(_encodeHookData(nextMessageId, 0));
+
+        quote = hook.quoteDispatch(testMetadata, nextMessage);
+        hook.postDispatch{value: quote}(testMetadata, nextMessage);
+
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        hook.postDispatch{value: quote}(testMetadata, encodedMessage);
+    }
+
     function test_postDispatch_revertWhen_chainIDNotSupported() public {
         bytes memory message = originMailbox.buildOutboundMessage(
             3,


### PR DESCRIPTION
### Description

Adds replay protection to `AbstractMessageIdAuthHook`.

The hook now validates and consumes the Mailbox's latest dispatched message ID before performing further validation or external bridge interactions. This prevents repeated `postDispatch` calls for the same message, including calls with altered metadata or `msg.value`, in the same block or later blocks.

Only the latest successfully consumed message ID is stored because older messages already fail `_isLatestDispatched`. Unstructured storage preserves inheritor storage layouts.

Adds regression coverage for Arb, OP Stack, ERC-5164, and CCIP hooks, including reentrancy, reverted bridge calls, subsequent messages, and live fork behavior.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. No public interface changes were made, and the new state uses an unstructured storage slot.

Existing deployed hooks do not gain replay protection automatically and require redeployment or upgrade. Duplicate successful `postDispatch` calls for the same latest message now revert as intended.

### Testing

Unit tests:

- Arb L2-to-L1 ISM: 28 passed
- OP Stack ISM: 27 passed
- ERC-5164 ISM: 29 passed
- OP L2-to-L1 hook: 4 passed

Fork tests:

- CCIP: 12 passed
- OP L2-to-L1: 1 passed

Prettier, Solhint, changeset validation, secret scanning, and pre-commit hooks passed.
