### PR TITLE
feat(rebalancer): per-route swaps.xyz API key for oUSDT

### DIFF
--- a/.changeset/debridge-inventory-bridge.md
+++ b/.changeset/debridge-inventory-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Added the deBridge DLN inventory adapter for Ethereum, BSC, Arbitrum, Plasma, Tron, and Solana. Quotes and execution responses were validated before exact token approvals, and persisted order IDs were used for status tracking.

--- a/.changeset/rebalancer-mcr-token-fe-approval.md
+++ b/.changeset/rebalancer-mcr-token-fe-approval.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+The movable-collateral rebalancer was updated to approve exact collateral-token bridge fees and revoke unused allowance after each batch.

--- a/.changeset/rebalancer-oft-settlement.md
+++ b/.changeset/rebalancer-oft-settlement.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Movable-collateral routes gained configurable settlement adapters. LayerZero OFT transfers were tracked by their exact GUID and confirmed against the finalized destination receipt, recipient, and amount, while source-committed failures remained suppressed for the running process and existing routes retained Hyperlane message delivery by default.

--- a/.changeset/rebalancer-route-controls.md
+++ b/.changeset/rebalancer-route-controls.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Config-driven route exclusions were added so unsupported chain pairs are not proposed for execution.

--- a/.changeset/rebalancer-source-action-tracking.md
+++ b/.changeset/rebalancer-source-action-tracking.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Source-started rebalance actions were recorded in memory before broadcast to suppress duplicate execution within a running process.

--- a/.changeset/rebalancer-tron-strategy-signer.md
+++ b/.changeset/rebalancer-tron-strategy-signer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Tron strategy chains were configured with a Tron signer so movable-collateral transactions can be broadcast through their configured RPC endpoint.

--- a/.changeset/rebalancer-xerc20-lockbox.md
+++ b/.changeset/rebalancer-xerc20-lockbox.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Added xERC20 and VS xERC20 lockbox collateral support, including wrapped token resolution for external bridge inventory transfers.

--- a/.changeset/safe-external-bridge-lifecycle.md
+++ b/.changeset/safe-external-bridge-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+External bridge execution was made safer by preserving provider transfer identifiers and standardizing exact ERC20 approvals with typed receipt timeouts.

--- a/.changeset/swapsxyz-external-bridge.md
+++ b/.changeset/swapsxyz-external-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+An EVM swaps.xyz external bridge was added with strict response, quote-loss, signer, transaction, and settlement-status validation.

--- a/.changeset/swapsxyz-external-bridge.md
+++ b/.changeset/swapsxyz-external-bridge.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/rebalancer': minor
 ---
 
-An EVM swaps.xyz external bridge was added with strict response, quote-loss, signer, transaction, and settlement-status validation.
+An EVM and Tron swaps.xyz external bridge was added with strict response, quote-loss, signer, transaction, and settlement-status validation.

--- a/.changeset/swapsxyz-solana-execution.md
+++ b/.changeset/swapsxyz-solana-execution.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Solana-source swaps.xyz execution was added with simulated wallet effects bound to the accepted quote.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1982,6 +1982,9 @@ importers:
       '@lifi/sdk':
         specifier: 'catalog:'
         version: 3.16.3(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@18.3.27)(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.55.10(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      '@solana/spl-token':
+        specifier: 'catalog:'
+        version: 0.4.15(@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: 'catalog:'
         version: 1.98.4(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2009,6 +2009,9 @@ importers:
       prom-client:
         specifier: 'catalog:'
         version: 14.2.0
+      tronweb:
+        specifier: 'catalog:'
+        version: 6.4.0(bufferutil@4.0.9)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(utf-8-validate@5.0.10)
       uuid:
         specifier: 'catalog:'
         version: 10.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1967,6 +1967,9 @@ importers:
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@hyperlane-xyz/tron-sdk':
+        specifier: workspace:*
+        version: link:../tron-sdk
       '@hyperlane-xyz/utils':
         specifier: workspace:*
         version: link:../utils

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -56,7 +56,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // standalone services
   keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
-  rebalancer: 'da26d9a-20260703-122943',
+  rebalancer: 'e9d67ae-20260828-115602',
   scraperProxy: '220f01c-20260827-145329',
   feeQuoting: '12d899d-20260325-184337',
 };

--- a/typescript/infra/config/environments/mainnet3/rebalancer/oUSDT/production-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/oUSDT/production-config.yaml
@@ -1,0 +1,75 @@
+warpRouteId: oUSDT/production
+
+# In-progress actions are intentionally process-local. Keep them suppressed for
+# two weeks while the process is running; a restart clears the action tracker.
+intentTTL: 1209600
+
+inventorySigners:
+  ethereum: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
+  tron: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
+
+externalBridges:
+  lifi:
+    integrator: rebalancer
+  swapsxyz:
+    defaultSlippage: 0.005
+    maxQuoteLossBps: 250
+
+strategy:
+  rebalanceStrategy: minAmount
+  chains:
+    arbitrum:
+      executionType: inventory
+      externalBridge: swapsxyz
+      minAmount:
+        min: 1000
+        target: 3000
+        type: absolute
+      override:
+        celo:
+          externalBridge: lifi
+        tron:
+          executionType: movableCollateral
+          bridge: '0x9323793FB9a071ce5fE839079925c0e39f37170F'
+          bridgeMinAcceptedAmount: 1000
+          statusAdapter:
+            kind: lz_scan
+            sourceEid: 30110
+            destinationEid: 30420
+            sourceOft: '0x77652D5aba086137b595875263FC200182919B92'
+            destinationOft: '0x3a08f76772e200653bb55c2a92998daca62e0e97'
+    celo:
+      executionType: inventory
+      externalBridge: swapsxyz
+      minAmount:
+        min: 1000
+        target: 3000
+        type: absolute
+    ethereum:
+      executionType: inventory
+      externalBridge: swapsxyz
+      minAmount:
+        min: 750000
+        target: 760000
+        type: absolute
+      override:
+        celo:
+          externalBridge: lifi
+    tron:
+      executionType: inventory
+      externalBridge: swapsxyz
+      minAmount:
+        min: 1000
+        target: 3000
+        type: absolute
+      override:
+        arbitrum:
+          executionType: movableCollateral
+          bridge: '0x43Bb7C9C64a05af94d67B52883a60756950058D7'
+          bridgeMinAcceptedAmount: 1000
+          statusAdapter:
+            kind: lz_scan
+            sourceEid: 30420
+            destinationEid: 30110
+            sourceOft: '0x3a08f76772e200653bb55c2a92998daca62e0e97'
+            destinationOft: '0x77652D5aba086137b595875263FC200182919B92'

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -96,6 +96,10 @@ The rebalancer container
     value: $(HYP_INVENTORY_KEY)
   - name: HYP_INVENTORY_KEY_ETHEREUM
     value: $(HYP_INVENTORY_KEY_ETHEREUM)
+  {{- if has "tron" .Values.hyperlane.inventorySignerProtocols }}
+  - name: HYP_INVENTORY_KEY_TRON
+    value: $(HYP_INVENTORY_KEY_TRON)
+  {{- end }}
   {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
   - name: HYP_INVENTORY_KEY_SEALEVEL
     value: $(HYP_INVENTORY_KEY_SEALEVEL)

--- a/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
@@ -25,6 +25,9 @@ spec:
         HYP_REBALANCER_KEY: {{ print "'{{ $json := .rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
         HYP_INVENTORY_KEY: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
         HYP_INVENTORY_KEY_ETHEREUM: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
+        {{- if has "tron" .Values.hyperlane.inventorySignerProtocols }}
+        HYP_INVENTORY_KEY_TRON: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
+        {{- end }}
         {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
         HYP_INVENTORY_KEY_SEALEVEL: {{ print "'{{ $json := .inventory_rebalancer_key_sealevel | fromJson }}{{ $json.privateKey }}'" }}
         {{- end }}

--- a/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
@@ -31,6 +31,9 @@ spec:
         {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
         HYP_INVENTORY_KEY_SEALEVEL: {{ print "'{{ $json := .inventory_rebalancer_key_sealevel | fromJson }}{{ $json.privateKey }}'" }}
         {{- end }}
+        {{- if has "swapsxyz" .Values.hyperlane.externalBridgeProviders }}
+        SWAPSXYZ_API_KEY: {{ printf "'{{ .%s_swapsxyz_api_key | toString }}'" .Values.hyperlane.runEnv }}
+        {{- end }}
         {{- range .Values.hyperlane.chains }}
         RPC_URL_{{ . | upper | replace "-" "_" }}: {{ printf "'{{ index (.%s_rpcs | fromJson) 0 }}'" . }}
         {{- end }}
@@ -48,6 +51,11 @@ spec:
   - secretKey: inventory_rebalancer_key_sealevel
     remoteRef:
       key: {{ printf "hyperlane-%s-key-sealevel-inventoryrebalancer" .Values.hyperlane.runEnv }}
+  {{- end }}
+  {{- if has "swapsxyz" .Values.hyperlane.externalBridgeProviders }}
+  - secretKey: {{ printf "%s_swapsxyz_api_key" .Values.hyperlane.runEnv }}
+    remoteRef:
+      key: {{ printf "%s-swapsxyz-api-key" .Values.hyperlane.runEnv }}
   {{- end }}
   {{- range .Values.hyperlane.chains }}
   - secretKey: {{ printf "%s_rpcs" . }}

--- a/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
@@ -55,7 +55,7 @@ spec:
   {{- if has "swapsxyz" .Values.hyperlane.externalBridgeProviders }}
   - secretKey: {{ printf "%s_swapsxyz_api_key" .Values.hyperlane.runEnv }}
     remoteRef:
-      key: {{ printf "%s-swapsxyz-api-key" .Values.hyperlane.runEnv }}
+      key: {{ .Values.hyperlane.swapsxyzApiKeySecretName | default (printf "%s-swapsxyz-api-key" .Values.hyperlane.runEnv) }}
   {{- end }}
   {{- range .Values.hyperlane.chains }}
   - secretKey: {{ printf "%s_rpcs" . }}

--- a/typescript/infra/helm/rebalancer/values.yaml
+++ b/typescript/infra/helm/rebalancer/values.yaml
@@ -12,6 +12,7 @@ hyperlane:
   # Used for fetching private RPC secrets
   chains: []
   inventorySignerProtocols: []
+  externalBridgeProviders: []
 nameOverride: ''
 fullnameOverride: ''
 externalSecrets:

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -38,6 +38,7 @@ export class RebalancerHelmManager extends HelmManager {
   private rebalancerConfigContent: string = '';
   private rebalancerChains: string[] = [];
   private inventorySignerProtocols: string[] = [];
+  private externalBridgeProviders: string[] = [];
 
   constructor(
     readonly warpRouteId: string,
@@ -88,6 +89,9 @@ export class RebalancerHelmManager extends HelmManager {
     this.inventorySignerProtocols = Object.keys(
       validationResult.data.inventorySigners ?? {},
     );
+    this.externalBridgeProviders = Object.keys(
+      validationResult.data.externalBridges ?? {},
+    );
   }
 
   get namespace() {
@@ -114,6 +118,7 @@ export class RebalancerHelmManager extends HelmManager {
         // Used for fetching private RPC secrets
         chains: this.rebalancerChains,
         inventorySignerProtocols: this.inventorySignerProtocols,
+        externalBridgeProviders: this.externalBridgeProviders,
       },
     };
   }

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -27,6 +27,14 @@ import {
 } from '../utils/helm.js';
 import { execCmdAndParseJson, getInfraPath } from '../utils/utils.js';
 
+// Dedicated per-warp-route swaps.xyz API key secrets so usage is attributable
+// per rebalancer on the swaps.xyz dashboard. Routes absent from this map fall
+// back to the shared `<runEnv>-swapsxyz-api-key` secret in the helm template.
+const SWAPSXYZ_API_KEY_SECRET_BY_WARP_ROUTE: Record<string, string> = {
+  'oUSDT/production': 'mainnet3-swapsxyz-api-key-ousdt',
+  'USDT/eclipsemainnet': 'mainnet3-swapsxyz-api-key-usdt-eclipse',
+};
+
 export class RebalancerHelmManager extends HelmManager {
   static helmReleasePrefix: string = 'hyperlane-rebalancer';
 
@@ -119,6 +127,8 @@ export class RebalancerHelmManager extends HelmManager {
         chains: this.rebalancerChains,
         inventorySignerProtocols: this.inventorySignerProtocols,
         externalBridgeProviders: this.externalBridgeProviders,
+        swapsxyzApiKeySecretName:
+          SWAPSXYZ_API_KEY_SECRET_BY_WARP_ROUTE[this.warpRouteId],
       },
     };
   }

--- a/typescript/rebalancer-sim/src/runners/MockActionTracker.ts
+++ b/typescript/rebalancer-sim/src/runners/MockActionTracker.ts
@@ -7,6 +7,7 @@ import type {
   RebalanceAction,
   RebalanceIntent,
   Transfer,
+  UpdateRebalanceActionExecutionParams,
 } from '@hyperlane-xyz/rebalancer';
 import type { Domain } from '@hyperlane-xyz/utils';
 import { rootLogger } from '@hyperlane-xyz/utils';
@@ -259,6 +260,17 @@ export class MockActionTracker implements IActionTracker {
     return Array.from(this.actions.values()).filter(
       (a) => a.status === 'in_progress',
     );
+  }
+
+  async updateRebalanceActionExecution(
+    id: string,
+    params: UpdateRebalanceActionExecutionParams,
+  ): Promise<void> {
+    const action = this.actions.get(id);
+    if (!action) {
+      throw new Error(`RebalanceAction ${id} not found`);
+    }
+    Object.assign(action, params, { updatedAt: Date.now() });
   }
 
   async completeRebalanceAction(id: string): Promise<void> {

--- a/typescript/rebalancer/README.md
+++ b/typescript/rebalancer/README.md
@@ -211,6 +211,7 @@ strategy:
 | `bridge`                  | `0x...` address  | Yes      | Bridge contract address for this chain                         |
 | `bridgeLockTime`          | number (seconds) | No       | Expected bridge transfer duration (used for inflight tracking) |
 | `bridgeMinAcceptedAmount` | number           | No       | Skip routes with amounts below this threshold                  |
+| `statusAdapter`           | object           | No       | Settlement tracker; defaults to `hyperlane_message`            |
 | `override`                | object           | No       | Per-destination bridge overrides (see below)                   |
 
 #### Per-Destination Overrides
@@ -228,9 +229,26 @@ strategy:
         arbitrum:
           bridge: '0xFastArbitrumBridge...'
           bridgeLockTime: 600
+          # Use for LayerZero OFT bridges that emit no Hyperlane Dispatch.
+          statusAdapter:
+            kind: lz_scan
+            sourceEid: 30101
+            destinationEid: 30110
+            sourceOft: '0xSourceOft...'
+            destinationOft: '0xDestinationOft...'
         optimism:
           bridge: '0xOptimismBridge...'
 ```
+
+`statusAdapter.kind` supports `hyperlane_message` and `lz_scan`. The default
+tracks a Hyperlane `Dispatch`; `lz_scan` extracts the exact OFT GUID and polls
+LayerZero Scan until a confirmed destination receipt contains the matching
+`OFTReceived` GUID, source EID, recipient, and amount from the source receipt.
+LayerZero EIDs and OFT contract addresses are required. Source-committed
+failures remain suppressed while the process runs rather than allowing a
+duplicate collateral move. A restart clears that in-memory suppression.
+For non-Hyperlane transfers, a restart while settlement is pending can therefore
+lose the action cursor; operators must verify source settlement before resuming.
 
 ## Architecture
 

--- a/typescript/rebalancer/README.md
+++ b/typescript/rebalancer/README.md
@@ -94,6 +94,10 @@ await service.executeManual({
 
 The rebalancer uses a YAML configuration file with a `warpRouteId` and `strategy` field.
 
+Source actions are recorded in memory before broadcast. This prevents an
+uncertain send from being retried while the process remains running. A restart
+clears this state; no action or intent state is written to disk.
+
 ### Basic Example (Single Strategy)
 
 ```yaml

--- a/typescript/rebalancer/package.json
+++ b/typescript/rebalancer/package.json
@@ -45,6 +45,7 @@
     "@hyperlane-xyz/provider-sdk": "workspace:*",
     "@hyperlane-xyz/registry": "catalog:",
     "@hyperlane-xyz/sdk": "workspace:*",
+    "@hyperlane-xyz/tron-sdk": "workspace:*",
     "@hyperlane-xyz/utils": "workspace:*",
     "@inquirer/prompts": "catalog:",
     "@inquirer/select": "catalog:",

--- a/typescript/rebalancer/package.json
+++ b/typescript/rebalancer/package.json
@@ -50,6 +50,7 @@
     "@inquirer/prompts": "catalog:",
     "@inquirer/select": "catalog:",
     "@lifi/sdk": "catalog:",
+    "@solana/spl-token": "catalog:",
     "@solana/web3.js": "catalog:",
     "bignumber.js": "catalog:",
     "bs58": "catalog:",

--- a/typescript/rebalancer/package.json
+++ b/typescript/rebalancer/package.json
@@ -59,6 +59,7 @@
     "pino": "catalog:",
     "pino-pretty": "catalog:",
     "prom-client": "catalog:",
+    "tronweb": "catalog:",
     "uuid": "catalog:",
     "viem": "catalog:",
     "yaml": "catalog:",

--- a/typescript/rebalancer/src/bridges/DeBridgeBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/DeBridgeBridge.test.ts
@@ -1,0 +1,745 @@
+import {
+  Connection,
+  Keypair,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import bs58 from 'bs58';
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import sinon from 'sinon';
+
+import {
+  TronJsonRpcProvider,
+  TronWallet,
+} from '@hyperlane-xyz/tron-sdk/runtime';
+import { ProtocolType, assert } from '@hyperlane-xyz/utils';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+} from '../interfaces/IExternalBridge.js';
+import { DeBridgeBridge, type DeBridgeBridgeConfig } from './DeBridgeBridge.js';
+import {
+  DEBRIDGE_SOLANA_CHAIN_ID,
+  DEBRIDGE_TRON_CHAIN_ID,
+  type DeBridgeCreateTxResponse,
+  type DeBridgeQuoteResponse,
+  formatAddressForDebridge,
+  hyperlaneChainIdToDebridge,
+} from './deBridgeUtils.js';
+
+const logger = pino({ level: 'silent' });
+const PRIVATE_KEY = ethers.utils.id('deBridge test signer');
+const OTHER_PRIVATE_KEY = ethers.utils.id('different deBridge test signer');
+const SIGNER_ADDRESS = new ethers.Wallet(PRIVATE_KEY).address;
+const BSC_USDT = '0x55d398326f99059fF775485246999027B3197955';
+const TRON_USDT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+const SOLANA_USDT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+const ORDER_ID = `0x${'a'.repeat(64)}`;
+const OTHER_ORDER_ID = `0x${'b'.repeat(64)}`;
+const DESTINATION_TX_HASH = `0x${'c'.repeat(64)}`;
+const DLN_SOURCE = '0xE6f924E3C42350684aF70F798c3cA2533A4c5Bd0';
+const SOURCE_AMOUNT = 1_000_000_000_000_000_000_000n;
+const DESTINATION_AMOUNT = 996_000_000n;
+const FIX_FEE = 5_000_000_000_000_000n;
+
+const BRIDGE_CONFIG: DeBridgeBridgeConfig = {
+  maxFeePercent: 2.5,
+  chainMetadata: {
+    bsc: {
+      chainId: 56,
+      name: 'bsc',
+      domainId: 56,
+      protocol: ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'https://bsc-rpc.example.com' }],
+    },
+    tron: {
+      chainId: 728126428,
+      name: 'tron',
+      domainId: 728126428,
+      protocol: ProtocolType.Tron,
+      rpcUrls: [{ http: 'https://api.trongrid.io' }],
+    },
+    solana: {
+      chainId: 1399811149,
+      name: 'solanamainnet',
+      domainId: 1399811149,
+      protocol: ProtocolType.Sealevel,
+      rpcUrls: [{ http: 'https://api.mainnet-beta.solana.com' }],
+    },
+  },
+};
+
+const BSC_TO_TRON_PARAMS: BridgeQuoteParams = {
+  fromChain: 56,
+  toChain: 728126428,
+  fromToken: BSC_USDT,
+  toToken: TRON_USDT,
+  fromAmount: SOURCE_AMOUNT,
+  fromAddress: SIGNER_ADDRESS,
+  toAddress: formatAddressForDebridge(SIGNER_ADDRESS, DEBRIDGE_TRON_CHAIN_ID),
+};
+
+function makeSolanaParams(signer: Keypair): BridgeQuoteParams {
+  return {
+    fromChain: 1399811149,
+    toChain: 56,
+    fromToken: SOLANA_USDT,
+    toToken: BSC_USDT,
+    fromAmount: 1_000_000_000n,
+    fromAddress: signer.publicKey.toBase58(),
+    toAddress: SIGNER_ADDRESS,
+  };
+}
+
+function makeSolanaQuoteResponse(): DeBridgeQuoteResponse {
+  return {
+    estimation: {
+      srcChainTokenIn: {
+        chainId: DEBRIDGE_SOLANA_CHAIN_ID,
+        address: SOLANA_USDT,
+        name: 'Tether USD',
+        symbol: 'USDT',
+        decimals: 6,
+        amount: '1000000000',
+      },
+      dstChainTokenOut: {
+        chainId: 56,
+        address: BSC_USDT,
+        name: 'Tether USD',
+        symbol: 'USDT',
+        decimals: 18,
+        amount: '996000000000000000000',
+      },
+    },
+    fixFee: '0',
+    protocolFee: '0',
+  };
+}
+
+function makeSerializedSolanaTransaction(payer: Keypair): string {
+  const message = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: '11111111111111111111111111111111',
+    instructions: [],
+  }).compileToV0Message();
+  return `0x${Buffer.from(new VersionedTransaction(message).serialize()).toString('hex')}`;
+}
+
+function makeQuoteResponse(
+  sourceAmount = SOURCE_AMOUNT,
+  destinationAmount = DESTINATION_AMOUNT,
+): DeBridgeQuoteResponse {
+  return {
+    estimation: {
+      srcChainTokenIn: {
+        chainId: 56,
+        address: BSC_USDT.toLowerCase(),
+        name: 'Tether USD',
+        symbol: 'USDT',
+        decimals: 18,
+        amount: sourceAmount.toString(),
+      },
+      dstChainTokenOut: {
+        chainId: DEBRIDGE_TRON_CHAIN_ID,
+        address: TRON_USDT,
+        name: 'Tether USD',
+        symbol: 'USDT',
+        decimals: 6,
+        amount: destinationAmount.toString(),
+      },
+    },
+    fixFee: FIX_FEE.toString(),
+    protocolFee: '0',
+  };
+}
+
+function makeCreateTxResponse(): DeBridgeCreateTxResponse {
+  return {
+    ...makeQuoteResponse(),
+    orderId: ORDER_ID,
+    fixFee: FIX_FEE.toString(),
+    tx: {
+      to: DLN_SOURCE,
+      data: '0xb9303701',
+      value: FIX_FEE.toString(),
+    },
+  };
+}
+
+function makeBridgeQuote(
+  params: BridgeQuoteParams,
+  response: DeBridgeQuoteResponse,
+): BridgeQuote {
+  return {
+    id: 'quote-id',
+    tool: 'debridge',
+    fromAmount: BigInt(response.estimation.srcChainTokenIn.amount),
+    toAmount: BigInt(response.estimation.dstChainTokenOut.amount),
+    toAmountMin: BigInt(response.estimation.dstChainTokenOut.amount),
+    executionDuration: 60,
+    gasCosts: 0n,
+    feeCosts: 0n,
+    route: response,
+    requestParams: params,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function getRejection(promise: Promise<unknown>): Promise<Error> {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+  assert(caught instanceof Error, 'Expected promise to reject with an Error');
+  return caught;
+}
+
+interface CapturedTransaction {
+  to?: string;
+  data: string;
+  value: ethers.BigNumber;
+}
+
+function makeTransactionResponse(
+  transaction: CapturedTransaction,
+  hash: string,
+): ethers.providers.TransactionResponse {
+  const receipt: ethers.providers.TransactionReceipt = {
+    to: transaction.to ?? ethers.constants.AddressZero,
+    from: SIGNER_ADDRESS,
+    contractAddress: ethers.constants.AddressZero,
+    transactionIndex: 0,
+    gasUsed: ethers.constants.Zero,
+    logsBloom: `0x${'0'.repeat(512)}`,
+    blockHash: `0x${'d'.repeat(64)}`,
+    transactionHash: hash,
+    logs: [],
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: ethers.constants.Zero,
+    effectiveGasPrice: ethers.constants.Zero,
+    byzantium: true,
+    type: 0,
+    status: 1,
+  };
+  return {
+    hash,
+    confirmations: 0,
+    from: SIGNER_ADDRESS,
+    to: transaction.to,
+    nonce: 0,
+    gasLimit: ethers.constants.Zero,
+    gasPrice: ethers.constants.Zero,
+    data: transaction.data,
+    value: transaction.value,
+    chainId: 56,
+    wait: async () => receipt,
+  };
+}
+
+describe('deBridge utilities', function () {
+  it('maps all production route chain IDs', () => {
+    expect(hyperlaneChainIdToDebridge(1)).to.equal(1);
+    expect(hyperlaneChainIdToDebridge(56)).to.equal(56);
+    expect(hyperlaneChainIdToDebridge(42161)).to.equal(42161);
+    expect(hyperlaneChainIdToDebridge(728126428)).to.equal(
+      DEBRIDGE_TRON_CHAIN_ID,
+    );
+    expect(hyperlaneChainIdToDebridge(1399811149)).to.equal(
+      DEBRIDGE_SOLANA_CHAIN_ID,
+    );
+  });
+
+  it('converts and validates Tron addresses', async () => {
+    const expected = 'TFdFSWMovbz9PSKm6skvV4RCxuXq3nepo5';
+    expect(
+      formatAddressForDebridge(
+        '0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5',
+        DEBRIDGE_TRON_CHAIN_ID,
+      ),
+    ).to.equal(expected);
+    expect(
+      formatAddressForDebridge(
+        '0x413e0A78A330F2b97059A4D507ca9d8292b65B6FB5',
+        DEBRIDGE_TRON_CHAIN_ID,
+      ),
+    ).to.equal(expected);
+    expect(
+      formatAddressForDebridge(
+        '413e0A78A330F2b97059A4D507ca9d8292b65B6FB5',
+        DEBRIDGE_TRON_CHAIN_ID,
+      ),
+    ).to.equal(expected);
+    const error = await getRejection(
+      Promise.resolve().then(() =>
+        formatAddressForDebridge(
+          'TFdFSWMovbz9PSKm6skvV4RCxuXq3nepo4',
+          DEBRIDGE_TRON_CHAIN_ID,
+        ),
+      ),
+    );
+    expect(error.message).to.include('checksum');
+  });
+
+  it('rejects unsupported chains', async () => {
+    for (const chainId of [9745, 99999]) {
+      const error = await getRejection(
+        Promise.resolve().then(() => hyperlaneChainIdToDebridge(chainId)),
+      );
+      expect(error.message).to.include('not supported');
+    }
+  });
+});
+
+describe('DeBridgeBridge.quote', function () {
+  afterEach(() => sinon.restore());
+
+  it('normalizes decimals for its fee guard and URL-encodes the request', async () => {
+    let calledUrl = '';
+    sinon.stub(globalThis, 'fetch').callsFake(async (input) => {
+      calledUrl = String(input);
+      return jsonResponse(makeQuoteResponse());
+    });
+
+    const quote = await new DeBridgeBridge(BRIDGE_CONFIG, logger).quote(
+      BSC_TO_TRON_PARAMS,
+    );
+
+    expect(quote.fromAmount).to.equal(SOURCE_AMOUNT);
+    expect(quote.toAmount).to.equal(DESTINATION_AMOUNT);
+    const url = new URL(calledUrl);
+    expect(url.pathname).to.equal('/v1.0/dln/order/quote');
+    expect(url.searchParams.get('srcChainId')).to.equal('56');
+    expect(url.searchParams.get('dstChainId')).to.equal('100000026');
+    expect(url.searchParams.get('dstChainTokenOut')).to.equal(TRON_USDT);
+  });
+
+  it('rejects a quote above maxFeePercent', async () => {
+    sinon
+      .stub(globalThis, 'fetch')
+      .resolves(jsonResponse(makeQuoteResponse(SOURCE_AMOUNT, 900_000_000n)));
+
+    const error = await getRejection(
+      new DeBridgeBridge(BRIDGE_CONFIG, logger).quote(BSC_TO_TRON_PARAMS),
+    );
+    expect(error.message).to.include('fee too high');
+  });
+
+  it('rejects malformed and mismatched responses', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub.onFirstCall().resolves(jsonResponse({ estimation: {} }));
+    fetchStub.onSecondCall().resolves(
+      jsonResponse({
+        ...makeQuoteResponse(),
+        estimation: {
+          ...makeQuoteResponse().estimation,
+          srcChainTokenIn: {
+            ...makeQuoteResponse().estimation.srcChainTokenIn,
+            chainId: 1,
+          },
+        },
+      }),
+    );
+
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+    const malformedError = await getRejection(bridge.quote(BSC_TO_TRON_PARAMS));
+    expect(malformedError.message).to.include('estimation');
+    const mismatchedError = await getRejection(
+      bridge.quote(BSC_TO_TRON_PARAMS),
+    );
+    expect(mismatchedError.message).to.include('source chain');
+  });
+
+  it('surfaces structured API errors', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      jsonResponse({
+        errorCode: 12,
+        errorId: 'ERROR_LOW_GIVE_AMOUNT',
+        errorMessage: 'Amount is too low',
+      }),
+    );
+
+    const error = await getRejection(
+      new DeBridgeBridge(BRIDGE_CONFIG, logger).quote(BSC_TO_TRON_PARAMS),
+    );
+    expect(error.message).to.include(
+      'ERROR_LOW_GIVE_AMOUNT: Amount is too low',
+    );
+  });
+
+  it('validates exact-input/exact-output invariants before fetching', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+
+    const conflictingAmountError = await getRejection(
+      bridge.quote({
+        ...BSC_TO_TRON_PARAMS,
+        toAmount: DESTINATION_AMOUNT,
+      }),
+    );
+    expect(conflictingAmountError.message).to.include('Cannot specify both');
+    const missingAmountError = await getRejection(
+      bridge.quote({
+        ...BSC_TO_TRON_PARAMS,
+        fromAmount: undefined,
+      }),
+    );
+    expect(missingAmountError.message).to.include('Must specify either');
+    expect(fetchStub.called).to.equal(false);
+  });
+});
+
+describe('DeBridgeBridge.execute', function () {
+  afterEach(() => sinon.restore());
+
+  it('rejects a private key that does not match the configured signer', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+    const quote = makeBridgeQuote(BSC_TO_TRON_PARAMS, makeQuoteResponse());
+
+    const error = await getRejection(
+      bridge.execute(quote, {
+        [ProtocolType.Ethereum]: OTHER_PRIVATE_KEY,
+      }),
+    );
+    expect(error.message).to.include('does not match inventory signer');
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it('resets and sets an exact EVM allowance before direct API execution', async () => {
+    sinon
+      .stub(globalThis, 'fetch')
+      .resolves(jsonResponse(makeCreateTxResponse()));
+    sinon
+      .stub(ethers.providers.StaticJsonRpcProvider.prototype, 'call')
+      .resolves(
+        ethers.utils.defaultAbiCoder.encode(['uint256'], [SOURCE_AMOUNT + 1n]),
+      );
+
+    const captured: CapturedTransaction[] = [];
+    sinon
+      .stub(ethers.Wallet.prototype, 'sendTransaction')
+      .callsFake(async (request) => {
+        const transaction = {
+          to: await request.to,
+          data: ethers.utils.hexlify((await request.data) ?? '0x'),
+          value: ethers.BigNumber.from((await request.value) ?? 0),
+        };
+        captured.push(transaction);
+        return makeTransactionResponse(
+          transaction,
+          `0x${captured.length.toString(16).padStart(64, '0')}`,
+        );
+      });
+
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+    const result = await bridge.execute(
+      makeBridgeQuote(BSC_TO_TRON_PARAMS, makeQuoteResponse()),
+      { [ProtocolType.Ethereum]: PRIVATE_KEY },
+    );
+
+    expect(captured).to.have.length(3);
+    const erc20 = new ethers.utils.Interface([
+      'function approve(address,uint256) returns (bool)',
+    ]);
+    const reset = erc20.decodeFunctionData('approve', captured[0].data);
+    const approval = erc20.decodeFunctionData('approve', captured[1].data);
+    expect(reset[0]).to.equal(DLN_SOURCE);
+    expect(reset[1].toString()).to.equal('0');
+    expect(approval[0]).to.equal(DLN_SOURCE);
+    expect(approval[1].toString()).to.equal(SOURCE_AMOUNT.toString());
+    expect(captured[2]).to.deep.include({
+      to: DLN_SOURCE,
+      data: '0xb9303701',
+    });
+    expect(captured[2].value.toString()).to.equal(FIX_FEE.toString());
+    expect(result).to.deep.equal({
+      txHash: `0x${'3'.padStart(64, '0')}`,
+      fromChain: 56,
+      toChain: 728126428,
+      transferId: ORDER_ID,
+    });
+  });
+
+  it('rejects value changes and direct calls to the source token', async () => {
+    const changedValue = makeCreateTxResponse();
+    changedValue.tx.value = (FIX_FEE + 1n).toString();
+    const directTokenCall = makeCreateTxResponse();
+    directTokenCall.tx.to = BSC_USDT;
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub.onFirstCall().resolves(jsonResponse(changedValue));
+    fetchStub.onSecondCall().resolves(jsonResponse(directTokenCall));
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+    const quote = makeBridgeQuote(BSC_TO_TRON_PARAMS, makeQuoteResponse());
+
+    const valueError = await getRejection(
+      bridge.execute(quote, { [ProtocolType.Ethereum]: PRIVATE_KEY }),
+    );
+    expect(valueError.message).to.include('does not match expected');
+    const targetError = await getRejection(
+      bridge.execute(quote, { [ProtocolType.Ethereum]: PRIVATE_KEY }),
+    );
+    expect(targetError.message).to.include('cannot be the source token');
+  });
+
+  it('constructs an exact TRC20 approval for Tron execution', async () => {
+    const params: BridgeQuoteParams = {
+      fromChain: 728126428,
+      toChain: 56,
+      fromToken: TRON_USDT,
+      toToken: BSC_USDT,
+      fromAmount: 1_000_000_000n,
+      fromAddress: SIGNER_ADDRESS,
+      toAddress: SIGNER_ADDRESS,
+    };
+    const response: DeBridgeQuoteResponse = {
+      estimation: {
+        srcChainTokenIn: {
+          chainId: DEBRIDGE_TRON_CHAIN_ID,
+          address: TRON_USDT,
+          name: 'Tether USD',
+          symbol: 'USDT',
+          decimals: 6,
+          amount: '1000000000',
+        },
+        dstChainTokenOut: {
+          chainId: 56,
+          address: BSC_USDT,
+          name: 'Tether USD',
+          symbol: 'USDT',
+          decimals: 18,
+          amount: '996000000000000000000',
+        },
+      },
+      fixFee: '4000000',
+      protocolFee: '400000',
+    };
+    sinon.stub(globalThis, 'fetch').resolves(
+      jsonResponse({
+        ...response,
+        orderId: ORDER_ID,
+        tx: { to: DLN_SOURCE, data: '0xb9303701', value: '4000000' },
+      }),
+    );
+    sinon
+      .stub(TronJsonRpcProvider.prototype, 'call')
+      .resolves(ethers.utils.defaultAbiCoder.encode(['uint256'], [0]));
+    let approvalRequest: CapturedTransaction | undefined;
+    sinon
+      .stub(TronWallet.prototype, 'sendTransaction')
+      .callsFake(async (request): Promise<never> => {
+        approvalRequest = {
+          to: await request.to,
+          data: ethers.utils.hexlify((await request.data) ?? '0x'),
+          value: ethers.BigNumber.from((await request.value) ?? 0),
+        };
+        throw new Error('stop after TRC20 approval capture');
+      });
+
+    const error = await getRejection(
+      new DeBridgeBridge(BRIDGE_CONFIG, logger).execute(
+        makeBridgeQuote(params, response),
+        { [ProtocolType.Tron]: PRIVATE_KEY },
+      ),
+    );
+    expect(error.message).to.include('stop after TRC20 approval capture');
+
+    expect(approvalRequest).not.to.equal(undefined);
+    assert(approvalRequest, 'Expected an approval transaction');
+    expect(approvalRequest.to).to.equal(
+      '0xa614f803B6FD780986A42c78Ec9c7f77e6DeD13C',
+    );
+    const erc20 = new ethers.utils.Interface([
+      'function approve(address,uint256) returns (bool)',
+    ]);
+    const approval = erc20.decodeFunctionData('approve', approvalRequest.data);
+    expect(approval[0]).to.equal(DLN_SOURCE);
+    expect(approval[1].toString()).to.equal('1000000000');
+  });
+
+  it('rejects a Solana transaction signed by another payer', async () => {
+    const signer = Keypair.generate();
+    const other = Keypair.generate();
+    const params = makeSolanaParams(signer);
+    const response = makeSolanaQuoteResponse();
+    sinon.stub(globalThis, 'fetch').resolves(
+      jsonResponse({
+        ...response,
+        orderId: ORDER_ID,
+        fixFee: '0',
+        tx: { data: makeSerializedSolanaTransaction(other) },
+      }),
+    );
+
+    const error = await getRejection(
+      new DeBridgeBridge(BRIDGE_CONFIG, logger).execute(
+        makeBridgeQuote(params, response),
+        { [ProtocolType.Sealevel]: bs58.encode(signer.secretKey) },
+      ),
+    );
+    expect(error.message).to.include('signer does not match');
+  });
+
+  it('signs, confirms, and returns the order ID for Solana', async () => {
+    const signer = Keypair.generate();
+    const params = makeSolanaParams(signer);
+    const response = makeSolanaQuoteResponse();
+    sinon.stub(globalThis, 'fetch').resolves(
+      jsonResponse({
+        ...response,
+        orderId: ORDER_ID,
+        fixFee: '0',
+        tx: { data: makeSerializedSolanaTransaction(signer) },
+      }),
+    );
+    sinon.stub(Connection.prototype, 'getLatestBlockhash').resolves({
+      blockhash: '11111111111111111111111111111111',
+      lastValidBlockHeight: 123,
+    });
+    const sendStub = sinon
+      .stub(Connection.prototype, 'sendTransaction')
+      .resolves('solana-signature');
+    sinon.stub(Connection.prototype, 'confirmTransaction').resolves({
+      context: { slot: 1 },
+      value: { err: null },
+    });
+
+    const result = await new DeBridgeBridge(BRIDGE_CONFIG, logger).execute(
+      makeBridgeQuote(params, response),
+      { [ProtocolType.Sealevel]: bs58.encode(signer.secretKey) },
+    );
+
+    expect(sendStub.calledOnce).to.equal(true);
+    expect(result).to.deep.equal({
+      txHash: 'solana-signature',
+      fromChain: 1399811149,
+      toChain: 56,
+      transferId: ORDER_ID,
+    });
+  });
+});
+
+describe('DeBridgeBridge.getStatus', function () {
+  afterEach(() => sinon.restore());
+
+  it('uses the persisted order ID and maps completion metadata', async () => {
+    let calledUrl = '';
+    sinon.stub(globalThis, 'fetch').callsFake(async (input) => {
+      calledUrl = String(input);
+      return jsonResponse({
+        orderId: ORDER_ID,
+        status: 'Fulfilled',
+        fulfilledDstEventMetadata: {
+          transactionHash: { stringValue: DESTINATION_TX_HASH },
+          receivedAmount: { bigIntegerValue: DESTINATION_AMOUNT.toString() },
+        },
+      });
+    });
+
+    const result = await new DeBridgeBridge(BRIDGE_CONFIG, logger).getStatus(
+      'origin-transaction-hash',
+      56,
+      728126428,
+      ORDER_ID,
+    );
+
+    expect(calledUrl).to.include(`/order/${ORDER_ID}/status`);
+    expect(calledUrl).not.to.include('origin-transaction-hash');
+    expect(result).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: DESTINATION_TX_HASH,
+      receivedAmount: DESTINATION_AMOUNT,
+    });
+  });
+
+  it('maps all cancellation states to failed', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    for (const status of [
+      'OrderCancelled',
+      'SentOrderCancel',
+      'ClaimedOrderCancel',
+    ]) {
+      fetchStub.resolves(jsonResponse({ orderId: ORDER_ID, status }));
+      const result = await new DeBridgeBridge(BRIDGE_CONFIG, logger).getStatus(
+        'tx',
+        56,
+        728126428,
+        ORDER_ID,
+      );
+      expect(result).to.deep.equal({ status: 'failed', error: status });
+      fetchStub.resetBehavior();
+    }
+  });
+
+  it('maps all fulfillment states to complete', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    for (const status of ['Fulfilled', 'SentUnlock', 'ClaimedUnlock']) {
+      fetchStub.resolves(jsonResponse({ orderId: ORDER_ID, status }));
+      const result = await new DeBridgeBridge(BRIDGE_CONFIG, logger).getStatus(
+        'tx',
+        56,
+        728126428,
+        ORDER_ID,
+      );
+      expect(result).to.deep.equal({
+        status: 'complete',
+        receivingTxHash: '',
+        receivedAmount: 0n,
+      });
+      fetchStub.resetBehavior();
+    }
+  });
+
+  it('maps Created to pending and None to not_found', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub
+      .onFirstCall()
+      .resolves(jsonResponse({ orderId: ORDER_ID, status: 'Created' }));
+    fetchStub
+      .onSecondCall()
+      .resolves(jsonResponse({ orderId: ORDER_ID, status: 'None' }));
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+
+    expect(await bridge.getStatus('tx', 56, 728126428, ORDER_ID)).to.deep.equal(
+      { status: 'pending', substatus: 'Created' },
+    );
+    expect(await bridge.getStatus('tx', 56, 728126428, ORDER_ID)).to.deep.equal(
+      { status: 'not_found' },
+    );
+  });
+
+  it('rejects missing IDs, mismatched IDs, and unknown statuses', async () => {
+    const bridge = new DeBridgeBridge(BRIDGE_CONFIG, logger);
+    const missingIdError = await getRejection(
+      bridge.getStatus('tx', 56, 728126428),
+    );
+    expect(missingIdError.message).to.include('order ID is required');
+
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub
+      .onFirstCall()
+      .resolves(jsonResponse({ orderId: OTHER_ORDER_ID, status: 'Created' }));
+    fetchStub
+      .onSecondCall()
+      .resolves(jsonResponse({ orderId: ORDER_ID, status: 'Unexpected' }));
+    const mismatchedIdError = await getRejection(
+      bridge.getStatus('tx', 56, 728126428, ORDER_ID),
+    );
+    expect(mismatchedIdError.message).to.include('unexpected order ID');
+    const statusError = await getRejection(
+      bridge.getStatus('tx', 56, 728126428, ORDER_ID),
+    );
+    expect(statusError.message).to.include('status');
+  });
+});

--- a/typescript/rebalancer/src/bridges/DeBridgeBridge.ts
+++ b/typescript/rebalancer/src/bridges/DeBridgeBridge.ts
@@ -1,0 +1,700 @@
+import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js';
+import { ethers } from 'ethers';
+import type { Logger } from 'pino';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { TronWallet } from '@hyperlane-xyz/tron-sdk/runtime';
+import { ProtocolType, addressToBytesTron, assert } from '@hyperlane-xyz/utils';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import { waitForReceiptWithTimeout } from '../utils/receiptTimeout.js';
+import { parseSolanaPrivateKey } from '../utils/solanaKeyParser.js';
+import { approveErc20IfNeeded } from './erc20Approve.js';
+import {
+  DEBRIDGE_API_BASE,
+  DEBRIDGE_STATUS_API,
+  DEBRIDGE_TOOL,
+  DEBRIDGE_TRON_CHAIN_ID,
+  type DeBridgeCreateTxResponse,
+  type DeBridgeQuoteResponse,
+  type DeBridgeTokenEstimation,
+  formatAddressForDebridge,
+  hyperlaneChainIdToDebridge,
+  isDebridgeSolanaChain,
+  isDebridgeTronChain,
+  parseDeBridgeCreateTxResponse,
+  parseDeBridgeOrderStatusResponse,
+  parseDeBridgeQuoteResponse,
+} from './deBridgeUtils.js';
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1_000;
+const DEFAULT_MAX_FEE_PERCENT = 10;
+const MAX_PERCENT = 100;
+const BASIS_POINTS_PER_PERCENT = 100;
+const BASIS_POINTS_DENOMINATOR = 10_000n;
+
+export interface DeBridgeBridgeConfig {
+  apiUrl?: string;
+  statusApiUrl?: string;
+  chainMetadata?: ChainMap<ChainMetadata>;
+  maxFeePercent?: number;
+}
+
+export class DeBridgeBridge implements IExternalBridge {
+  readonly externalBridgeId = DEBRIDGE_TOOL;
+  readonly logger: Logger;
+
+  private readonly apiUrl: string;
+  private readonly statusApiUrl: string;
+  private readonly chainMetadataByChainId: Map<number, ChainMetadata>;
+  private readonly maxFeeBps: number;
+
+  constructor(config: DeBridgeBridgeConfig, logger: Logger) {
+    this.logger = logger;
+    this.apiUrl = this.validateApiUrl(config.apiUrl ?? DEBRIDGE_API_BASE);
+    this.statusApiUrl = this.validateApiUrl(
+      config.statusApiUrl ?? DEBRIDGE_STATUS_API,
+    );
+
+    const maxFeePercent = config.maxFeePercent ?? DEFAULT_MAX_FEE_PERCENT;
+    assert(
+      Number.isFinite(maxFeePercent) &&
+        maxFeePercent >= 0 &&
+        maxFeePercent <= MAX_PERCENT,
+      `maxFeePercent must be between 0 and ${MAX_PERCENT}`,
+    );
+    const maxFeeBps = maxFeePercent * BASIS_POINTS_PER_PERCENT;
+    assert(
+      Number.isInteger(maxFeeBps),
+      'maxFeePercent must have at most two decimal places',
+    );
+    this.maxFeeBps = maxFeeBps;
+
+    this.chainMetadataByChainId = new Map();
+    for (const metadata of Object.values(config.chainMetadata ?? {})) {
+      if (
+        metadata.chainId === undefined ||
+        (metadata.protocol !== ProtocolType.Ethereum &&
+          metadata.protocol !== ProtocolType.Tron &&
+          metadata.protocol !== ProtocolType.Sealevel)
+      ) {
+        continue;
+      }
+
+      const chainId = Number(metadata.chainId);
+      assert(
+        !this.chainMetadataByChainId.has(chainId),
+        `Duplicate chain metadata for chain ID ${chainId}`,
+      );
+      this.chainMetadataByChainId.set(chainId, metadata);
+    }
+  }
+
+  async quote(params: BridgeQuoteParams): Promise<BridgeQuote> {
+    this.validateQuoteParams(params);
+
+    const srcDebridgeChainId = hyperlaneChainIdToDebridge(params.fromChain);
+    const dstDebridgeChainId = hyperlaneChainIdToDebridge(params.toChain);
+    const srcToken = formatAddressForDebridge(
+      params.fromToken,
+      srcDebridgeChainId,
+    );
+    const dstToken = formatAddressForDebridge(
+      params.toToken,
+      dstDebridgeChainId,
+    );
+    formatAddressForDebridge(params.fromAddress, srcDebridgeChainId);
+    if (params.toAddress) {
+      formatAddressForDebridge(params.toAddress, dstDebridgeChainId);
+    }
+
+    const url = this.buildApiUrl('/dln/order/quote', {
+      srcChainId: srcDebridgeChainId.toString(),
+      srcChainTokenIn: srcToken,
+      srcChainTokenInAmount: params.fromAmount?.toString() ?? 'auto',
+      dstChainId: dstDebridgeChainId.toString(),
+      dstChainTokenOut: dstToken,
+      dstChainTokenOutAmount: params.toAmount?.toString() ?? 'auto',
+      prependOperatingExpenses: 'false',
+    });
+
+    this.logger.debug(
+      {
+        fromChain: params.fromChain,
+        toChain: params.toChain,
+        srcDebridgeChainId,
+        dstDebridgeChainId,
+      },
+      'Requesting deBridge quote',
+    );
+
+    const response = await this.fetchWithRetry(url);
+    const body: unknown = await response.json();
+    const data = parseDeBridgeQuoteResponse(body);
+    this.validateEstimation(data, params);
+    this.assertFeeWithinLimit(data, params.fromChain, params.toChain);
+
+    const fromAmount = BigInt(data.estimation.srcChainTokenIn.amount);
+    const toAmount = BigInt(data.estimation.dstChainTokenOut.amount);
+    const feeCosts =
+      BigInt(data.fixFee ?? '0') + BigInt(data.protocolFee ?? '0');
+
+    return {
+      id: uuidv4(),
+      tool: DEBRIDGE_TOOL,
+      fromAmount,
+      toAmount,
+      toAmountMin: toAmount,
+      executionDuration: 60,
+      gasCosts: 0n,
+      feeCosts,
+      route: data,
+      requestParams: { ...params },
+    };
+  }
+
+  async execute(
+    quote: BridgeQuote,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    assert(quote.tool === DEBRIDGE_TOOL, 'Quote was not created by deBridge');
+    assert(quote.fromAmount > 0n, 'Quote fromAmount must be positive');
+    assert(quote.toAmountMin > 0n, 'Quote toAmountMin must be positive');
+    const quotedRoute = parseDeBridgeQuoteResponse(quote.route);
+    const params = quote.requestParams;
+    this.validateQuoteParams(params);
+    this.validateEstimation(quotedRoute, params);
+    assert(
+      BigInt(quotedRoute.estimation.srcChainTokenIn.amount) ===
+        quote.fromAmount,
+      'Quote route fromAmount does not match quote',
+    );
+    assert(
+      BigInt(quotedRoute.estimation.dstChainTokenOut.amount) === quote.toAmount,
+      'Quote route toAmount does not match quote',
+    );
+
+    const srcDebridgeChainId = hyperlaneChainIdToDebridge(params.fromChain);
+    const dstDebridgeChainId = hyperlaneChainIdToDebridge(params.toChain);
+    const sourceProtocol = this.getProtocol(srcDebridgeChainId);
+    const sourcePrivateKey = privateKeys[sourceProtocol];
+    assert(sourcePrivateKey, `Missing private key for ${sourceProtocol} chain`);
+    assert(params.toAddress, 'toAddress is required for deBridge execution');
+
+    const senderAddress = this.deriveAndValidateSender(
+      sourceProtocol,
+      sourcePrivateKey,
+      params.fromAddress,
+      srcDebridgeChainId,
+    );
+    const recipientAddress = formatAddressForDebridge(
+      params.toAddress,
+      dstDebridgeChainId,
+    );
+    const srcToken = formatAddressForDebridge(
+      params.fromToken,
+      srcDebridgeChainId,
+    );
+    const dstToken = formatAddressForDebridge(
+      params.toToken,
+      dstDebridgeChainId,
+    );
+
+    const createTxUrl = this.buildApiUrl('/dln/order/create-tx', {
+      srcChainId: srcDebridgeChainId.toString(),
+      srcChainTokenIn: srcToken,
+      srcChainTokenInAmount: quote.fromAmount.toString(),
+      dstChainId: dstDebridgeChainId.toString(),
+      dstChainTokenOut: dstToken,
+      dstChainTokenOutAmount: 'auto',
+      dstChainTokenOutRecipient: recipientAddress,
+      senderAddress,
+      srcChainOrderAuthorityAddress: senderAddress,
+      srcChainRefundAddress: senderAddress,
+      dstChainOrderAuthorityAddress: recipientAddress,
+      prependOperatingExpenses: 'false',
+    });
+
+    this.logger.info(
+      {
+        fromChain: params.fromChain,
+        toChain: params.toChain,
+        amount: quote.fromAmount.toString(),
+        sender: senderAddress,
+        recipient: recipientAddress,
+      },
+      'Creating deBridge order transaction',
+    );
+
+    const response = await this.fetchWithRetry(createTxUrl);
+    const body: unknown = await response.json();
+    const createTx = parseDeBridgeCreateTxResponse(body);
+    this.validateEstimation(createTx, params, {
+      exactFromAmount: quote.fromAmount,
+      minimumToAmount: quote.toAmountMin,
+    });
+    this.assertFeeWithinLimit(createTx, params.fromChain, params.toChain);
+
+    switch (sourceProtocol) {
+      case ProtocolType.Ethereum:
+      case ProtocolType.Tron:
+        return this.executeEvmLike(
+          sourceProtocol,
+          sourcePrivateKey,
+          createTx,
+          quote,
+        );
+      case ProtocolType.Sealevel:
+        return this.executeSolana(sourcePrivateKey, createTx, quote);
+      default: {
+        const exhaustiveProtocol: never = sourceProtocol;
+        throw new Error(`Unsupported source protocol: ${exhaustiveProtocol}`);
+      }
+    }
+  }
+
+  async getStatus(
+    txHash: string,
+    _fromChain: number,
+    _toChain: number,
+    transferId?: string,
+  ): Promise<BridgeTransferStatus> {
+    assert(
+      transferId && /^0x[0-9a-fA-F]{64}$/.test(transferId),
+      'A valid deBridge order ID is required to check transfer status',
+    );
+    const url = new URL(
+      `/v1.0/dln/order/${encodeURIComponent(transferId)}/status`,
+      this.statusApiUrl,
+    ).toString();
+
+    this.logger.debug(
+      { txHash, orderId: transferId },
+      'Checking deBridge order',
+    );
+    const response = await this.fetchWithRetry(url);
+    const body: unknown = await response.json();
+    const data = parseDeBridgeOrderStatusResponse(body);
+    assert(
+      data.orderId.toLowerCase() === transferId.toLowerCase(),
+      `deBridge status returned unexpected order ID ${data.orderId}`,
+    );
+
+    switch (data.status) {
+      case 'None':
+        return { status: 'not_found' };
+      case 'Created':
+        return { status: 'pending', substatus: data.status };
+      case 'Fulfilled':
+      case 'SentUnlock':
+      case 'ClaimedUnlock':
+        return {
+          status: 'complete',
+          receivingTxHash:
+            data.fulfilledDstEventMetadata?.transactionHash?.stringValue ?? '',
+          receivedAmount: BigInt(
+            data.fulfilledDstEventMetadata?.receivedAmount?.bigIntegerValue ??
+              '0',
+          ),
+        };
+      case 'OrderCancelled':
+      case 'SentOrderCancel':
+      case 'ClaimedOrderCancel':
+        return { status: 'failed', error: data.status };
+      default: {
+        const exhaustiveStatus: never = data.status;
+        throw new Error(`Unsupported deBridge status: ${exhaustiveStatus}`);
+      }
+    }
+  }
+
+  private async executeEvmLike(
+    protocol: ProtocolType.Ethereum | ProtocolType.Tron,
+    privateKey: string,
+    createTx: DeBridgeCreateTxResponse,
+    quote: BridgeQuote,
+  ): Promise<BridgeTransferResult> {
+    const { tx, fixFee, orderId } = createTx;
+    assert(tx.to, 'deBridge create-tx response is missing tx.to');
+    assert(tx.value, 'deBridge create-tx response is missing tx.value');
+    assert(
+      ethers.utils.isAddress(tx.to),
+      `deBridge returned invalid transaction target: ${tx.to}`,
+    );
+
+    const rpcUrl = this.getRpcUrl(quote.requestParams.fromChain);
+    const wallet =
+      protocol === ProtocolType.Tron
+        ? new TronWallet(privateKey, rpcUrl)
+        : new ethers.Wallet(
+            privateKey,
+            new ethers.providers.StaticJsonRpcProvider(
+              rpcUrl,
+              quote.requestParams.fromChain,
+            ),
+          );
+    const tokenAddress = this.getEvmLikeAddress(
+      quote.requestParams.fromToken,
+      protocol,
+    );
+    const isNativeToken =
+      tokenAddress === ethers.constants.AddressZero.toLowerCase();
+    const expectedValue =
+      BigInt(fixFee) + (isNativeToken ? quote.fromAmount : 0n);
+    assert(
+      BigInt(tx.value) === expectedValue,
+      `deBridge transaction value ${tx.value} does not match expected ${expectedValue}`,
+    );
+
+    if (!isNativeToken) {
+      assert(
+        tokenAddress !== tx.to.toLowerCase(),
+        'deBridge transaction target cannot be the source token contract',
+      );
+      await approveErc20IfNeeded(
+        wallet,
+        tokenAddress,
+        tx.to,
+        quote.fromAmount,
+        this.logger,
+      );
+    }
+
+    this.logger.info(
+      {
+        from: wallet.address,
+        to: tx.to,
+        fromChain: quote.requestParams.fromChain,
+        orderId,
+      },
+      `Sending deBridge ${protocol} transaction`,
+    );
+    const transaction = await wallet.sendTransaction({
+      to: tx.to,
+      data: tx.data,
+      value: ethers.BigNumber.from(tx.value),
+    });
+    const receipt = await waitForReceiptWithTimeout(transaction.wait(), {
+      txHash: transaction.hash,
+      operation: 'deBridge origin transaction',
+    });
+    assert(
+      receipt.status === 1,
+      `deBridge origin transaction failed: ${transaction.hash}`,
+    );
+
+    return {
+      txHash: transaction.hash,
+      fromChain: quote.requestParams.fromChain,
+      toChain: quote.requestParams.toChain,
+      transferId: orderId,
+    };
+  }
+
+  private async executeSolana(
+    privateKey: string,
+    createTx: DeBridgeCreateTxResponse,
+    quote: BridgeQuote,
+  ): Promise<BridgeTransferResult> {
+    const keypair = Keypair.fromSecretKey(parseSolanaPrivateKey(privateKey));
+    const serialized = Buffer.from(createTx.tx.data.slice(2), 'hex');
+    const transaction = VersionedTransaction.deserialize(serialized);
+    assert(
+      transaction.message.header.numRequiredSignatures === 1,
+      'deBridge Solana transaction must require exactly one signer',
+    );
+    assert(
+      transaction.message.staticAccountKeys[0]?.equals(keypair.publicKey),
+      'deBridge Solana transaction signer does not match inventory signer',
+    );
+
+    const connection = new Connection(
+      this.getRpcUrl(quote.requestParams.fromChain),
+    );
+    const { blockhash, lastValidBlockHeight } =
+      await connection.getLatestBlockhash();
+    transaction.message.recentBlockhash = blockhash;
+    transaction.sign([keypair]);
+
+    const signature = await connection.sendTransaction(transaction);
+    const confirmation = await connection.confirmTransaction(
+      { signature, blockhash, lastValidBlockHeight },
+      'confirmed',
+    );
+    assert(
+      confirmation.value.err === null,
+      `deBridge Solana transaction failed: ${JSON.stringify(confirmation.value.err)}`,
+    );
+
+    return {
+      txHash: signature,
+      fromChain: quote.requestParams.fromChain,
+      toChain: quote.requestParams.toChain,
+      transferId: createTx.orderId,
+    };
+  }
+
+  private deriveAndValidateSender(
+    protocol: ProtocolType.Ethereum | ProtocolType.Tron | ProtocolType.Sealevel,
+    privateKey: string,
+    configuredAddress: string,
+    srcDebridgeChainId: number,
+  ): string {
+    let derivedAddress: string;
+    switch (protocol) {
+      case ProtocolType.Ethereum:
+      case ProtocolType.Tron:
+        derivedAddress = new ethers.Wallet(privateKey).address;
+        break;
+      case ProtocolType.Sealevel:
+        derivedAddress = Keypair.fromSecretKey(
+          parseSolanaPrivateKey(privateKey),
+        ).publicKey.toBase58();
+        break;
+      default: {
+        const exhaustiveProtocol: never = protocol;
+        throw new Error(`Unsupported source protocol: ${exhaustiveProtocol}`);
+      }
+    }
+
+    const formattedDerived = formatAddressForDebridge(
+      derivedAddress,
+      srcDebridgeChainId,
+    );
+    const formattedConfigured = formatAddressForDebridge(
+      configuredAddress,
+      srcDebridgeChainId,
+    );
+    const matches =
+      protocol === ProtocolType.Ethereum
+        ? formattedDerived.toLowerCase() === formattedConfigured.toLowerCase()
+        : formattedDerived === formattedConfigured;
+    assert(matches, `${protocol} private key does not match inventory signer`);
+    return formattedDerived;
+  }
+
+  private validateQuoteParams(params: BridgeQuoteParams): void {
+    assert(
+      params.fromChain !== params.toChain,
+      'Source and destination must differ',
+    );
+    assert(
+      !(params.fromAmount !== undefined && params.toAmount !== undefined),
+      'Cannot specify both fromAmount and toAmount',
+    );
+    assert(
+      params.fromAmount !== undefined || params.toAmount !== undefined,
+      'Must specify either fromAmount or toAmount',
+    );
+    if (params.fromAmount !== undefined) {
+      assert(params.fromAmount > 0n, 'fromAmount must be positive');
+    }
+    if (params.toAmount !== undefined) {
+      assert(params.toAmount > 0n, 'toAmount must be positive');
+    }
+  }
+
+  private validateEstimation(
+    response: DeBridgeQuoteResponse,
+    params: BridgeQuoteParams,
+    limits?: { exactFromAmount: bigint; minimumToAmount: bigint },
+  ): void {
+    const srcChainId = hyperlaneChainIdToDebridge(params.fromChain);
+    const dstChainId = hyperlaneChainIdToDebridge(params.toChain);
+    const { srcChainTokenIn, dstChainTokenOut } = response.estimation;
+
+    assert(
+      srcChainTokenIn.chainId === srcChainId,
+      `deBridge returned unexpected source chain ${srcChainTokenIn.chainId}`,
+    );
+    assert(
+      dstChainTokenOut.chainId === dstChainId,
+      `deBridge returned unexpected destination chain ${dstChainTokenOut.chainId}`,
+    );
+    assert(
+      this.addressesEqual(
+        srcChainTokenIn.address,
+        params.fromToken,
+        srcChainId,
+      ),
+      `deBridge returned unexpected source token ${srcChainTokenIn.address}`,
+    );
+    assert(
+      this.addressesEqual(dstChainTokenOut.address, params.toToken, dstChainId),
+      `deBridge returned unexpected destination token ${dstChainTokenOut.address}`,
+    );
+
+    const fromAmount = BigInt(srcChainTokenIn.amount);
+    const toAmount = BigInt(dstChainTokenOut.amount);
+    assert(fromAmount > 0n, 'deBridge source amount must be positive');
+    assert(toAmount > 0n, 'deBridge destination amount must be positive');
+    const exactFromAmount = limits?.exactFromAmount ?? params.fromAmount;
+    if (exactFromAmount !== undefined) {
+      assert(
+        fromAmount === exactFromAmount,
+        `deBridge returned unexpected source amount ${fromAmount}`,
+      );
+    }
+    const minimumToAmount = limits?.minimumToAmount ?? params.toAmount;
+    if (minimumToAmount !== undefined) {
+      assert(
+        toAmount >= minimumToAmount,
+        `deBridge destination amount ${toAmount} is below required ${minimumToAmount}`,
+      );
+    }
+  }
+
+  private assertFeeWithinLimit(
+    response: DeBridgeQuoteResponse,
+    fromChain: number,
+    toChain: number,
+  ): void {
+    const { srcChainTokenIn, dstChainTokenOut } = response.estimation;
+    const commonDecimals = Math.max(
+      srcChainTokenIn.decimals,
+      dstChainTokenOut.decimals,
+    );
+    const sourceAmount = this.scaleAmount(srcChainTokenIn, commonDecimals);
+    const destinationAmount = this.scaleAmount(
+      dstChainTokenOut,
+      commonDecimals,
+    );
+    const feeAmount =
+      sourceAmount > destinationAmount ? sourceAmount - destinationAmount : 0n;
+    const feeBps =
+      feeAmount === 0n
+        ? 0n
+        : (feeAmount * BASIS_POINTS_DENOMINATOR + sourceAmount - 1n) /
+          sourceAmount;
+
+    this.logger.info(
+      {
+        fromChain,
+        toChain,
+        feeBps: feeBps.toString(),
+        maxFeeBps: this.maxFeeBps,
+      },
+      'deBridge fee guard',
+    );
+    assert(
+      feeBps <= BigInt(this.maxFeeBps),
+      `deBridge fee too high: ${feeBps} bps. Max allowed: ${this.maxFeeBps} bps`,
+    );
+  }
+
+  private scaleAmount(
+    estimation: DeBridgeTokenEstimation,
+    decimals: number,
+  ): bigint {
+    return (
+      BigInt(estimation.amount) * 10n ** BigInt(decimals - estimation.decimals)
+    );
+  }
+
+  private addressesEqual(
+    first: string,
+    second: string,
+    debridgeChainId: number,
+  ): boolean {
+    const formattedFirst = formatAddressForDebridge(first, debridgeChainId);
+    const formattedSecond = formatAddressForDebridge(second, debridgeChainId);
+    return isDebridgeSolanaChain(debridgeChainId) ||
+      isDebridgeTronChain(debridgeChainId)
+      ? formattedFirst === formattedSecond
+      : formattedFirst.toLowerCase() === formattedSecond.toLowerCase();
+  }
+
+  private getEvmLikeAddress(
+    address: string,
+    protocol: ProtocolType.Ethereum | ProtocolType.Tron,
+  ): string {
+    if (protocol === ProtocolType.Ethereum) {
+      assert(
+        ethers.utils.isAddress(address),
+        `Invalid EVM address: ${address}`,
+      );
+      return address.toLowerCase();
+    }
+
+    const formatted = formatAddressForDebridge(address, DEBRIDGE_TRON_CHAIN_ID);
+    return ethers.utils.hexlify(addressToBytesTron(formatted)).toLowerCase();
+  }
+
+  private getProtocol(
+    debridgeChainId: number,
+  ): ProtocolType.Ethereum | ProtocolType.Tron | ProtocolType.Sealevel {
+    if (isDebridgeTronChain(debridgeChainId)) return ProtocolType.Tron;
+    if (isDebridgeSolanaChain(debridgeChainId)) return ProtocolType.Sealevel;
+    return ProtocolType.Ethereum;
+  }
+
+  private getRpcUrl(chainId: number): string {
+    const rpcUrl = this.chainMetadataByChainId.get(chainId)?.rpcUrls?.[0]?.http;
+    assert(rpcUrl, `No RPC URL configured for chain ${chainId}`);
+    return rpcUrl;
+  }
+
+  private validateApiUrl(rawUrl: string): string {
+    const url = new URL(rawUrl);
+    assert(url.protocol === 'https:', 'deBridge API URL must use HTTPS');
+    return url.toString();
+  }
+
+  private buildApiUrl(path: string, params: Record<string, string>): string {
+    const url = new URL(`/v1.0${path}`, this.apiUrl);
+    url.search = new URLSearchParams(params).toString();
+    return url.toString();
+  }
+
+  private async fetchWithRetry(url: string): Promise<Response> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, BASE_BACKOFF_MS * 2 ** (attempt - 1)),
+        );
+      }
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        REQUEST_TIMEOUT_MS,
+      );
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        if (
+          response.status >= 400 &&
+          response.status < 500 &&
+          response.status !== 429
+        ) {
+          const body = await response.text();
+          throw new Error(`deBridge HTTP ${response.status}: ${body}`);
+        }
+        if (response.ok) return response;
+        lastError = new Error(`deBridge HTTP ${response.status}`);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          /^deBridge HTTP 4\d\d:/.test(error.message)
+        ) {
+          throw error;
+        }
+        lastError = error instanceof Error ? error : new Error(String(error));
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }
+
+    throw lastError ?? new Error('deBridge request exhausted retries');
+  }
+}

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.test.ts
@@ -1,5 +1,5 @@
 import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { ProtocolType, bytesToAddressTron } from '@hyperlane-xyz/utils';
 import { AccountLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import {
   AddressLookupTableAccount,
@@ -14,7 +14,15 @@ import {
   VersionedTransaction,
 } from '@solana/web3.js';
 import { expect } from 'chai';
-import { BigNumber, Wallet, providers, utils } from 'ethers';
+import {
+  BigNumber,
+  Contract,
+  Wallet,
+  providers,
+  utils,
+  type BigNumberish,
+  type Signer,
+} from 'ethers';
 import { pino } from 'pino';
 import sinon from 'sinon';
 
@@ -51,6 +59,16 @@ const SOLANA_OTHER_SOURCE_ACCOUNT = Keypair.generate().publicKey;
 const SOLANA_LOOKUP_TABLE_KEY = Keypair.generate().publicKey;
 const SOLANA_PROGRAM = Keypair.generate().publicKey;
 const SOLANA_BLOCKHASH = new PublicKey(new Uint8Array(32).fill(1)).toBase58();
+const TRON_CHAIN_ID = 728126428;
+const TRON_TOKEN_HEX = '0xa614f803b6fd780986a42c78ec9c7f77e6ded13c';
+const TRON_TOKEN_BASE58 = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+const TRON_SENDER_BASE58 = bytesToAddressTron(
+  Buffer.from(SENDER.slice(2), 'hex'),
+);
+const TRON_SPENDER_BASE58 = bytesToAddressTron(
+  Buffer.from(SPENDER.slice(2), 'hex'),
+);
+const TRON_TX_HASH = `0x${'ab'.repeat(32)}`;
 
 const ETHEREUM_METADATA: ChainMetadata = {
   chainId: 1,
@@ -82,9 +100,20 @@ const SOLANA_METADATA: ChainMetadata = {
   nativeToken: { name: 'Solana', symbol: 'SOL', decimals: 9 },
 };
 
+const TRON_METADATA: ChainMetadata = {
+  chainId: TRON_CHAIN_ID,
+  protocol: ProtocolType.Tron,
+  name: 'tron',
+  displayName: 'Tron',
+  domainId: TRON_CHAIN_ID,
+  rpcUrls: [{ http: 'https://tron.example.invalid/jsonrpc' }],
+  nativeToken: { name: 'Tron', symbol: 'TRX', decimals: 6 },
+};
+
 const CHAIN_METADATA: ChainMap<ChainMetadata> = {
   ethereum: ETHEREUM_METADATA,
   base: BASE_METADATA,
+  tron: TRON_METADATA,
 };
 
 function actionResponse(
@@ -188,6 +217,7 @@ function createBridge(
     maxSolanaNativeSpendLamports?: number;
     evmProviderFactory?: (rpcUrl: string) => providers.Provider;
     solanaConnectionFactory?: (rpcUrl: string) => Connection;
+    tronWalletFactory?: (privateKey: string, rpcUrl: string) => Wallet;
     registerTxRetryDelayMs?: number;
     erc20ContractFactory?: Erc20ContractFactory;
   } = {},
@@ -201,6 +231,7 @@ function createBridge(
       maxSolanaNativeSpendLamports: overrides.maxSolanaNativeSpendLamports,
       evmProviderFactory: overrides.evmProviderFactory,
       solanaConnectionFactory: overrides.solanaConnectionFactory,
+      tronWalletFactory: overrides.tronWalletFactory,
       registerTxRetryDelayMs: overrides.registerTxRetryDelayMs,
       erc20ContractFactory: overrides.erc20ContractFactory,
     },
@@ -295,6 +326,97 @@ function createExecuteHarness(response = actionResponse()): {
     getActionStub,
     sendTransactionStub,
     waitForTransactionStub,
+  };
+}
+
+function tronActionResponse(
+  overrides: Partial<SwapsXyzActionResponse> = {},
+): SwapsXyzActionResponse {
+  return actionResponse({
+    tx: {
+      to: TRON_SPENDER_BASE58,
+      toExtra: '0xdeadbeef',
+      value: '0',
+      chainId: TRON_CHAIN_ID,
+      chainKey: 'trx',
+    },
+    txId: 'tron-transfer-id',
+    vmId: 'alt-vm',
+    amountIn: {
+      chainId: TRON_CHAIN_ID,
+      address: TRON_TOKEN_BASE58,
+      amount: '1000000',
+      decimals: 6,
+    },
+    amountOut: {
+      chainId: 1,
+      address: TO_TOKEN,
+      amount: '995000',
+      decimals: 6,
+    },
+    amountOutMin: {
+      chainId: 1,
+      address: TO_TOKEN,
+      amount: '990025',
+      decimals: 6,
+    },
+    requiresRegisterTransaction: true,
+    ...overrides,
+  });
+}
+
+function tronBridgeQuote(
+  response = tronActionResponse(),
+): BridgeQuote<SwapsXyzBridgeRoute> {
+  return {
+    ...bridgeQuote(
+      quoteParams({
+        fromChain: TRON_CHAIN_ID,
+        toChain: 1,
+        fromToken: TRON_TOKEN_HEX,
+        toToken: TO_TOKEN,
+        fromAddress: TRON_SENDER_BASE58,
+        toAddress: SENDER,
+      }),
+    ),
+    id: response.txId,
+    tool: response.bridgeIds?.join('+') || 'swapsxyz',
+    route: { actionResponse: response },
+  };
+}
+
+function createTronExecuteHarness(response = tronActionResponse()): {
+  bridge: SwapsXyzBridge;
+  client: SwapsXyzClient;
+  getActionStub: sinon.SinonStub;
+  registerTxsStub: sinon.SinonStub;
+  sendTransactionStub: sinon.SinonStub;
+  waitStub: sinon.SinonStub;
+  wallet: Wallet;
+} {
+  const client = createClient();
+  const getActionStub = sinon.stub(client, 'getAction').resolves(response);
+  const registerTxsStub = sinon
+    .stub(client, 'registerTxs')
+    .resolves([{ success: true, error: null }]);
+  const wallet = new Wallet(TEST_PRIVATE_KEY);
+  const txResponse = transactionResponse(TRON_TX_HASH);
+  const waitStub = sinon.stub(txResponse, 'wait');
+  const sendTransactionStub = sinon
+    .stub(wallet, 'sendTransaction')
+    .resolves(txResponse);
+  const bridge = createBridge(client, {
+    tronWalletFactory: () => wallet,
+    registerTxRetryDelayMs: 1,
+  });
+  return {
+    bridge,
+    client,
+    getActionStub,
+    registerTxsStub,
+    sendTransactionStub,
+    waitStub,
+    wallet,
   };
 }
 
@@ -590,6 +712,65 @@ function createSolanaExecuteHarness(
 
 describe('SwapsXyzBridge.quote', () => {
   afterEach(() => sinon.restore());
+
+  it('normalizes Tron senders, recipients, and tokens to checksummed base58', async () => {
+    const client = createClient();
+    const getActionStub = sinon
+      .stub(client, 'getAction')
+      .resolves(tronActionResponse());
+    const bridge = createBridge(client);
+
+    await bridge.quote(
+      quoteParams({
+        fromChain: TRON_CHAIN_ID,
+        toChain: 1,
+        fromToken: TRON_TOKEN_HEX,
+        toToken: TO_TOKEN,
+        fromAddress: SENDER,
+        toAddress: SENDER,
+      }),
+    );
+    await bridge.quote(
+      quoteParams({
+        fromChain: 1,
+        toChain: TRON_CHAIN_ID,
+        fromToken: FROM_TOKEN,
+        toToken: TRON_TOKEN_HEX,
+        fromAddress: SENDER,
+        toAddress: SENDER,
+      }),
+    );
+
+    expect(getActionStub.firstCall.args[0]).to.include({
+      sender: TRON_SENDER_BASE58,
+      srcToken: TRON_TOKEN_BASE58,
+      recipient: SENDER,
+    });
+    expect(getActionStub.secondCall.args[0]).to.include({
+      sender: SENDER,
+      dstToken: TRON_TOKEN_BASE58,
+      recipient: TRON_SENDER_BASE58,
+    });
+  });
+
+  it('rejects invalid Tron base58 checksums before quoting', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    const invalidToken = `${TRON_TOKEN_BASE58.slice(0, -1)}1`;
+
+    const error = await captureError(
+      createBridge(client).quote(
+        quoteParams({
+          fromChain: TRON_CHAIN_ID,
+          fromToken: invalidToken,
+          fromAddress: SENDER,
+        }),
+      ),
+    );
+
+    expect(error.message).to.include('invalid Tron address');
+    expect(getActionStub.callCount).to.equal(0);
+  });
 
   it('maps fees, tool, id, costs, duration, and amountInMax', async () => {
     const client = createClient();
@@ -958,6 +1139,257 @@ describe('SwapsXyzBridge.execute', () => {
 
     expect(error.message).to.include('Ethereum (EVM) private key');
     expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('throws before re-quoting when the Tron private key is missing', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+
+    const error = await captureError(
+      createBridge(client).execute(tronBridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('Tron private key');
+    expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('throws before re-quoting when the Tron signer does not match', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    const quote = tronBridgeQuote();
+    quote.requestParams.fromAddress =
+      '0x4444444444444444444444444444444444444444';
+
+    const error = await captureError(
+      createBridge(client, {
+        tronWalletFactory: () => new Wallet(TEST_PRIVATE_KEY),
+      }).execute(quote, { [ProtocolType.Tron]: TEST_PRIVATE_KEY }),
+    );
+
+    expect(error.message).to.include('Tron signer does not match');
+    expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('broadcasts Tron calldata and returns before confirmation', async () => {
+    const harness = createTronExecuteHarness();
+
+    const result = await harness.bridge.execute(tronBridgeQuote(), {
+      [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+    });
+
+    expect(harness.getActionStub.firstCall.args[0]).to.include({
+      sender: TRON_SENDER_BASE58,
+      srcToken: TRON_TOKEN_BASE58,
+    });
+    expect(harness.sendTransactionStub.firstCall.args[0]).to.deep.include({
+      to: SPENDER,
+      data: '0xdeadbeef',
+    });
+    expect(harness.waitStub.callCount).to.equal(0);
+    expect(result).to.deep.equal({
+      txHash: TRON_TX_HASH,
+      fromChain: TRON_CHAIN_ID,
+      toChain: 1,
+      transferId: 'tron-transfer-id',
+    });
+  });
+
+  it('broadcasts the direct TRC20 deposit shape returned by swaps.xyz', async () => {
+    const accepted = tronActionResponse({
+      tx: {
+        to: TRON_SPENDER_BASE58,
+        toExtra: null,
+        value: '1000000',
+        chainId: TRON_CHAIN_ID,
+        chainKey: 'trx',
+      },
+      bridgeIds: ['alt-vm-1'],
+    });
+    const freshRecipient = '0x4444444444444444444444444444444444444444';
+    const response = tronActionResponse({
+      tx: {
+        to: bytesToAddressTron(Buffer.from(freshRecipient.slice(2), 'hex')),
+        toExtra: null,
+        value: '1000000',
+        chainId: TRON_CHAIN_ID,
+        chainKey: 'trx',
+      },
+      bridgeIds: ['alt-vm-1'],
+    });
+    const harness = createTronExecuteHarness(response);
+
+    const result = await harness.bridge.execute(tronBridgeQuote(accepted), {
+      [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+    });
+
+    const sent = harness.sendTransactionStub.firstCall.args[0];
+    expect(sent.to).to.equal(TRON_TOKEN_HEX);
+    expect(BigNumber.from(sent.value).isZero()).to.equal(true);
+    const transfer = new utils.Interface([
+      'function transfer(address recipient, uint256 amount) returns (bool)',
+    ]).decodeFunctionData('transfer', sent.data);
+    expect(transfer.recipient.toLowerCase()).to.equal(
+      freshRecipient.toLowerCase(),
+    );
+    expect(transfer.amount.toString()).to.equal('1000000');
+    expect(harness.waitStub.callCount).to.equal(0);
+    expect(result.transferId).to.equal('tron-transfer-id');
+  });
+
+  it('rejects a refreshed direct Tron deposit on another bridge rail', async () => {
+    const directTx = {
+      to: TRON_SPENDER_BASE58,
+      toExtra: null,
+      value: '1000000',
+      chainId: TRON_CHAIN_ID,
+      chainKey: 'trx' as const,
+    };
+    const accepted = tronActionResponse({
+      tx: directTx,
+      bridgeIds: ['alt-vm-1'],
+    });
+    const fresh = tronActionResponse({
+      tx: {
+        ...directTx,
+        to: bytesToAddressTron(Buffer.from('44'.repeat(20), 'hex')),
+      },
+      bridgeIds: ['other-rail'],
+    });
+    const harness = createTronExecuteHarness(fresh);
+
+    const error = await captureError(
+      harness.bridge.execute(tronBridgeQuote(accepted), {
+        [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('fresh bridge');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects an unregistrable Tron action before broadcasting', async () => {
+    const harness = createTronExecuteHarness(
+      tronActionResponse({ requiresRegisterTransaction: false }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(tronBridgeQuote(), {
+        [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('must require transaction registration');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects a direct Tron source-token call', async () => {
+    const harness = createTronExecuteHarness(
+      tronActionResponse({
+        tx: {
+          to: TRON_TOKEN_BASE58,
+          toExtra: `0xa9059cbb${'00'.repeat(64)}`,
+          value: '0',
+          chainId: TRON_CHAIN_ID,
+          chainKey: 'trx',
+        },
+      }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(tronBridgeQuote(), {
+        [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('direct source-token selector');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects refreshed Tron target and selector changes', async () => {
+    for (const tx of [
+      {
+        to: bytesToAddressTron(Buffer.from('44'.repeat(20), 'hex')),
+        toExtra: '0xdeadbeef',
+      },
+      { to: TRON_SPENDER_BASE58, toExtra: '0xfeedface' },
+    ]) {
+      const harness = createTronExecuteHarness(
+        tronActionResponse({
+          tx: {
+            ...tx,
+            value: '0',
+            chainId: TRON_CHAIN_ID,
+            chainKey: 'trx',
+          },
+        }),
+      );
+
+      const error = await captureError(
+        harness.bridge.execute(tronBridgeQuote(), {
+          [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+        }),
+      );
+
+      expect(error.message).to.match(/fresh target|calldata selector/);
+      expect(harness.sendTransactionStub.callCount).to.equal(0);
+      sinon.restore();
+    }
+  });
+
+  it('resets and approves the exact Tron token input', async () => {
+    const harness = createTronExecuteHarness(
+      tronActionResponse({ requiresTokenApproval: true }),
+    );
+    const allowanceStub = sinon
+      .stub<[string, string], Promise<BigNumber>>()
+      .resolves(BigNumber.from('2000000'));
+    const approveStub = sinon.stub<
+      [string, BigNumberish],
+      Promise<providers.TransactionResponse>
+    >();
+    approveStub
+      .onFirstCall()
+      .resolves(transactionResponse(`0x${'cd'.repeat(32)}`));
+    approveStub
+      .onSecondCall()
+      .resolves(transactionResponse(`0x${'ef'.repeat(32)}`));
+
+    class TronApprovalContract extends Contract {
+      constructor() {
+        super(TRON_TOKEN_HEX, [], harness.wallet);
+      }
+      allowance(owner: string, spender: string): Promise<BigNumber> {
+        return allowanceStub(owner, spender);
+      }
+      approve(
+        spender: string,
+        amount: BigNumberish,
+      ): Promise<providers.TransactionResponse> {
+        return approveStub(spender, amount);
+      }
+    }
+
+    const contractFactory = sinon
+      .stub<[string, string[], Signer], Contract>()
+      .returns(new TronApprovalContract());
+    const bridge = createBridge(harness.client, {
+      tronWalletFactory: () => harness.wallet,
+      erc20ContractFactory: contractFactory,
+      registerTxRetryDelayMs: 1,
+    });
+
+    await bridge.execute(tronBridgeQuote(), {
+      [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+    });
+
+    expect(contractFactory.firstCall.args[0]).to.equal(TRON_TOKEN_HEX);
+    expect(approveStub.callCount).to.equal(2);
+    expect(BigNumber.from(approveStub.firstCall.args[1]).isZero()).to.be.true;
+    expect(BigNumber.from(approveStub.secondCall.args[1]).toString()).to.equal(
+      '1000000',
+    );
   });
 
   it('throws before re-quoting when the signer does not match fromAddress', async () => {

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.test.ts
@@ -1,5 +1,18 @@
 import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
+import { AccountLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import {
+  AddressLookupTableAccount,
+  type AccountInfo,
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
 import { expect } from 'chai';
 import { BigNumber, Wallet, providers, utils } from 'ethers';
 import { pino } from 'pino';
@@ -28,6 +41,16 @@ const TO_TOKEN = '0x2222222222222222222222222222222222222222';
 const SPENDER = '0xfffffffffffffffffffffffffffffffffffffff1';
 const SENDER = TEST_WALLET.address;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const SOLANA_DOMAIN = 1399811149;
+const SOLANA_KEYPAIR = Keypair.fromSeed(new Uint8Array(32).fill(7));
+const SOLANA_PRIVATE_KEY = JSON.stringify(Array.from(SOLANA_KEYPAIR.secretKey));
+const SOLANA_TOKEN = Keypair.generate().publicKey;
+const SOLANA_SOURCE_ACCOUNT = Keypair.generate().publicKey;
+const SOLANA_OTHER_TOKEN = Keypair.generate().publicKey;
+const SOLANA_OTHER_SOURCE_ACCOUNT = Keypair.generate().publicKey;
+const SOLANA_LOOKUP_TABLE_KEY = Keypair.generate().publicKey;
+const SOLANA_PROGRAM = Keypair.generate().publicKey;
+const SOLANA_BLOCKHASH = new PublicKey(new Uint8Array(32).fill(1)).toBase58();
 
 const ETHEREUM_METADATA: ChainMetadata = {
   chainId: 1,
@@ -47,6 +70,16 @@ const BASE_METADATA: ChainMetadata = {
   domainId: 8453,
   rpcUrls: [{ http: 'https://base.example.invalid' }],
   nativeToken: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+};
+
+const SOLANA_METADATA: ChainMetadata = {
+  chainId: SOLANA_DOMAIN,
+  protocol: ProtocolType.Sealevel,
+  name: 'solanamainnet',
+  displayName: 'Solana',
+  domainId: SOLANA_DOMAIN,
+  rpcUrls: [{ http: 'https://solana.example.invalid' }],
+  nativeToken: { name: 'Solana', symbol: 'SOL', decimals: 9 },
 };
 
 const CHAIN_METADATA: ChainMap<ChainMetadata> = {
@@ -152,7 +185,9 @@ function createBridge(
     chainMetadata?: ChainMap<ChainMetadata>;
     defaultSlippage?: number;
     maxQuoteLossBps?: number;
+    maxSolanaNativeSpendLamports?: number;
     evmProviderFactory?: (rpcUrl: string) => providers.Provider;
+    solanaConnectionFactory?: (rpcUrl: string) => Connection;
     registerTxRetryDelayMs?: number;
     erc20ContractFactory?: Erc20ContractFactory;
   } = {},
@@ -163,7 +198,9 @@ function createBridge(
       chainMetadata: overrides.chainMetadata ?? CHAIN_METADATA,
       defaultSlippage: overrides.defaultSlippage,
       maxQuoteLossBps: overrides.maxQuoteLossBps,
+      maxSolanaNativeSpendLamports: overrides.maxSolanaNativeSpendLamports,
       evmProviderFactory: overrides.evmProviderFactory,
+      solanaConnectionFactory: overrides.solanaConnectionFactory,
       registerTxRetryDelayMs: overrides.registerTxRetryDelayMs,
       erc20ContractFactory: overrides.erc20ContractFactory,
     },
@@ -258,6 +295,296 @@ function createExecuteHarness(response = actionResponse()): {
     getActionStub,
     sendTransactionStub,
     waitForTransactionStub,
+  };
+}
+
+function tokenAccountData(
+  amount: bigint,
+  overrides: {
+    mint?: PublicKey;
+    delegateOption?: 0 | 1;
+    delegate?: PublicKey;
+  } = {},
+): Buffer {
+  const data = Buffer.alloc(AccountLayout.span);
+  AccountLayout.encode(
+    {
+      mint: overrides.mint ?? SOLANA_TOKEN,
+      owner: SOLANA_KEYPAIR.publicKey,
+      amount,
+      delegateOption: overrides.delegateOption ?? 0,
+      delegate: overrides.delegate ?? PublicKey.default,
+      state: 1,
+      isNativeOption: 0,
+      isNative: 0n,
+      delegatedAmount: 0n,
+      closeAuthorityOption: 0,
+      closeAuthority: PublicKey.default,
+    },
+    data,
+  );
+  return data;
+}
+
+function accountInfo(
+  owner: PublicKey,
+  data: Buffer,
+  lamports: number,
+): AccountInfo<Buffer> {
+  return { owner, data, lamports, executable: false, rentEpoch: 0 };
+}
+
+function simulatedAccount(owner: PublicKey, data: Buffer, lamports: number) {
+  return {
+    owner: owner.toBase58(),
+    data: [data.toString('base64'), 'base64'],
+    lamports,
+    executable: false,
+    rentEpoch: 0,
+  };
+}
+
+function solanaLookupTableAccount(): AddressLookupTableAccount {
+  return new AddressLookupTableAccount({
+    key: SOLANA_LOOKUP_TABLE_KEY,
+    state: {
+      deactivationSlot: 18_446_744_073_709_551_615n,
+      lastExtendedSlot: 0,
+      lastExtendedSlotStartIndex: 0,
+      authority: undefined,
+      addresses: [SOLANA_SOURCE_ACCOUNT],
+    },
+  });
+}
+
+function serializedSolanaTransaction(
+  options: {
+    lookupTable?: AddressLookupTableAccount;
+    additionalWritable?: PublicKey;
+  } = {},
+): string {
+  const instruction = new TransactionInstruction({
+    programId: SOLANA_PROGRAM,
+    keys: [
+      {
+        pubkey: SOLANA_SOURCE_ACCOUNT,
+        isSigner: false,
+        isWritable: true,
+      },
+      ...(options.additionalWritable
+        ? [
+            {
+              pubkey: options.additionalWritable,
+              isSigner: false,
+              isWritable: true,
+            },
+          ]
+        : []),
+    ],
+    data: Buffer.from([1]),
+  });
+  const message = new TransactionMessage({
+    payerKey: SOLANA_KEYPAIR.publicKey,
+    recentBlockhash: SOLANA_BLOCKHASH,
+    instructions: [instruction],
+  }).compileToV0Message(
+    options.lookupTable === undefined ? [] : [options.lookupTable],
+  );
+  return Buffer.from(new VersionedTransaction(message).serialize()).toString(
+    'base64',
+  );
+}
+
+function serializedLegacySolanaTransaction(): string {
+  const transaction = new Transaction({
+    feePayer: SOLANA_KEYPAIR.publicKey,
+    recentBlockhash: SOLANA_BLOCKHASH,
+  }).add(
+    new TransactionInstruction({
+      programId: SOLANA_PROGRAM,
+      keys: [
+        {
+          pubkey: SOLANA_SOURCE_ACCOUNT,
+          isSigner: false,
+          isWritable: true,
+        },
+      ],
+      data: Buffer.from([1]),
+    }),
+  );
+  return transaction
+    .serialize({ requireAllSignatures: false, verifySignatures: false })
+    .toString('base64');
+}
+
+function solanaActionResponse(
+  overrides: Partial<SwapsXyzActionResponse> = {},
+): SwapsXyzActionResponse {
+  return actionResponse({
+    tx: {
+      base64Tx: serializedSolanaTransaction(),
+      payer: SOLANA_KEYPAIR.publicKey.toBase58(),
+      chainId: SOLANA_DOMAIN,
+    },
+    txId: 'solana-tx-1',
+    vmId: 'solana',
+    amountIn: {
+      chainId: SOLANA_DOMAIN,
+      address: SOLANA_TOKEN.toBase58(),
+      amount: '1000000',
+      decimals: 6,
+    },
+    amountOut: {
+      chainId: 1,
+      address: FROM_TOKEN,
+      amount: '995000',
+      decimals: 6,
+    },
+    amountOutMin: {
+      chainId: 1,
+      address: FROM_TOKEN,
+      amount: '990025',
+      decimals: 6,
+    },
+    bridgeIds: ['solana-rail'],
+    requiresRegisterTransaction: true,
+    ...overrides,
+  });
+}
+
+function solanaQuote(
+  response = solanaActionResponse(),
+  overrides: Partial<BridgeQuoteParams> = {},
+): BridgeQuote<SwapsXyzBridgeRoute> {
+  const params: BridgeQuoteParams = {
+    fromChain: SOLANA_DOMAIN,
+    toChain: 1,
+    fromToken: SOLANA_TOKEN.toBase58(),
+    toToken: FROM_TOKEN,
+    fromAmount: 1_000_000n,
+    fromAddress: SOLANA_KEYPAIR.publicKey.toBase58(),
+    toAddress: SENDER,
+    ...overrides,
+  };
+  return {
+    id: response.txId,
+    tool: 'solana-rail',
+    fromAmount: 1_000_000n,
+    toAmount: 995_000n,
+    toAmountMin: 990_025n,
+    executionDuration: 60,
+    gasCosts: 0n,
+    feeCosts: 0n,
+    route: { actionResponse: response },
+    requestParams: params,
+  };
+}
+
+function createSolanaExecuteHarness(
+  options: {
+    response?: SwapsXyzActionResponse;
+    postSourceData?: Buffer;
+    postSignerLamports?: number;
+    postSignerOwner?: PublicKey;
+    maxSolanaNativeSpendLamports?: number;
+    lookupTable?: AddressLookupTableAccount;
+    additionalSignerToken?: {
+      address: PublicKey;
+      mint: PublicKey;
+      preAmount: bigint;
+      postAmount: bigint;
+    };
+  } = {},
+) {
+  const response = options.response ?? solanaActionResponse();
+  const client = createClient();
+  const connection = new Connection('https://solana.example.invalid');
+  const getActionStub = sinon.stub(client, 'getAction').resolves(response);
+  const preAccounts = [
+    accountInfo(SystemProgram.programId, Buffer.alloc(0), 1_000_000_000),
+    accountInfo(TOKEN_PROGRAM_ID, tokenAccountData(1_000_000n), 2_039_280),
+  ];
+  const postAccounts = [
+    simulatedAccount(
+      options.postSignerOwner ?? SystemProgram.programId,
+      Buffer.alloc(0),
+      options.postSignerLamports ?? 999_995_000,
+    ),
+    simulatedAccount(
+      TOKEN_PROGRAM_ID,
+      options.postSourceData ?? tokenAccountData(0n),
+      2_039_280,
+    ),
+  ];
+  if (options.additionalSignerToken) {
+    preAccounts.push(
+      accountInfo(
+        TOKEN_PROGRAM_ID,
+        tokenAccountData(options.additionalSignerToken.preAmount, {
+          mint: options.additionalSignerToken.mint,
+        }),
+        2_039_280,
+      ),
+    );
+    postAccounts.push(
+      simulatedAccount(
+        TOKEN_PROGRAM_ID,
+        tokenAccountData(options.additionalSignerToken.postAmount, {
+          mint: options.additionalSignerToken.mint,
+        }),
+        2_039_280,
+      ),
+    );
+  }
+  const getMultipleAccountsInfoStub = sinon
+    .stub(connection, 'getMultipleAccountsInfoAndContext')
+    .resolves({ context: { slot: 1 }, value: preAccounts });
+  if (options.lookupTable) {
+    sinon.stub(connection, 'getAddressLookupTable').resolves({
+      context: { slot: 1 },
+      value: options.lookupTable,
+    });
+  }
+  sinon.stub(connection, 'getLatestBlockhash').resolves({
+    blockhash: SOLANA_BLOCKHASH,
+    lastValidBlockHeight: 100,
+  });
+  const simulateTransactionStub = sinon
+    .stub(connection, 'simulateTransaction')
+    .resolves({
+      context: { slot: 1 },
+      value: {
+        err: null,
+        logs: [],
+        accounts: postAccounts,
+        unitsConsumed: 1,
+      },
+    });
+  sinon.stub(connection, 'getFeeForMessage').resolves({
+    context: { slot: 1 },
+    value: 5_000,
+  });
+  const sendRawTransactionStub = sinon
+    .stub(connection, 'sendRawTransaction')
+    .resolves('solana-signature');
+  const registerTxsStub = sinon
+    .stub(client, 'registerTxs')
+    .resolves([{ success: true, error: null }]);
+  const bridge = createBridge(client, {
+    chainMetadata: { ethereum: ETHEREUM_METADATA, solana: SOLANA_METADATA },
+    solanaConnectionFactory: () => connection,
+    maxSolanaNativeSpendLamports:
+      options.maxSolanaNativeSpendLamports ?? 10_000_000,
+    registerTxRetryDelayMs: 1,
+  });
+  return {
+    bridge,
+    connection,
+    getActionStub,
+    getMultipleAccountsInfoStub,
+    simulateTransactionStub,
+    sendRawTransactionStub,
+    registerTxsStub,
   };
 }
 
@@ -1048,6 +1375,221 @@ describe('SwapsXyzBridge.execute', () => {
 
     expect(error.message).to.include('fresh minimum output');
     expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+});
+
+describe('SwapsXyzBridge.execute Solana', () => {
+  afterEach(() => sinon.restore());
+
+  it('simulates, binds, broadcasts, and registers an exact-input transfer', async () => {
+    const harness = createSolanaExecuteHarness();
+
+    const result = await harness.bridge.execute(solanaQuote(), {
+      [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(result).to.deep.equal({
+      txHash: 'solana-signature',
+      fromChain: SOLANA_DOMAIN,
+      toChain: 1,
+      transferId: 'solana-tx-1',
+    });
+    expect(harness.simulateTransactionStub.callCount).to.equal(1);
+    expect(harness.simulateTransactionStub.firstCall.args[1]).to.include({
+      minContextSlot: 1,
+      sigVerify: true,
+    });
+    expect(harness.sendRawTransactionStub.callCount).to.equal(1);
+    expect(harness.registerTxsStub.firstCall.args[0]).to.deep.equal([
+      { txId: 'solana-tx-1', txHash: 'solana-signature' },
+    ]);
+  });
+
+  it('supports legacy Solana transactions through the same validation', async () => {
+    const response = solanaActionResponse({
+      tx: {
+        base64Tx: serializedLegacySolanaTransaction(),
+        payer: SOLANA_KEYPAIR.publicKey.toBase58(),
+        chainId: SOLANA_DOMAIN,
+      },
+    });
+    const harness = createSolanaExecuteHarness({ response });
+
+    await harness.bridge.execute(solanaQuote(response), {
+      [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+    });
+
+    expect(harness.sendRawTransactionStub.callCount).to.equal(1);
+  });
+
+  it('resolves address lookup tables before validating effects', async () => {
+    const lookupTable = solanaLookupTableAccount();
+    const response = solanaActionResponse({
+      tx: {
+        base64Tx: serializedSolanaTransaction({ lookupTable }),
+        payer: SOLANA_KEYPAIR.publicKey.toBase58(),
+        chainId: SOLANA_DOMAIN,
+      },
+    });
+    const harness = createSolanaExecuteHarness({ response, lookupTable });
+
+    await harness.bridge.execute(solanaQuote(response), {
+      [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+    });
+
+    expect(harness.sendRawTransactionStub.callCount).to.equal(1);
+  });
+
+  it('rejects a source-token debit that does not match exact input', async () => {
+    const harness = createSolanaExecuteHarness({
+      postSourceData: tokenAccountData(1n),
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(solanaQuote(), {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('does not match exact input');
+    expect(harness.sendRawTransactionStub.callCount).to.equal(0);
+  });
+
+  it('accepts a positive source-token debit below an exact-output cap', async () => {
+    const response = solanaActionResponse({
+      amountInMax: {
+        chainId: SOLANA_DOMAIN,
+        address: SOLANA_TOKEN.toBase58(),
+        amount: '1000000',
+      },
+    });
+    const harness = createSolanaExecuteHarness({
+      response,
+      postSourceData: tokenAccountData(100n),
+    });
+    const quote = solanaQuote(response, {
+      fromAmount: undefined,
+      toAmount: 995_000n,
+    });
+
+    await harness.bridge.execute(quote, {
+      [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+    });
+
+    expect(harness.sendRawTransactionStub.callCount).to.equal(1);
+  });
+
+  it('rejects source-token authority changes', async () => {
+    const harness = createSolanaExecuteHarness({
+      postSourceData: tokenAccountData(0n, {
+        delegateOption: 1,
+        delegate: Keypair.generate().publicKey,
+      }),
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(solanaQuote(), {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('changes authority or state');
+    expect(harness.sendRawTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects debits from another signer-owned token', async () => {
+    const response = solanaActionResponse({
+      tx: {
+        base64Tx: serializedSolanaTransaction({
+          additionalWritable: SOLANA_OTHER_SOURCE_ACCOUNT,
+        }),
+        payer: SOLANA_KEYPAIR.publicKey.toBase58(),
+        chainId: SOLANA_DOMAIN,
+      },
+    });
+    const harness = createSolanaExecuteHarness({
+      response,
+      additionalSignerToken: {
+        address: SOLANA_OTHER_SOURCE_ACCOUNT,
+        mint: SOLANA_OTHER_TOKEN,
+        preAmount: 100n,
+        postAmount: 99n,
+      },
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(solanaQuote(response), {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('debits non-source token account');
+    expect(harness.sendRawTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects changing the signer account owner', async () => {
+    const harness = createSolanaExecuteHarness({
+      postSignerOwner: SOLANA_PROGRAM,
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(solanaQuote(), {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('signer account ownership or data');
+    expect(harness.sendRawTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects native spend above transaction fee plus configured cap', async () => {
+    const harness = createSolanaExecuteHarness({
+      postSignerLamports: 999_989_999,
+      maxSolanaNativeSpendLamports: 5_000,
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(solanaQuote(), {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('native spend');
+    expect(harness.sendRawTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects simulation failures before broadcast', async () => {
+    const harness = createSolanaExecuteHarness();
+    harness.simulateTransactionStub.resolves({
+      context: { slot: 1 },
+      value: { err: { InstructionError: [0, 'Custom'] }, logs: [] },
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(solanaQuote(), {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('simulation failed');
+    expect(harness.sendRawTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects a quote whose Solana signer does not match fromAddress', async () => {
+    const harness = createSolanaExecuteHarness();
+    const quote = solanaQuote(solanaActionResponse(), {
+      fromAddress: Keypair.generate().publicKey.toBase58(),
+    });
+
+    const error = await captureError(
+      harness.bridge.execute(quote, {
+        [ProtocolType.Sealevel]: SOLANA_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('signer does not match');
+    expect(harness.getActionStub.callCount).to.equal(0);
   });
 });
 

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.test.ts
@@ -1,0 +1,1226 @@
+import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { expect } from 'chai';
+import { BigNumber, Wallet, providers, utils } from 'ethers';
+import { pino } from 'pino';
+import sinon from 'sinon';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+} from '../interfaces/IExternalBridge.js';
+
+import {
+  SwapsXyzClient,
+  SwapsXyzRequestError,
+  type SwapsXyzActionResponse,
+  type SwapsXyzStatus,
+  type SwapsXyzStatusResponse,
+} from './SwapsXyzClient.js';
+import { SwapsXyzBridge, type SwapsXyzBridgeRoute } from './SwapsXyzBridge.js';
+import type { Erc20ContractFactory } from './erc20Approve.js';
+
+const logger = pino({ level: 'silent' });
+const TEST_WALLET = Wallet.createRandom();
+const TEST_PRIVATE_KEY = TEST_WALLET.privateKey;
+const FROM_TOKEN = '0x1111111111111111111111111111111111111111';
+const TO_TOKEN = '0x2222222222222222222222222222222222222222';
+const SPENDER = '0xfffffffffffffffffffffffffffffffffffffff1';
+const SENDER = TEST_WALLET.address;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const ETHEREUM_METADATA: ChainMetadata = {
+  chainId: 1,
+  protocol: ProtocolType.Ethereum,
+  name: 'ethereum',
+  displayName: 'Ethereum',
+  domainId: 1,
+  rpcUrls: [{ http: 'https://ethereum.example.invalid' }],
+  nativeToken: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+};
+
+const BASE_METADATA: ChainMetadata = {
+  chainId: 8453,
+  protocol: ProtocolType.Ethereum,
+  name: 'base',
+  displayName: 'Base',
+  domainId: 8453,
+  rpcUrls: [{ http: 'https://base.example.invalid' }],
+  nativeToken: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+};
+
+const CHAIN_METADATA: ChainMap<ChainMetadata> = {
+  ethereum: ETHEREUM_METADATA,
+  base: BASE_METADATA,
+};
+
+function actionResponse(
+  overrides: Partial<SwapsXyzActionResponse> = {},
+): SwapsXyzActionResponse {
+  return {
+    tx: {
+      to: SPENDER,
+      data: '0xdeadbeef',
+      value: '0',
+      chainId: 1,
+    },
+    txId: 'tx-1',
+    vmId: 'evm',
+    amountIn: {
+      chainId: 1,
+      address: FROM_TOKEN,
+      amount: '1000000',
+      decimals: 6,
+    },
+    amountOut: {
+      chainId: 8453,
+      address: TO_TOKEN,
+      amount: '995000',
+      decimals: 6,
+    },
+    amountOutMin: {
+      chainId: 8453,
+      address: TO_TOKEN,
+      amount: '990025',
+      decimals: 6,
+    },
+    bridgeIds: ['across'],
+    requiresTokenApproval: false,
+    estimatedTxTime: 60,
+    protocolFee: { amount: '100' },
+    applicationFee: { amount: '50' },
+    bridgeFee: { amount: '200' },
+    ...overrides,
+  };
+}
+
+function quoteParams(
+  overrides: Partial<BridgeQuoteParams> = {},
+): BridgeQuoteParams {
+  return {
+    fromChain: 1,
+    toChain: 8453,
+    fromToken: FROM_TOKEN,
+    toToken: TO_TOKEN,
+    fromAmount: 1_000_000n,
+    fromAddress: SENDER,
+    ...overrides,
+  };
+}
+
+function bridgeQuote(
+  params: BridgeQuoteParams = quoteParams(),
+): BridgeQuote<SwapsXyzBridgeRoute> {
+  const response = actionResponse();
+  return {
+    id: response.txId,
+    tool: 'across',
+    fromAmount: 1_000_000n,
+    toAmount: 995_000n,
+    toAmountMin: 990_025n,
+    executionDuration: 60,
+    gasCosts: 0n,
+    feeCosts: 350n,
+    route: { actionResponse: response },
+    requestParams: params,
+  };
+}
+
+function statusResponse(
+  status: SwapsXyzStatus,
+  overrides: Partial<SwapsXyzStatusResponse> = {},
+): SwapsXyzStatusResponse {
+  return {
+    status,
+    txId: 'tx-1',
+    srcChainId: 1,
+    dstChainId: 8453,
+    srcTxHash: '0xsource',
+    dstTxHash: '0xdestination',
+    actionResponse: actionResponse(),
+    ...overrides,
+  };
+}
+
+function createClient(): SwapsXyzClient {
+  return new SwapsXyzClient({ apiKey: 'test-key' }, logger);
+}
+
+function createBridge(
+  client: SwapsXyzClient,
+  overrides: {
+    chainMetadata?: ChainMap<ChainMetadata>;
+    defaultSlippage?: number;
+    maxQuoteLossBps?: number;
+    evmProviderFactory?: (rpcUrl: string) => providers.Provider;
+    registerTxRetryDelayMs?: number;
+    erc20ContractFactory?: Erc20ContractFactory;
+  } = {},
+): SwapsXyzBridge {
+  return new SwapsXyzBridge(
+    {
+      apiKey: 'test-key',
+      chainMetadata: overrides.chainMetadata ?? CHAIN_METADATA,
+      defaultSlippage: overrides.defaultSlippage,
+      maxQuoteLossBps: overrides.maxQuoteLossBps,
+      evmProviderFactory: overrides.evmProviderFactory,
+      registerTxRetryDelayMs: overrides.registerTxRetryDelayMs,
+      erc20ContractFactory: overrides.erc20ContractFactory,
+    },
+    logger,
+    client,
+  );
+}
+
+async function captureError(promise: Promise<unknown>): Promise<Error> {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+  if (!(caught instanceof Error)) {
+    throw new Error(`Expected an Error, received ${String(caught)}`);
+  }
+  return caught;
+}
+
+function transactionReceipt(
+  hash: string,
+  status: number,
+): providers.TransactionReceipt {
+  return {
+    to: SPENDER,
+    from: SENDER,
+    contractAddress: '',
+    transactionIndex: 0,
+    gasUsed: BigNumber.from(1),
+    logsBloom: '0x',
+    blockHash: '0xblock',
+    transactionHash: hash,
+    logs: [],
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: BigNumber.from(1),
+    effectiveGasPrice: BigNumber.from(1),
+    byzantium: true,
+    type: 2,
+    status,
+  };
+}
+
+function transactionResponse(
+  hash: string,
+  status = 1,
+): providers.TransactionResponse {
+  return {
+    hash,
+    confirmations: 0,
+    from: SENDER,
+    nonce: 0,
+    gasLimit: BigNumber.from(1),
+    gasPrice: BigNumber.from(1),
+    data: '0x',
+    value: BigNumber.from(0),
+    chainId: 1,
+    wait: async () => transactionReceipt(hash, status),
+  };
+}
+
+function createExecuteHarness(response = actionResponse()): {
+  bridge: SwapsXyzBridge;
+  client: SwapsXyzClient;
+  provider: providers.StaticJsonRpcProvider;
+  getActionStub: sinon.SinonStub;
+  sendTransactionStub: sinon.SinonStub;
+  waitForTransactionStub: sinon.SinonStub;
+} {
+  const client = createClient();
+  const provider = new providers.StaticJsonRpcProvider(
+    'https://ethereum.example.invalid',
+    { chainId: 1, name: 'ethereum' },
+  );
+  const bridge = createBridge(client, {
+    evmProviderFactory: () => provider,
+    registerTxRetryDelayMs: 1,
+  });
+  const getActionStub = sinon.stub(client, 'getAction').resolves(response);
+  const sendTransactionStub = sinon
+    .stub(Wallet.prototype, 'sendTransaction')
+    .resolves(transactionResponse('0xbridge'));
+  const waitForTransactionStub = sinon
+    .stub(provider, 'waitForTransaction')
+    .resolves(transactionReceipt('0xbridge', 1));
+  return {
+    bridge,
+    client,
+    provider,
+    getActionStub,
+    sendTransactionStub,
+    waitForTransactionStub,
+  };
+}
+
+describe('SwapsXyzBridge.quote', () => {
+  afterEach(() => sinon.restore());
+
+  it('maps fees, tool, id, costs, duration, and amountInMax', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getAction').resolves(
+      actionResponse({
+        txId: 'fresh-id',
+        bridgeIds: ['across', 'cctp'],
+        amountInMax: { amount: '1005000' },
+      }),
+    );
+    const quote = await createBridge(client).quote(quoteParams());
+
+    expect(quote.id).to.equal('fresh-id');
+    expect(quote.tool).to.equal('across+cctp');
+    expect(quote.fromAmount).to.equal(1_005_000n);
+    expect(quote.toAmount).to.equal(995_000n);
+    expect(quote.toAmountMin).to.equal(990_025n);
+    expect(quote.executionDuration).to.equal(60);
+    expect(quote.gasCosts).to.equal(0n);
+    expect(quote.feeCosts).to.equal(350n);
+  });
+
+  it('defaults tool, duration, and absent fees', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getAction').resolves(
+      actionResponse({
+        bridgeIds: undefined,
+        estimatedTxTime: undefined,
+        protocolFee: undefined,
+        applicationFee: undefined,
+        bridgeFee: undefined,
+      }),
+    );
+
+    const quote = await createBridge(client).quote(quoteParams());
+
+    expect(quote.tool).to.equal('swapsxyz');
+    expect(quote.executionDuration).to.equal(0);
+    expect(quote.feeCosts).to.equal(0n);
+  });
+
+  it('defaults recipient to fromAddress and honors toAddress', async () => {
+    const client = createClient();
+    const getActionStub = sinon
+      .stub(client, 'getAction')
+      .resolves(actionResponse());
+    const bridge = createBridge(client);
+
+    await bridge.quote(quoteParams());
+    await bridge.quote(quoteParams({ toAddress: '0xRecipient' }));
+
+    expect(getActionStub.firstCall.args[0].recipient).to.equal(SENDER);
+    expect(getActionStub.secondCall.args[0].recipient).to.equal('0xRecipient');
+  });
+
+  it('converts explicit and configured slippage fractions to bps', async () => {
+    const client = createClient();
+    const getActionStub = sinon
+      .stub(client, 'getAction')
+      .resolves(actionResponse());
+    const bridge = createBridge(client, { defaultSlippage: 0.0123 });
+
+    await bridge.quote(quoteParams({ slippage: 0.005 }));
+    await bridge.quote(quoteParams());
+
+    expect(getActionStub.firstCall.args[0].slippage).to.equal(50);
+    expect(getActionStub.secondCall.args[0].slippage).to.equal(123);
+  });
+
+  it('rejects both, neither, and nonpositive amounts', async () => {
+    const client = createClient();
+    const bridge = createBridge(client);
+    const cases: Array<{ params: BridgeQuoteParams; message: string }> = [
+      {
+        params: quoteParams({ fromAmount: 1n, toAmount: 1n }),
+        message: 'Cannot specify both',
+      },
+      {
+        params: quoteParams({ fromAmount: undefined, toAmount: undefined }),
+        message: 'Must specify either',
+      },
+      {
+        params: quoteParams({ fromAmount: 0n }),
+        message: 'fromAmount must be positive',
+      },
+      {
+        params: quoteParams({ fromAmount: undefined, toAmount: -1n }),
+        message: 'toAmount must be positive',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const error = await captureError(bridge.quote(testCase.params));
+      expect(error.message).to.include(testCase.message);
+    }
+  });
+
+  it('returns the zero native-token address', () => {
+    expect(createBridge(createClient()).getNativeTokenAddress()).to.equal(
+      ZERO_ADDRESS,
+    );
+  });
+
+  it('accepts quote loss at the configured bps boundary', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getAction').resolves(actionResponse());
+
+    const quote = await createBridge(client, {
+      maxQuoteLossBps: 100,
+    }).quote(quoteParams());
+
+    expect(quote.toAmountMin).to.equal(990_025n);
+  });
+
+  it('rejects quote loss above the configured bps boundary', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getAction').resolves(actionResponse());
+
+    const error = await captureError(
+      createBridge(client, { maxQuoteLossBps: 99 }).quote(quoteParams()),
+    );
+
+    expect(error.message).to.include('quote loss 100 bps');
+    expect(error.message).to.include('maximum 99 bps');
+  });
+
+  it('normalizes token decimals before enforcing quote loss', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getAction').resolves(
+      actionResponse({
+        amountIn: { amount: '1000000', decimals: 6 },
+        amountOut: { amount: '995000000000000000', decimals: 18 },
+        amountOutMin: { amount: '990000000000000000', decimals: 18 },
+      }),
+    );
+
+    const quote = await createBridge(client, {
+      maxQuoteLossBps: 100,
+    }).quote(quoteParams());
+
+    expect(quote.toAmountMin).to.equal(990_000_000_000_000_000n);
+  });
+});
+
+describe('SwapsXyzBridge reverse quote fallback', () => {
+  afterEach(() => sinon.restore());
+
+  function unsupportedDirection(): SwapsXyzRequestError {
+    return new SwapsXyzRequestError(
+      'exact-out unavailable',
+      400,
+      'Bad Request',
+      'UNSUPPORTED_SWAP_DIRECTION',
+    );
+  }
+
+  function providerWithDecimals(
+    decimals: number,
+  ): providers.StaticJsonRpcProvider {
+    const provider = new providers.StaticJsonRpcProvider();
+    sinon
+      .stub(provider, 'call')
+      .resolves(utils.defaultAbiCoder.encode(['uint8'], [decimals]));
+    return provider;
+  }
+
+  it('uses a decimal-scaled 6-to-18 seed with headroom', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    getActionStub.onFirstCall().rejects(unsupportedDirection());
+    getActionStub.onSecondCall().resolves(
+      actionResponse({
+        amountIn: { amount: '1008000' },
+        amountOut: { amount: '1000000000000000000' },
+        amountOutMin: { amount: '1000000000000000000' },
+      }),
+    );
+    const sourceProvider = providerWithDecimals(6);
+    const destinationProvider = providerWithDecimals(18);
+    const bridge = createBridge(client, {
+      evmProviderFactory: (rpcUrl) =>
+        rpcUrl.includes('ethereum') ? sourceProvider : destinationProvider,
+    });
+
+    await bridge.quote(
+      quoteParams({
+        fromAmount: undefined,
+        toAmount: 1_000_000_000_000_000_000n,
+      }),
+    );
+
+    expect(getActionStub.secondCall.args[0].amount).to.equal('1008000');
+    expect(getActionStub.secondCall.args[0].swapDirection).to.equal(
+      'exact-amount-in',
+    );
+  });
+
+  it('uses a decimal-scaled 18-to-6 seed with headroom', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    getActionStub.onFirstCall().rejects(unsupportedDirection());
+    getActionStub.onSecondCall().resolves(
+      actionResponse({
+        amountIn: { amount: '1008000000000000000' },
+        amountOut: { amount: '1000000' },
+        amountOutMin: { amount: '1000000' },
+      }),
+    );
+    const sourceProvider = providerWithDecimals(18);
+    const destinationProvider = providerWithDecimals(6);
+    const bridge = createBridge(client, {
+      evmProviderFactory: (rpcUrl) =>
+        rpcUrl.includes('ethereum') ? sourceProvider : destinationProvider,
+    });
+
+    await bridge.quote(
+      quoteParams({ fromAmount: undefined, toAmount: 1_000_000n }),
+    );
+
+    expect(getActionStub.secondCall.args[0].amount).to.equal(
+      '1008000000000000000',
+    );
+  });
+
+  it('iteratively scales up and rewrites requestParams to exact-in', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    getActionStub.onFirstCall().rejects(unsupportedDirection());
+    getActionStub.onSecondCall().resolves(
+      actionResponse({
+        amountIn: { amount: '1008' },
+        amountOutMin: { amount: '900' },
+      }),
+    );
+    getActionStub.onThirdCall().resolves(
+      actionResponse({
+        amountIn: { amount: '1121' },
+        amountOut: { amount: '1005' },
+        amountOutMin: { amount: '1000' },
+      }),
+    );
+    const provider = providerWithDecimals(6);
+    const bridge = createBridge(client, {
+      evmProviderFactory: () => provider,
+    });
+
+    const quote = await bridge.quote(
+      quoteParams({ fromAmount: undefined, toAmount: 1_000n }),
+    );
+
+    expect(getActionStub.thirdCall.args[0].amount).to.equal('1121');
+    expect(quote.requestParams.fromAmount).to.equal(1_121n);
+    expect(quote.requestParams.toAmount).to.equal(undefined);
+  });
+
+  it('throws after four unsuccessful forward attempts', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    getActionStub.onFirstCall().rejects(unsupportedDirection());
+    for (let index = 1; index <= 4; index++) {
+      getActionStub.onCall(index).resolves(
+        actionResponse({
+          amountIn: { amount: String(index * 1_000) },
+          amountOutMin: { amount: '500' },
+        }),
+      );
+    }
+    const provider = providerWithDecimals(6);
+    const bridge = createBridge(client, {
+      evmProviderFactory: () => provider,
+    });
+
+    const error = await captureError(
+      bridge.quote(quoteParams({ fromAmount: undefined, toAmount: 1_000n })),
+    );
+
+    expect(getActionStub.callCount).to.equal(5);
+    expect(error.message).to.include('exhausted after 4 attempts');
+    expect(error.message).to.include('last amountOutMin 500');
+  });
+
+  it('propagates other terminal errors without falling back', async () => {
+    const client = createClient();
+    const routeError = new SwapsXyzRequestError(
+      'no route',
+      400,
+      'Bad Request',
+      'NO_AVAILABLE_ROUTE',
+    );
+    const getActionStub = sinon.stub(client, 'getAction').rejects(routeError);
+
+    const error = await captureError(
+      createBridge(client).quote(
+        quoteParams({ fromAmount: undefined, toAmount: 1_000n }),
+      ),
+    );
+
+    expect(error).to.equal(routeError);
+    expect(getActionStub.callCount).to.equal(1);
+  });
+
+  it('keeps native exact-out requestParams untouched when API succeeds', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getAction').resolves(actionResponse());
+    const params = quoteParams({
+      fromToken: ZERO_ADDRESS,
+      toToken: ZERO_ADDRESS,
+      fromAmount: undefined,
+      toAmount: 1_000n,
+    });
+
+    const quote = await createBridge(client).quote(params);
+
+    expect(quote.requestParams).to.equal(params);
+    expect(quote.requestParams.fromAmount).to.equal(undefined);
+    expect(quote.requestParams.toAmount).to.equal(1_000n);
+  });
+});
+
+describe('SwapsXyzBridge.execute', () => {
+  afterEach(() => sinon.restore());
+
+  it('throws before re-quoting when source metadata is missing', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    const bridge = createBridge(client, { chainMetadata: {} });
+
+    const error = await captureError(
+      bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('no chain metadata');
+    expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('throws before re-quoting when source RPC metadata is missing', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+    const noRpcMetadata: ChainMetadata = {
+      ...ETHEREUM_METADATA,
+      rpcUrls: [],
+    };
+    const bridge = createBridge(client, {
+      chainMetadata: { ethereum: noRpcMetadata },
+    });
+
+    const error = await captureError(
+      bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('no RPC URL');
+    expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('throws when the EVM private key is missing', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+
+    const error = await captureError(
+      createBridge(client).execute(bridgeQuote(), {}),
+    );
+
+    expect(error.message).to.include('Ethereum (EVM) private key');
+    expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('throws before re-quoting when the signer does not match fromAddress', async () => {
+    const client = createClient();
+    const getActionStub = sinon.stub(client, 'getAction');
+
+    const error = await captureError(
+      createBridge(client).execute(
+        bridgeQuote(
+          quoteParams({
+            fromAddress: '0x3333333333333333333333333333333333333333',
+          }),
+        ),
+        { [ProtocolType.Ethereum]: TEST_PRIVATE_KEY },
+      ),
+    );
+
+    expect(error.message).to.include('signer does not match');
+    expect(getActionStub.callCount).to.equal(0);
+  });
+
+  it('does not register an EVM transfer when the flag is absent', async () => {
+    const harness = createExecuteHarness();
+    const registerTxsStub = sinon.stub(harness.client, 'registerTxs');
+
+    await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(registerTxsStub.callCount).to.equal(0);
+  });
+
+  it('returns the transfer after persistent registration failures', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({ requiresRegisterTransaction: true }),
+    );
+    const registerTxsStub = sinon
+      .stub(harness.client, 'registerTxs')
+      .resolves([{ success: false, error: 'indexer unavailable' }]);
+    const loggerErrorStub = sinon.stub(logger, 'error');
+
+    const result = await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(result.transferId).to.equal('tx-1');
+    expect(result.txHash).to.equal('0xbridge');
+    expect(registerTxsStub.callCount).to.equal(3);
+    expect(loggerErrorStub.callCount).to.equal(1);
+    expect(loggerErrorStub.firstCall.args[0]).to.include({
+      txId: 'tx-1',
+      txHash: '0xbridge',
+    });
+  });
+
+  it('re-quotes with forward params and returns the fresh transfer ID', async () => {
+    const fresh = actionResponse({ txId: 'fresh-transfer-id' });
+    const harness = createExecuteHarness(fresh);
+
+    const result = await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(harness.getActionStub.callCount).to.equal(1);
+    expect(harness.getActionStub.firstCall.args[0].amount).to.equal('1000000');
+    expect(harness.getActionStub.firstCall.args[0].swapDirection).to.equal(
+      'exact-amount-in',
+    );
+    expect(result).to.deep.equal({
+      txHash: '0xbridge',
+      fromChain: 1,
+      toChain: 8453,
+      transferId: 'fresh-transfer-id',
+    });
+  });
+
+  it('approves only when required, using fresh spender and amountInMax', async () => {
+    const fresh = actionResponse({
+      requiresTokenApproval: true,
+      amountIn: { amount: '100' },
+      amountInMax: { amount: '150' },
+    });
+    const harness = createExecuteHarness(fresh);
+    const providerCallStub = sinon
+      .stub(harness.provider, 'call')
+      .callsFake(async (transaction) => {
+        const transactionData = await transaction.data;
+        if (transactionData === undefined) {
+          throw new Error('Expected contract call data');
+        }
+        const data = utils.hexlify(transactionData);
+        if (data.startsWith('0xdd62ed3e')) {
+          return utils.defaultAbiCoder.encode(['uint256'], ['100']);
+        }
+        return utils.defaultAbiCoder.encode(['uint8'], [6]);
+      });
+    harness.sendTransactionStub
+      .onFirstCall()
+      .resolves(transactionResponse('0xrevoke'));
+    harness.sendTransactionStub
+      .onSecondCall()
+      .resolves(transactionResponse('0xapproval'));
+    harness.sendTransactionStub
+      .onThirdCall()
+      .resolves(transactionResponse('0xbridge'));
+
+    await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(providerCallStub.callCount).to.equal(1);
+    expect(harness.sendTransactionStub.callCount).to.equal(3);
+    const approvalRequest = harness.sendTransactionStub.secondCall.args[0];
+    const approvalTo = await approvalRequest.to;
+    const approvalData = await approvalRequest.data;
+    if (approvalTo === undefined || approvalData === undefined) {
+      throw new Error('Expected approval transaction target and data');
+    }
+    expect(approvalTo.toLowerCase()).to.equal(FROM_TOKEN);
+    expect(utils.hexlify(approvalData).toLowerCase()).to.include(
+      SPENDER.slice(2),
+    );
+    expect(utils.hexlify(approvalData).toLowerCase()).to.include(
+      utils.hexZeroPad(utils.hexlify(150), 32).slice(2),
+    );
+  });
+
+  it('does not call the token contract when approval is not required', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({ requiresTokenApproval: false }),
+    );
+    const providerCallStub = sinon.stub(harness.provider, 'call');
+
+    await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(providerCallStub.callCount).to.equal(0);
+    expect(harness.sendTransactionStub.callCount).to.equal(1);
+  });
+
+  it('returns the EVM broadcast identity before confirmation', async () => {
+    const harness = createExecuteHarness();
+
+    const result = await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(result.txHash).to.equal('0xbridge');
+    expect(result.transferId).to.equal('tx-1');
+    expect(harness.waitForTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects fresh EVM native value above the accepted quote', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        tx: {
+          to: SPENDER,
+          data: '0xdeadbeef',
+          value: '1',
+          chainId: 1,
+        },
+      }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('fresh native value');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects a direct EVM source-token approval', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        tx: {
+          to: FROM_TOKEN,
+          data: `0x095ea7b3${'00'.repeat(64)}`,
+          value: '0',
+          chainId: 1,
+        },
+      }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('direct source-token selector');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects a fresh transaction target mismatch', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        tx: {
+          to: '0x4444444444444444444444444444444444444444',
+          data: '0xdeadbeef',
+          value: '0',
+          chainId: 1,
+        },
+      }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('fresh target');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects a fresh transaction calldata selector mismatch', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        tx: {
+          to: SPENDER,
+          data: '0xfeedface',
+          value: '0',
+          chainId: 1,
+        },
+      }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('calldata selector');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('allows refreshed calldata when target and selector are unchanged', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        tx: {
+          to: SPENDER,
+          data: `0xdeadbeef${'00'.repeat(32)}`,
+          value: '0',
+          chainId: 1,
+        },
+      }),
+    );
+
+    await harness.bridge.execute(bridgeQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(harness.sendTransactionStub.callCount).to.equal(1);
+  });
+
+  it('rejects native value on an ERC20 route', async () => {
+    const response = actionResponse({
+      tx: { to: SPENDER, data: '0xdeadbeef', value: '1', chainId: 1 },
+    });
+    const acceptedQuote = bridgeQuote();
+    acceptedQuote.route = { actionResponse: response };
+    const harness = createExecuteHarness(response);
+
+    const error = await captureError(
+      harness.bridge.execute(acceptedQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('ERC20 routes must not send native value');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  const mismatchCases: Array<{
+    name: string;
+    response: SwapsXyzActionResponse;
+    message: string;
+  }> = [
+    {
+      name: 'transaction source chain',
+      response: actionResponse({
+        tx: {
+          to: SPENDER,
+          data: '0xdeadbeef',
+          value: '0',
+          chainId: 10,
+        },
+      }),
+      message: 'tx chainId',
+    },
+    {
+      name: 'source chain',
+      response: actionResponse({
+        amountIn: { chainId: 10, address: FROM_TOKEN, amount: '1000000' },
+      }),
+      message: 'amountIn chainId',
+    },
+    {
+      name: 'destination chain',
+      response: actionResponse({
+        amountOut: { chainId: 10, address: TO_TOKEN, amount: '995000' },
+      }),
+      message: 'amountOut chainId',
+    },
+    {
+      name: 'source token',
+      response: actionResponse({
+        amountIn: {
+          chainId: 1,
+          address: '0x4444444444444444444444444444444444444444',
+          amount: '1000000',
+        },
+      }),
+      message: 'amountIn token',
+    },
+    {
+      name: 'destination token',
+      response: actionResponse({
+        amountOut: {
+          chainId: 8453,
+          address: '0x4444444444444444444444444444444444444444',
+          amount: '995000',
+        },
+      }),
+      message: 'amountOut token',
+    },
+  ];
+
+  for (const testCase of mismatchCases) {
+    it(`rejects a fresh ${testCase.name} mismatch`, async () => {
+      const harness = createExecuteHarness(testCase.response);
+
+      const error = await captureError(
+        harness.bridge.execute(bridgeQuote(), {
+          [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+        }),
+      );
+
+      expect(error.message).to.include(testCase.message);
+      expect(harness.sendTransactionStub.callCount).to.equal(0);
+    });
+  }
+
+  it('rejects exact-in output degradation from a fresh quote', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        amountOutMin: {
+          chainId: 8453,
+          address: TO_TOKEN,
+          amount: '990024',
+        },
+      }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(bridgeQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('fresh minimum output');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects exact-out input growth from a fresh quote', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        amountInMax: {
+          chainId: 1,
+          address: FROM_TOKEN,
+          amount: '1000001',
+        },
+      }),
+    );
+    const exactOutQuote = bridgeQuote(
+      quoteParams({ fromAmount: undefined, toAmount: 995_000n }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(exactOutQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('fresh input');
+    expect(error.message).to.include('accepted input cap');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+
+  it('rejects exact-out output degradation from a fresh quote', async () => {
+    const harness = createExecuteHarness(
+      actionResponse({
+        amountOutMin: {
+          chainId: 8453,
+          address: TO_TOKEN,
+          amount: '990024',
+        },
+      }),
+    );
+    const exactOutQuote = bridgeQuote(
+      quoteParams({ fromAmount: undefined, toAmount: 995_000n }),
+    );
+
+    const error = await captureError(
+      harness.bridge.execute(exactOutQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    );
+
+    expect(error.message).to.include('fresh minimum output');
+    expect(harness.sendTransactionStub.callCount).to.equal(0);
+  });
+});
+
+describe('SwapsXyzBridge.getStatus', () => {
+  afterEach(() => sinon.restore());
+
+  it('maps success and completed with required defaults', async () => {
+    const client = createClient();
+    const getStatusStub = sinon.stub(client, 'getStatus');
+    getStatusStub.onFirstCall().resolves(statusResponse('success'));
+    getStatusStub.onSecondCall().resolves(
+      statusResponse('completed', {
+        dstTxHash: undefined,
+        actionResponse: undefined,
+      }),
+    );
+    const bridge = createBridge(client);
+
+    const success = await bridge.getStatus('0xsource', 1, 8453);
+    const completed = await bridge.getStatus('0xsource2', 1, 8453);
+
+    expect(success).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdestination',
+      receivedAmount: 995_000n,
+    });
+    expect(completed).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '',
+      receivedAmount: 0n,
+    });
+    expect(getStatusStub.firstCall.args[0]).to.deep.equal({
+      txHash: '0xsource',
+      chainId: 1,
+    });
+  });
+
+  it('retries persisted transaction registration after status lookup fails', async () => {
+    const client = createClient();
+    const getStatusStub = sinon.stub(client, 'getStatus');
+    getStatusStub.onFirstCall().rejects(new Error('not registered'));
+    getStatusStub.onSecondCall().resolves(statusResponse('success'));
+    const registerTxsStub = sinon
+      .stub(client, 'registerTxs')
+      .resolves([{ success: true, error: null }]);
+    const bridge = createBridge(client, { registerTxRetryDelayMs: 1 });
+
+    const result = await bridge.getStatus(
+      '0xsource',
+      1,
+      8453,
+      'persisted-transfer-id',
+    );
+
+    expect(getStatusStub.firstCall.args[0]).to.deep.equal({
+      txHash: '0xsource',
+      txId: 'persisted-transfer-id',
+      chainId: 1,
+    });
+    expect(registerTxsStub.firstCall.args[0]).to.deep.equal([
+      { txId: 'persisted-transfer-id', txHash: '0xsource' },
+    ]);
+    expect(getStatusStub.secondCall.args[0]).to.deep.equal({
+      txHash: '0xsource',
+      txId: 'persisted-transfer-id',
+      chainId: 1,
+    });
+    expect(result.status).to.equal('complete');
+  });
+
+  it('returns not_found when the response srcChainId does not match the requested chain', async () => {
+    const client = createClient();
+    sinon
+      .stub(client, 'getStatus')
+      .resolves(statusResponse('success', { srcChainId: 10 }));
+
+    const result = await createBridge(client).getStatus('0xsource', 1, 8453);
+
+    expect(result).to.deep.equal({ status: 'not_found' });
+  });
+
+  it('returns not_found when the response dstChainId does not match the requested chain', async () => {
+    const client = createClient();
+    sinon
+      .stub(client, 'getStatus')
+      .resolves(statusResponse('success', { dstChainId: 10 }));
+
+    const result = await createBridge(client).getStatus('0xsource', 1, 8453);
+
+    expect(result).to.deep.equal({ status: 'not_found' });
+  });
+
+  it('maps status strings case-insensitively', async () => {
+    const client = createClient();
+    Object.defineProperty(client, 'getStatus', {
+      configurable: true,
+      value: async () => ({
+        ...statusResponse('success'),
+        status: 'SUCCESS',
+      }),
+    });
+
+    const result = await createBridge(client).getStatus('0xsource', 1, 8453);
+
+    expect(result.status).to.equal('complete');
+  });
+
+  const terminalCases: Array<{
+    raw: SwapsXyzStatus;
+    error: string;
+  }> = [
+    { raw: 'failed', error: 'swaps.xyz reported transfer failed' },
+    { raw: 'refunded', error: 'refunded' },
+    {
+      raw: 'requires refund',
+      error: 'requires refund (claim via swaps.xyz)',
+    },
+    { raw: 'expired', error: 'swaps.xyz transfer expired' },
+  ];
+
+  for (const testCase of terminalCases) {
+    it(`maps ${testCase.raw} to failed`, async () => {
+      const client = createClient();
+      sinon.stub(client, 'getStatus').resolves(statusResponse(testCase.raw));
+
+      const result = await createBridge(client).getStatus('0xsource', 1, 8453);
+
+      expect(result).to.deep.equal({
+        status: 'failed',
+        error: testCase.error,
+      });
+    });
+  }
+
+  const pendingCases: SwapsXyzStatus[] = [
+    'pending',
+    'submitted',
+    'not yet created',
+  ];
+
+  for (const rawStatus of pendingCases) {
+    it(`maps ${rawStatus} to pending with raw substatus`, async () => {
+      const client = createClient();
+      sinon.stub(client, 'getStatus').resolves(statusResponse(rawStatus));
+
+      const result = await createBridge(client).getStatus('0xsource', 1, 8453);
+
+      expect(result).to.deep.equal({
+        status: 'pending',
+        substatus: rawStatus,
+      });
+    });
+  }
+
+  it('propagates status API outages', async () => {
+    const client = createClient();
+    sinon.stub(client, 'getStatus').rejects(new Error('network unavailable'));
+
+    const error = await captureError(
+      createBridge(client).getStatus('0xsource', 1, 8453),
+    );
+
+    expect(error.message).to.equal('network unavailable');
+  });
+
+  it('returns not_found for an explicit API not-found response', async () => {
+    const client = createClient();
+    sinon
+      .stub(client, 'getStatus')
+      .rejects(new SwapsXyzRequestError('missing', 404, 'Not Found'));
+
+    const result = await createBridge(client).getStatus('0xsource', 1, 8453);
+
+    expect(result).to.deep.equal({ status: 'not_found' });
+  });
+});

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
@@ -1,4 +1,5 @@
 import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { TronWallet } from '@hyperlane-xyz/tron-sdk/runtime';
 import {
   ACCOUNT_SIZE,
   AccountLayout,
@@ -21,8 +22,9 @@ import {
   isEVMLike,
   retryAsync,
 } from '@hyperlane-xyz/utils';
-import { BigNumber, Contract, Wallet, providers } from 'ethers';
+import { BigNumber, Contract, Wallet, providers, utils } from 'ethers';
 import type { Logger } from 'pino';
+import { TronWeb } from 'tronweb';
 
 import { ExternalBridgeType } from '../config/types.js';
 import type {
@@ -44,6 +46,7 @@ import {
   isEvmTx,
   isSolanaTx,
   isSwapsXyzNotFoundError,
+  isTronTx,
   type SwapsXyzActionRequest,
   type SwapsXyzActionResponse,
   type SwapsXyzStatusResponse,
@@ -55,6 +58,9 @@ const REVERSE_QUOTE_ATTEMPTS = 4;
 const REVERSE_QUOTE_HEADROOM_BPS = 30n;
 const BPS_DENOMINATOR = 10_000n;
 const ERC20_DECIMALS_ABI = ['function decimals() view returns (uint8)'];
+const ERC20_TRANSFER_INTERFACE = new utils.Interface([
+  'function transfer(address recipient, uint256 amount) returns (bool)',
+]);
 const REGISTER_TX_RETRY_DELAY_MS = 2_000;
 const DEFAULT_MAX_SOLANA_NATIVE_SPEND_LAMPORTS = 10_000_000;
 const tokenAmountOffset = AccountLayout.offsetOf('amount');
@@ -78,6 +84,7 @@ export interface SwapsXyzBridgeConfig {
   chainMetadata?: ChainMap<ChainMetadata>;
   evmProviderFactory?: (rpcUrl: string) => providers.Provider;
   solanaConnectionFactory?: (rpcUrl: string) => Connection;
+  tronWalletFactory?: (privateKey: string, rpcUrl: string) => Wallet;
   registerTxRetryDelayMs?: number;
   erc20ContractFactory?: Erc20ContractFactory;
 }
@@ -191,6 +198,10 @@ export class SwapsXyzBridge implements IExternalBridge {
   private readonly evmProviderFactory: (rpcUrl: string) => providers.Provider;
   private readonly solanaConnectionFactory: (rpcUrl: string) => Connection;
   private readonly maxSolanaNativeSpendLamports: number;
+  private readonly tronWalletFactory: (
+    privateKey: string,
+    rpcUrl: string,
+  ) => Wallet;
   private readonly registerTxRetryDelayMs: number;
   // Prevent source-account races when movements share a source in one cycle.
   private _executeLock: Promise<void> = Promise.resolve();
@@ -235,6 +246,9 @@ export class SwapsXyzBridge implements IExternalBridge {
       config.solanaConnectionFactory ??
       ((rpcUrl) => new Connection(rpcUrl, 'confirmed'));
     this.maxSolanaNativeSpendLamports = maxSolanaNativeSpendLamports;
+    this.tronWalletFactory =
+      config.tronWalletFactory ??
+      ((privateKey, rpcUrl) => new TronWallet(privateKey, rpcUrl));
     this.registerTxRetryDelayMs =
       config.registerTxRetryDelayMs ?? REGISTER_TX_RETRY_DELAY_MS;
 
@@ -425,12 +439,15 @@ export class SwapsXyzBridge implements IExternalBridge {
     assert(amount !== undefined, 'Must specify either fromAmount or toAmount');
     return {
       actionType: 'swap-action',
-      sender: params.fromAddress,
-      recipient: params.toAddress ?? params.fromAddress,
+      sender: this.formatAddressForApi(params.fromChain, params.fromAddress),
+      recipient: this.formatAddressForApi(
+        params.toChain,
+        params.toAddress ?? params.fromAddress,
+      ),
       srcChainId: params.fromChain,
       dstChainId: params.toChain,
-      srcToken: params.fromToken,
-      dstToken: params.toToken,
+      srcToken: this.formatAddressForApi(params.fromChain, params.fromToken),
+      dstToken: this.formatAddressForApi(params.toChain, params.toToken),
       slippage: this.getSlippageBps(params.slippage),
       amount: amount.toString(),
       swapDirection:
@@ -438,6 +455,44 @@ export class SwapsXyzBridge implements IExternalBridge {
           ? 'exact-amount-in'
           : 'exact-amount-out',
     };
+  }
+
+  private formatAddressForApi(chainId: number, address: string): string {
+    const protocol = this.chainMetadataByChainId.get(chainId)?.protocol;
+    if (protocol === ProtocolType.Tron) {
+      return TronWeb.address.fromHex(`41${this.tronAddressHex20(address)}`);
+    }
+    if (protocol === ProtocolType.Ethereum && address.startsWith('T')) {
+      return this.tronAddressToEvm(address);
+    }
+    return address;
+  }
+
+  private tronAddressHex20(address: string): string {
+    if (address.startsWith('T')) {
+      assert(
+        TronWeb.isAddress(address),
+        `SwapsXyzBridge: invalid Tron address ${address}`,
+      );
+      const hex = TronWeb.address.toHex(address);
+      assert(
+        /^41[0-9a-fA-F]{40}$/.test(hex),
+        `SwapsXyzBridge: invalid Tron address ${address}`,
+      );
+      return hex.slice(2).toLowerCase();
+    }
+
+    let hex = address.startsWith('0x') ? address.slice(2) : address;
+    if (/^41[0-9a-fA-F]{40}$/.test(hex)) hex = hex.slice(2);
+    assert(
+      /^[0-9a-fA-F]{40}$/.test(hex) && TronWeb.isAddress(`41${hex}`),
+      `SwapsXyzBridge: invalid Tron address ${address}`,
+    );
+    return hex.toLowerCase();
+  }
+
+  private tronAddressToEvm(address: string): string {
+    return ensure0x(this.tronAddressHex20(address));
   }
 
   private getSlippageBps(slippage?: number): number {
@@ -548,7 +603,15 @@ export class SwapsXyzBridge implements IExternalBridge {
       `SwapsXyzBridge: no RPC URL configured for chainId ${chainId}`,
     );
     const provider = this.evmProviderFactory(rpcUrl);
-    const tokenContract = new Contract(token, ERC20_DECIMALS_ABI, provider);
+    const tokenAddress =
+      metadata.protocol === ProtocolType.Tron
+        ? this.tronAddressToEvm(token)
+        : token;
+    const tokenContract = new Contract(
+      tokenAddress,
+      ERC20_DECIMALS_ABI,
+      provider,
+    );
     return Number(await tokenContract.decimals());
   }
 
@@ -602,6 +665,9 @@ export class SwapsXyzBridge implements IExternalBridge {
     );
     if (metadata.protocol === ProtocolType.Sealevel) {
       return this.executeSolana(quote, privateKeys, rpcUrl);
+    }
+    if (metadata.protocol === ProtocolType.Tron) {
+      return this.executeTron(quote, privateKeys, rpcUrl);
     }
     const privateKey = privateKeys[ProtocolType.Ethereum];
     assert(
@@ -771,6 +837,96 @@ export class SwapsXyzBridge implements IExternalBridge {
     };
   }
 
+  private async executeTron(
+    quote: BridgeQuote,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+    rpcUrl: string,
+  ): Promise<BridgeTransferResult> {
+    const { fromChain, toChain } = quote.requestParams;
+    const privateKey = privateKeys[ProtocolType.Tron];
+    assert(
+      privateKey,
+      'SwapsXyzBridge.execute requires a Tron private key for Tron-source routes',
+    );
+    const signer = this.tronWalletFactory(ensure0x(privateKey), rpcUrl);
+    assert(
+      this.addressesEqual(
+        await signer.getAddress(),
+        quote.requestParams.fromAddress,
+        fromChain,
+      ),
+      'SwapsXyzBridge.execute Tron signer does not match quote fromAddress',
+    );
+
+    const fresh = await this.client.getAction(
+      this.buildActionRequest(quote.requestParams),
+    );
+    const freshTx = fresh.tx;
+    assert(isTronTx(freshTx), 'SwapsXyzBridge.execute requires a Tron tx');
+    assert(
+      fresh.requiresRegisterTransaction === true,
+      'SwapsXyzBridge.execute Tron actions must require transaction registration',
+    );
+    this.validateActionResponse(fresh, quote, 'alt-vm');
+
+    const transactionTo = this.tronAddressToEvm(freshTx.to);
+    const sourceToken = this.tronAddressToEvm(quote.requestParams.fromToken);
+    let txResponse: providers.TransactionResponse;
+    if (freshTx.toExtra === null) {
+      assert(
+        !fresh.requiresTokenApproval,
+        'SwapsXyzBridge.execute direct Tron transfers must not require token approval',
+      );
+      const transferAmount = BigNumber.from(freshTx.value);
+      if (
+        this.addressesEqual(
+          quote.requestParams.fromToken,
+          NATIVE_TOKEN_ADDRESS,
+          fromChain,
+        )
+      ) {
+        txResponse = await signer.sendTransaction({
+          to: transactionTo,
+          value: transferAmount,
+        });
+      } else {
+        txResponse = await signer.sendTransaction({
+          to: sourceToken,
+          data: ERC20_TRANSFER_INTERFACE.encodeFunctionData('transfer', [
+            transactionTo,
+            transferAmount,
+          ]),
+          value: 0,
+        });
+      }
+    } else {
+      if (fresh.requiresTokenApproval) {
+        await approveErc20IfNeeded(
+          signer,
+          sourceToken,
+          transactionTo,
+          BigInt((fresh.amountInMax ?? fresh.amountIn).amount),
+          this.logger,
+          { contractFactory: this.config.erc20ContractFactory },
+        );
+      }
+
+      txResponse = await signer.sendTransaction({
+        to: transactionTo,
+        data: ensure0x(freshTx.toExtra),
+        value: BigNumber.from(freshTx.value),
+      });
+    }
+    const txHash = ensure0x(txResponse.hash);
+    void this.registerIfRequired(fresh, txHash);
+    return {
+      txHash,
+      fromChain,
+      toChain,
+      transferId: fresh.txId,
+    };
+  }
+
   private async resolveAddressLookupTables(
     connection: Connection,
     transaction: VersionedTransaction,
@@ -793,7 +949,7 @@ export class SwapsXyzBridge implements IExternalBridge {
   private validateActionResponseMetadata(
     response: SwapsXyzActionResponse,
     quote: BridgeQuote,
-    expectedVmId: 'evm' | 'solana',
+    expectedVmId: 'evm' | 'solana' | 'alt-vm',
   ): void {
     const params = quote.requestParams;
     assert(
@@ -860,7 +1016,7 @@ export class SwapsXyzBridge implements IExternalBridge {
   private validateActionResponse(
     response: SwapsXyzActionResponse,
     quote: BridgeQuote,
-    expectedVmId: 'evm',
+    expectedVmId: 'evm' | 'alt-vm',
   ): void {
     this.validateActionResponseMetadata(response, quote, expectedVmId);
     assert(
@@ -870,10 +1026,22 @@ export class SwapsXyzBridge implements IExternalBridge {
     );
     const params = quote.requestParams;
     const tx = response.tx;
-    assert(isEvmTx(tx), 'SwapsXyzBridge.execute EVM transaction is invalid');
+    assert(
+      isEvmTx(tx) || isTronTx(tx),
+      'SwapsXyzBridge.execute transaction is invalid',
+    );
+    assert(
+      expectedVmId === 'evm' ? isEvmTx(tx) : isTronTx(tx),
+      `SwapsXyzBridge.execute ${expectedVmId} transaction is invalid`,
+    );
     if (this.addressesEqual(tx.to, params.fromToken, params.fromChain)) {
+      const sourceTokenData = isTronTx(tx) ? tx.toExtra : tx.data;
+      assert(
+        sourceTokenData !== null,
+        'SwapsXyzBridge.execute rejects direct Tron deposits to the source token',
+      );
       const selector = transactionSelector(
-        tx.data,
+        ensure0x(sourceTokenData),
         'SwapsXyzBridge.execute fresh',
       );
       assert(
@@ -884,18 +1052,80 @@ export class SwapsXyzBridge implements IExternalBridge {
 
     const acceptedTx = quote.route.actionResponse.tx;
     assert(
-      isEvmTx(acceptedTx),
-      'SwapsXyzBridge.execute accepted EVM transaction is invalid',
+      isEvmTx(acceptedTx) || isTronTx(acceptedTx),
+      'SwapsXyzBridge.execute accepted transaction is invalid',
     );
     assert(
-      this.addressesEqual(tx.to, acceptedTx.to, params.fromChain),
-      `SwapsXyzBridge.execute fresh target ${tx.to} does not match accepted target ${acceptedTx.to}`,
+      expectedVmId === 'evm' ? isEvmTx(acceptedTx) : isTronTx(acceptedTx),
+      `SwapsXyzBridge.execute accepted ${expectedVmId} transaction is invalid`,
     );
+    const isDirectTronTransfer = isTronTx(tx) && tx.toExtra === null;
+    const isAcceptedDirectTronTransfer =
+      isTronTx(acceptedTx) && acceptedTx.toExtra === null;
+    if (!isDirectTronTransfer || !isAcceptedDirectTronTransfer) {
+      assert(
+        this.addressesEqual(tx.to, acceptedTx.to, params.fromChain),
+        `SwapsXyzBridge.execute fresh target ${tx.to} does not match accepted target ${acceptedTx.to}`,
+      );
+    } else {
+      const sourceToken = this.tronAddressToEvm(params.fromToken).toLowerCase();
+      const freshTarget = this.tronAddressToEvm(tx.to).toLowerCase();
+      const acceptedTarget = this.tronAddressToEvm(acceptedTx.to).toLowerCase();
+      assert(
+        freshTarget !== sourceToken && acceptedTarget !== sourceToken,
+        'SwapsXyzBridge.execute rejects direct Tron deposits to the source token',
+      );
+      const freshTool = response.bridgeIds?.join('+') || 'swapsxyz';
+      assert(
+        freshTool === quote.tool,
+        `SwapsXyzBridge.execute fresh bridge ${freshTool} does not match accepted bridge ${quote.tool}`,
+      );
+    }
+    const freshData = isTronTx(tx) ? tx.toExtra : tx.data;
+    const acceptedData = isTronTx(acceptedTx)
+      ? acceptedTx.toExtra
+      : acceptedTx.data;
     assert(
-      transactionSelector(tx.data, 'SwapsXyzBridge.execute fresh') ===
-        transactionSelector(acceptedTx.data, 'SwapsXyzBridge.execute accepted'),
-      'SwapsXyzBridge.execute fresh calldata selector does not match accepted selector',
+      (freshData === null) === (acceptedData === null),
+      'SwapsXyzBridge.execute fresh transaction kind does not match accepted transaction',
     );
+    if (freshData !== null && acceptedData !== null) {
+      assert(
+        transactionSelector(
+          ensure0x(freshData),
+          'SwapsXyzBridge.execute fresh',
+        ) ===
+          transactionSelector(
+            ensure0x(acceptedData),
+            'SwapsXyzBridge.execute accepted',
+          ),
+        'SwapsXyzBridge.execute fresh calldata selector does not match accepted selector',
+      );
+    }
+    if (isTronTx(tx) && tx.toExtra === null) {
+      assert(
+        isTronTx(acceptedTx) && acceptedTx.toExtra === null,
+        'SwapsXyzBridge.execute accepted direct Tron transaction is invalid',
+      );
+      assert(
+        response.requiresTokenApproval === false,
+        'SwapsXyzBridge.execute direct Tron transfers must not require token approval',
+      );
+      const freshFromAmount = BigInt(
+        (response.amountInMax ?? response.amountIn).amount,
+      );
+      const freshTransferAmount = BigInt(tx.value);
+      const acceptedTransferAmount = BigInt(acceptedTx.value);
+      assert(
+        freshTransferAmount === freshFromAmount,
+        `SwapsXyzBridge.execute Tron transfer amount ${freshTransferAmount} does not match fresh input ${freshFromAmount}`,
+      );
+      assert(
+        acceptedTransferAmount === quote.fromAmount,
+        `SwapsXyzBridge.execute accepted Tron transfer amount ${acceptedTransferAmount} does not match accepted input ${quote.fromAmount}`,
+      );
+      return;
+    }
     const freshValue = transactionValue(
       response.tx,
       'SwapsXyzBridge.execute fresh',
@@ -1109,8 +1339,13 @@ export class SwapsXyzBridge implements IExternalBridge {
   private addressesEqual(
     left: string,
     right: string,
-    _chainId: number,
+    chainId: number,
   ): boolean {
+    if (
+      this.chainMetadataByChainId.get(chainId)?.protocol === ProtocolType.Tron
+    ) {
+      return this.tronAddressHex20(left) === this.tronAddressHex20(right);
+    }
     if (left.startsWith('0x') && right.startsWith('0x')) {
       return left.toLowerCase() === right.toLowerCase();
     }

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
@@ -1,5 +1,20 @@
 import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 import {
+  ACCOUNT_SIZE,
+  AccountLayout,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import {
+  type AccountInfo,
+  type AddressLookupTableAccount,
+  Connection,
+  Keypair,
+  PublicKey,
+  type SimulatedTransactionAccountInfo,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import {
   ProtocolType,
   assert,
   ensure0x,
@@ -17,6 +32,7 @@ import type {
   BridgeTransferStatus,
   IExternalBridge,
 } from '../interfaces/IExternalBridge.js';
+import { parseSolanaPrivateKey } from '../utils/solanaKeyParser.js';
 
 import {
   approveErc20IfNeeded,
@@ -26,6 +42,7 @@ import {
   SwapsXyzClient,
   SwapsXyzRequestError,
   isEvmTx,
+  isSolanaTx,
   isSwapsXyzNotFoundError,
   type SwapsXyzActionRequest,
   type SwapsXyzActionResponse,
@@ -39,6 +56,13 @@ const REVERSE_QUOTE_HEADROOM_BPS = 30n;
 const BPS_DENOMINATOR = 10_000n;
 const ERC20_DECIMALS_ABI = ['function decimals() view returns (uint8)'];
 const REGISTER_TX_RETRY_DELAY_MS = 2_000;
+const DEFAULT_MAX_SOLANA_NATIVE_SPEND_LAMPORTS = 10_000_000;
+const tokenAmountOffset = AccountLayout.offsetOf('amount');
+assert(
+  tokenAmountOffset !== undefined,
+  'SPL token account layout is missing amount',
+);
+const TOKEN_AMOUNT_OFFSET = tokenAmountOffset;
 const UNSAFE_SOURCE_TOKEN_SELECTORS = new Set([
   '095ea7b3', // approve(address,uint256)
   '23b872dd', // transferFrom(address,address,uint256)
@@ -50,15 +74,47 @@ export interface SwapsXyzBridgeConfig {
   apiUrl?: string;
   defaultSlippage?: number;
   maxQuoteLossBps?: number;
+  maxSolanaNativeSpendLamports?: number;
   chainMetadata?: ChainMap<ChainMetadata>;
   evmProviderFactory?: (rpcUrl: string) => providers.Provider;
+  solanaConnectionFactory?: (rpcUrl: string) => Connection;
   registerTxRetryDelayMs?: number;
   erc20ContractFactory?: Erc20ContractFactory;
+}
+
+interface TokenAccountSnapshot {
+  mint: PublicKey;
+  owner: PublicKey;
+  amount: bigint;
+  delegateOption: number;
+  delegate: PublicKey;
+  delegatedAmount: bigint;
+  closeAuthorityOption: number;
+  closeAuthority: PublicKey;
+  state: number;
 }
 
 export interface SwapsXyzBridgeRoute {
   // Telemetry only. execute() always re-quotes before signing.
   actionResponse: SwapsXyzActionResponse;
+}
+
+function isSwapsXyzActionResponseValue(
+  value: unknown,
+): value is SwapsXyzActionResponse {
+  return (
+    isRecord(value) &&
+    isRecord(value.tx) &&
+    typeof value.txId === 'string' &&
+    typeof value.vmId === 'string' &&
+    isRecord(value.amountIn) &&
+    typeof value.amountIn.amount === 'string' &&
+    isRecord(value.amountOut) &&
+    typeof value.amountOut.amount === 'string' &&
+    isRecord(value.amountOutMin) &&
+    typeof value.amountOutMin.amount === 'string' &&
+    typeof value.requiresTokenApproval === 'boolean'
+  );
 }
 
 function ceilDiv(numerator: bigint, denominator: bigint): bigint {
@@ -87,6 +143,43 @@ function transactionSelector(data: string, context: string): string {
   return data.slice(2, 10).toLowerCase();
 }
 
+function isTokenProgram(programId: PublicKey): boolean {
+  return (
+    programId.equals(TOKEN_PROGRAM_ID) ||
+    programId.equals(TOKEN_2022_PROGRAM_ID)
+  );
+}
+
+function decodeTokenAccount(
+  programId: PublicKey,
+  data: Buffer,
+): TokenAccountSnapshot | undefined {
+  if (!isTokenProgram(programId) || data.length < ACCOUNT_SIZE)
+    return undefined;
+  const decoded = AccountLayout.decode(data.subarray(0, ACCOUNT_SIZE));
+  return {
+    mint: decoded.mint,
+    owner: decoded.owner,
+    amount: decoded.amount,
+    delegateOption: decoded.delegateOption,
+    delegate: decoded.delegate,
+    delegatedAmount: decoded.delegatedAmount,
+    closeAuthorityOption: decoded.closeAuthorityOption,
+    closeAuthority: decoded.closeAuthority,
+    state: decoded.state,
+  };
+}
+
+function simulatedAccountData(
+  account: SimulatedTransactionAccountInfo,
+): Buffer {
+  assert(
+    account.data[1] === 'base64',
+    'SwapsXyzBridge.execute Solana simulation account must use base64 encoding',
+  );
+  return Buffer.from(account.data[0], 'base64');
+}
+
 export class SwapsXyzBridge implements IExternalBridge {
   readonly externalBridgeId = ExternalBridgeType.SwapsXyz;
   readonly logger: Logger;
@@ -96,6 +189,8 @@ export class SwapsXyzBridge implements IExternalBridge {
   private readonly chainMetadataByChainId = new Map<number, ChainMetadata>();
   private readonly tokenDecimalsCache = new Map<string, Promise<number>>();
   private readonly evmProviderFactory: (rpcUrl: string) => providers.Provider;
+  private readonly solanaConnectionFactory: (rpcUrl: string) => Connection;
+  private readonly maxSolanaNativeSpendLamports: number;
   private readonly registerTxRetryDelayMs: number;
   // Prevent source-account races when movements share a source in one cycle.
   private _executeLock: Promise<void> = Promise.resolve();
@@ -113,6 +208,14 @@ export class SwapsXyzBridge implements IExternalBridge {
           config.maxQuoteLossBps <= Number(BPS_DENOMINATOR)),
       'maxQuoteLossBps must be an integer between 0 and 10000',
     );
+    const maxSolanaNativeSpendLamports =
+      config.maxSolanaNativeSpendLamports ??
+      DEFAULT_MAX_SOLANA_NATIVE_SPEND_LAMPORTS;
+    assert(
+      Number.isSafeInteger(maxSolanaNativeSpendLamports) &&
+        maxSolanaNativeSpendLamports >= 0,
+      'maxSolanaNativeSpendLamports must be a non-negative safe integer',
+    );
     this.logger = logger;
     const defaultSlippageBps = this.getSlippageBps();
     this.client =
@@ -128,10 +231,22 @@ export class SwapsXyzBridge implements IExternalBridge {
     this.evmProviderFactory =
       config.evmProviderFactory ??
       ((rpcUrl) => new providers.StaticJsonRpcProvider(rpcUrl));
+    this.solanaConnectionFactory =
+      config.solanaConnectionFactory ??
+      ((rpcUrl) => new Connection(rpcUrl, 'confirmed'));
+    this.maxSolanaNativeSpendLamports = maxSolanaNativeSpendLamports;
     this.registerTxRetryDelayMs =
       config.registerTxRetryDelayMs ?? REGISTER_TX_RETRY_DELAY_MS;
 
     if (config.chainMetadata) {
+      for (const metadata of Object.values(config.chainMetadata)) {
+        if (
+          metadata.protocol === ProtocolType.Sealevel &&
+          !this.chainMetadataByChainId.has(metadata.domainId)
+        ) {
+          this.chainMetadataByChainId.set(metadata.domainId, metadata);
+        }
+      }
       for (const metadata of Object.values(config.chainMetadata)) {
         if (metadata.chainId !== undefined && isEVMLike(metadata.protocol)) {
           this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
@@ -409,6 +524,17 @@ export class SwapsXyzBridge implements IExternalBridge {
       metadata,
       `SwapsXyzBridge: no chain metadata configured for chainId ${chainId}`,
     );
+    if (metadata.protocol === ProtocolType.Sealevel) {
+      const rpcUrl = metadata.rpcUrls[0]?.http;
+      assert(
+        rpcUrl,
+        `SwapsXyzBridge: no RPC URL configured for chainId ${chainId}`,
+      );
+      const supply = await this.solanaConnectionFactory(rpcUrl).getTokenSupply(
+        new PublicKey(token),
+      );
+      return supply.value.decimals;
+    }
     if (token.toLowerCase() === NATIVE_TOKEN_ADDRESS) {
       return metadata.nativeToken?.decimals ?? 18;
     }
@@ -474,6 +600,9 @@ export class SwapsXyzBridge implements IExternalBridge {
       rpcUrl,
       `SwapsXyzBridge.execute: no RPC URL configured for chainId ${fromChain}`,
     );
+    if (metadata.protocol === ProtocolType.Sealevel) {
+      return this.executeSolana(quote, privateKeys, rpcUrl);
+    }
     const privateKey = privateKeys[ProtocolType.Ethereum];
     assert(
       privateKey,
@@ -525,10 +654,146 @@ export class SwapsXyzBridge implements IExternalBridge {
     };
   }
 
-  private validateActionResponse(
+  private async executeSolana(
+    quote: BridgeQuote,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+    rpcUrl: string,
+  ): Promise<BridgeTransferResult> {
+    const { fromChain, toChain } = quote.requestParams;
+    const rawKey = privateKeys[ProtocolType.Sealevel];
+    assert(
+      rawKey,
+      'SwapsXyzBridge.execute requires a Sealevel private key for Solana-source routes',
+    );
+    const keypair = Keypair.fromSecretKey(parseSolanaPrivateKey(rawKey));
+    assert(
+      keypair.publicKey.toBase58() === quote.requestParams.fromAddress,
+      'SwapsXyzBridge.execute Solana signer does not match quote fromAddress',
+    );
+
+    const fresh = await this.client.getAction(
+      this.buildActionRequest(quote.requestParams),
+    );
+    assert(isSolanaTx(fresh.tx), 'SwapsXyzBridge.execute requires a Solana tx');
+    this.validateSolanaActionResponse(fresh, quote);
+
+    const transaction = VersionedTransaction.deserialize(
+      Buffer.from(fresh.tx.base64Tx, 'base64'),
+    );
+    assert(
+      transaction.message.header.numRequiredSignatures === 1,
+      'SwapsXyzBridge.execute Solana transaction must require exactly one signer',
+    );
+    assert(
+      transaction.message.staticAccountKeys[0]?.equals(keypair.publicKey),
+      'SwapsXyzBridge.execute Solana payer does not match inventory signer',
+    );
+    if (fresh.tx.payer !== undefined) {
+      assert(
+        fresh.tx.payer === keypair.publicKey.toBase58(),
+        `SwapsXyzBridge.execute Solana payer ${fresh.tx.payer} does not match signer ${keypair.publicKey.toBase58()}`,
+      );
+    }
+
+    const connection = this.solanaConnectionFactory(rpcUrl);
+    const addressLookupTables = await this.resolveAddressLookupTables(
+      connection,
+      transaction,
+    );
+    const accountKeys = transaction.message.getAccountKeys({
+      addressLookupTableAccounts: addressLookupTables,
+    });
+    const writableKeys = accountKeys
+      .keySegments()
+      .flat()
+      .filter((_, index) => transaction.message.isAccountWritable(index));
+    assert(
+      writableKeys.some((key) => key.equals(keypair.publicKey)),
+      'SwapsXyzBridge.execute Solana payer must be writable',
+    );
+
+    const preAccounts = await connection.getMultipleAccountsInfoAndContext(
+      writableKeys,
+      { commitment: 'confirmed' },
+    );
+    assert(
+      preAccounts.value.length === writableKeys.length,
+      'SwapsXyzBridge.execute Solana preflight did not return every writable account',
+    );
+    const { blockhash } = await connection.getLatestBlockhash('confirmed');
+    transaction.message.recentBlockhash = blockhash;
+    transaction.sign([keypair]);
+    const simulation = await connection.simulateTransaction(transaction, {
+      sigVerify: true,
+      commitment: 'confirmed',
+      minContextSlot: preAccounts.context.slot,
+      accounts: {
+        encoding: 'base64',
+        addresses: writableKeys.map((key) => key.toBase58()),
+      },
+    });
+    assert(
+      simulation.value.err === null,
+      `SwapsXyzBridge.execute Solana simulation failed: ${JSON.stringify(simulation.value.err)}`,
+    );
+    assert(
+      simulation.value.accounts?.length === writableKeys.length,
+      'SwapsXyzBridge.execute Solana simulation did not return every writable account',
+    );
+    const fee = await connection.getFeeForMessage(
+      transaction.message,
+      'confirmed',
+    );
+    assert(
+      fee.value !== null,
+      'SwapsXyzBridge.execute could not calculate the Solana transaction fee',
+    );
+    this.validateSolanaAccountEffects(
+      quote,
+      fresh,
+      keypair.publicKey,
+      writableKeys,
+      preAccounts.value,
+      simulation.value.accounts,
+      fee.value,
+    );
+
+    const signature = await connection.sendRawTransaction(
+      transaction.serialize(),
+      { skipPreflight: false, maxRetries: 5 },
+    );
+    void this.registerIfRequired(fresh, signature);
+    return {
+      txHash: signature,
+      fromChain,
+      toChain,
+      transferId: fresh.txId,
+    };
+  }
+
+  private async resolveAddressLookupTables(
+    connection: Connection,
+    transaction: VersionedTransaction,
+  ): Promise<AddressLookupTableAccount[]> {
+    return Promise.all(
+      transaction.message.addressTableLookups.map(async (lookup) => {
+        const { value } = await connection.getAddressLookupTable(
+          lookup.accountKey,
+          { commitment: 'confirmed' },
+        );
+        assert(
+          value,
+          `SwapsXyzBridge.execute Solana address lookup table ${lookup.accountKey.toBase58()} was not found`,
+        );
+        return value;
+      }),
+    );
+  }
+
+  private validateActionResponseMetadata(
     response: SwapsXyzActionResponse,
     quote: BridgeQuote,
-    expectedVmId: 'evm',
+    expectedVmId: 'evm' | 'solana',
   ): void {
     const params = quote.requestParams;
     assert(
@@ -573,19 +838,6 @@ export class SwapsXyzBridge implements IExternalBridge {
         `SwapsXyzBridge.execute amountOut token ${response.amountOut.address} does not match requested ${params.toToken}`,
       );
     }
-    const tx = response.tx;
-    assert(isEvmTx(tx), 'SwapsXyzBridge.execute EVM transaction is invalid');
-    if (this.addressesEqual(tx.to, params.fromToken, params.fromChain)) {
-      const selector = transactionSelector(
-        tx.data,
-        'SwapsXyzBridge.execute fresh',
-      );
-      assert(
-        !UNSAFE_SOURCE_TOKEN_SELECTORS.has(selector),
-        `SwapsXyzBridge.execute rejects direct source-token selector 0x${selector}`,
-      );
-    }
-
     const freshFromAmount = BigInt(
       (response.amountInMax ?? response.amountIn).amount,
     );
@@ -599,9 +851,37 @@ export class SwapsXyzBridge implements IExternalBridge {
       `SwapsXyzBridge.execute fresh minimum output ${freshToAmountMin} is below accepted minimum ${quote.toAmountMin}`,
     );
     assert(
-      isRecord(quote.route) && isRecord(quote.route.actionResponse),
+      isRecord(quote.route) &&
+        isSwapsXyzActionResponseValue(quote.route.actionResponse),
       'SwapsXyzBridge.execute accepted action response is missing',
     );
+  }
+
+  private validateActionResponse(
+    response: SwapsXyzActionResponse,
+    quote: BridgeQuote,
+    expectedVmId: 'evm',
+  ): void {
+    this.validateActionResponseMetadata(response, quote, expectedVmId);
+    assert(
+      isRecord(quote.route) &&
+        isSwapsXyzActionResponseValue(quote.route.actionResponse),
+      'SwapsXyzBridge.execute accepted action response is missing',
+    );
+    const params = quote.requestParams;
+    const tx = response.tx;
+    assert(isEvmTx(tx), 'SwapsXyzBridge.execute EVM transaction is invalid');
+    if (this.addressesEqual(tx.to, params.fromToken, params.fromChain)) {
+      const selector = transactionSelector(
+        tx.data,
+        'SwapsXyzBridge.execute fresh',
+      );
+      assert(
+        !UNSAFE_SOURCE_TOKEN_SELECTORS.has(selector),
+        `SwapsXyzBridge.execute rejects direct source-token selector 0x${selector}`,
+      );
+    }
+
     const acceptedTx = quote.route.actionResponse.tx;
     assert(
       isEvmTx(acceptedTx),
@@ -638,6 +918,151 @@ export class SwapsXyzBridge implements IExternalBridge {
       assert(
         acceptedValue === 0n && freshValue === 0n,
         'SwapsXyzBridge.execute ERC20 routes must not send native value',
+      );
+    }
+  }
+
+  private validateSolanaActionResponse(
+    response: SwapsXyzActionResponse,
+    quote: BridgeQuote,
+  ): void {
+    this.validateActionResponseMetadata(response, quote, 'solana');
+    assert(
+      isRecord(quote.route) &&
+        isSwapsXyzActionResponseValue(quote.route.actionResponse),
+      'SwapsXyzBridge.execute accepted action response is missing',
+    );
+    assert(
+      isSolanaTx(response.tx),
+      'SwapsXyzBridge.execute Solana transaction is invalid',
+    );
+    assert(
+      response.requiresRegisterTransaction === true,
+      'SwapsXyzBridge.execute Solana actions must require transaction registration',
+    );
+    const acceptedTx = quote.route.actionResponse.tx;
+    assert(
+      isSolanaTx(acceptedTx),
+      'SwapsXyzBridge.execute accepted Solana transaction is invalid',
+    );
+    const freshTool = response.bridgeIds?.join('+') || 'swapsxyz';
+    assert(
+      freshTool === quote.tool,
+      `SwapsXyzBridge.execute fresh bridge ${freshTool} does not match accepted bridge ${quote.tool}`,
+    );
+  }
+
+  private validateSolanaAccountEffects(
+    quote: BridgeQuote,
+    response: SwapsXyzActionResponse,
+    signer: PublicKey,
+    writableKeys: PublicKey[],
+    preAccounts: Array<AccountInfo<Buffer> | null>,
+    postAccounts: Array<SimulatedTransactionAccountInfo | null>,
+    transactionFeeLamports: number,
+  ): void {
+    const sourceMint = new PublicKey(quote.requestParams.fromToken);
+    let sourceDebit = 0n;
+    let signerLamportDebit: bigint | undefined;
+
+    for (let index = 0; index < writableKeys.length; index++) {
+      const address = writableKeys[index];
+      const pre = preAccounts[index];
+      const post = postAccounts[index];
+
+      if (address.equals(signer)) {
+        assert(pre && post, 'Solana signer account is missing from simulation');
+        assert(
+          post.owner === pre.owner.toBase58() &&
+            post.executable === pre.executable &&
+            simulatedAccountData(post).equals(pre.data),
+          'SwapsXyzBridge.execute Solana transaction changes signer account ownership or data',
+        );
+        signerLamportDebit =
+          pre.lamports > post.lamports
+            ? BigInt(pre.lamports - post.lamports)
+            : 0n;
+      }
+
+      if (!pre) continue;
+      const preToken = decodeTokenAccount(pre.owner, pre.data);
+      if (!preToken?.owner.equals(signer)) continue;
+      assert(
+        post,
+        `SwapsXyzBridge.execute Solana transaction closes signer token account ${address.toBase58()}`,
+      );
+      const postData = simulatedAccountData(post);
+      const postToken = decodeTokenAccount(new PublicKey(post.owner), postData);
+      assert(
+        postToken,
+        `SwapsXyzBridge.execute Solana transaction changes signer token account ${address.toBase58()} into a non-token account`,
+      );
+      assert(
+        postToken.mint.equals(preToken.mint) &&
+          postToken.owner.equals(preToken.owner) &&
+          postToken.delegateOption === preToken.delegateOption &&
+          postToken.delegate.equals(preToken.delegate) &&
+          postToken.delegatedAmount === preToken.delegatedAmount &&
+          postToken.closeAuthorityOption === preToken.closeAuthorityOption &&
+          postToken.closeAuthority.equals(preToken.closeAuthority) &&
+          postToken.state === preToken.state,
+        `SwapsXyzBridge.execute Solana transaction changes authority or state for signer token account ${address.toBase58()}`,
+      );
+      assert(
+        postData.length === pre.data.length,
+        `SwapsXyzBridge.execute Solana transaction changes data length for signer token account ${address.toBase58()}`,
+      );
+      const normalizedPostData = Buffer.from(postData);
+      pre.data.copy(
+        normalizedPostData,
+        TOKEN_AMOUNT_OFFSET,
+        TOKEN_AMOUNT_OFFSET,
+        TOKEN_AMOUNT_OFFSET + 8,
+      );
+      assert(
+        normalizedPostData.equals(pre.data),
+        `SwapsXyzBridge.execute Solana transaction changes non-balance data for signer token account ${address.toBase58()}`,
+      );
+
+      const debit =
+        preToken.amount > postToken.amount
+          ? preToken.amount - postToken.amount
+          : 0n;
+      if (preToken.mint.equals(sourceMint)) {
+        sourceDebit += debit;
+      } else {
+        assert(
+          debit === 0n,
+          `SwapsXyzBridge.execute Solana transaction debits non-source token account ${address.toBase58()}`,
+        );
+      }
+    }
+
+    assert(
+      signerLamportDebit !== undefined,
+      'SwapsXyzBridge.execute Solana simulation omitted the signer account',
+    );
+    const maxLamportDebit =
+      BigInt(transactionFeeLamports) +
+      BigInt(this.maxSolanaNativeSpendLamports);
+    assert(
+      signerLamportDebit <= maxLamportDebit,
+      `SwapsXyzBridge.execute Solana native spend ${signerLamportDebit} exceeds maximum ${maxLamportDebit}`,
+    );
+
+    if (quote.requestParams.fromAmount !== undefined) {
+      const expectedDebit = BigInt(response.amountIn.amount);
+      assert(
+        sourceDebit === expectedDebit,
+        `SwapsXyzBridge.execute Solana source-token debit ${sourceDebit} does not match exact input ${expectedDebit}`,
+      );
+    } else {
+      const maxDebit = BigInt(
+        (response.amountInMax ?? response.amountIn).amount,
+      );
+      assert(
+        sourceDebit > 0n && sourceDebit <= maxDebit,
+        `SwapsXyzBridge.execute Solana source-token debit ${sourceDebit} exceeds exact-output cap ${maxDebit}`,
       );
     }
   }

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
@@ -1,0 +1,730 @@
+import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import {
+  ProtocolType,
+  assert,
+  ensure0x,
+  isEVMLike,
+  retryAsync,
+} from '@hyperlane-xyz/utils';
+import { BigNumber, Contract, Wallet, providers } from 'ethers';
+import type { Logger } from 'pino';
+
+import { ExternalBridgeType } from '../config/types.js';
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+
+import {
+  approveErc20IfNeeded,
+  type Erc20ContractFactory,
+} from './erc20Approve.js';
+import {
+  SwapsXyzClient,
+  SwapsXyzRequestError,
+  isEvmTx,
+  isSwapsXyzNotFoundError,
+  type SwapsXyzActionRequest,
+  type SwapsXyzActionResponse,
+  type SwapsXyzStatusResponse,
+} from './SwapsXyzClient.js';
+
+const NATIVE_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
+const DEFAULT_SLIPPAGE = 0.005;
+const REVERSE_QUOTE_ATTEMPTS = 4;
+const REVERSE_QUOTE_HEADROOM_BPS = 30n;
+const BPS_DENOMINATOR = 10_000n;
+const ERC20_DECIMALS_ABI = ['function decimals() view returns (uint8)'];
+const REGISTER_TX_RETRY_DELAY_MS = 2_000;
+const UNSAFE_SOURCE_TOKEN_SELECTORS = new Set([
+  '095ea7b3', // approve(address,uint256)
+  '23b872dd', // transferFrom(address,address,uint256)
+  'a9059cbb', // transfer(address,uint256)
+]);
+
+export interface SwapsXyzBridgeConfig {
+  apiKey: string;
+  apiUrl?: string;
+  defaultSlippage?: number;
+  maxQuoteLossBps?: number;
+  chainMetadata?: ChainMap<ChainMetadata>;
+  evmProviderFactory?: (rpcUrl: string) => providers.Provider;
+  registerTxRetryDelayMs?: number;
+  erc20ContractFactory?: Erc20ContractFactory;
+}
+
+export interface SwapsXyzBridgeRoute {
+  // Telemetry only. execute() always re-quotes before signing.
+  actionResponse: SwapsXyzActionResponse;
+}
+
+function ceilDiv(numerator: bigint, denominator: bigint): bigint {
+  return (numerator + denominator - 1n) / denominator;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function transactionValue(tx: unknown, context: string): bigint {
+  assert(isRecord(tx), `${context} transaction is missing`);
+  const value = tx.value;
+  assert(
+    value === undefined || typeof value === 'string',
+    `${context} transaction value is invalid`,
+  );
+  return value === undefined || value === '' ? 0n : BigInt(value);
+}
+
+function transactionSelector(data: string, context: string): string {
+  assert(
+    /^0x[0-9a-fA-F]+$/.test(data) && data.length >= 10 && data.length % 2 === 0,
+    `${context} transaction calldata is invalid`,
+  );
+  return data.slice(2, 10).toLowerCase();
+}
+
+export class SwapsXyzBridge implements IExternalBridge {
+  readonly externalBridgeId = ExternalBridgeType.SwapsXyz;
+  readonly logger: Logger;
+
+  private readonly client: SwapsXyzClient;
+  private readonly config: SwapsXyzBridgeConfig;
+  private readonly chainMetadataByChainId = new Map<number, ChainMetadata>();
+  private readonly tokenDecimalsCache = new Map<string, Promise<number>>();
+  private readonly evmProviderFactory: (rpcUrl: string) => providers.Provider;
+  private readonly registerTxRetryDelayMs: number;
+  // Prevent source-account races when movements share a source in one cycle.
+  private _executeLock: Promise<void> = Promise.resolve();
+
+  constructor(
+    config: SwapsXyzBridgeConfig,
+    logger: Logger,
+    client?: SwapsXyzClient,
+  ) {
+    this.config = config;
+    assert(
+      config.maxQuoteLossBps === undefined ||
+        (Number.isInteger(config.maxQuoteLossBps) &&
+          config.maxQuoteLossBps >= 0 &&
+          config.maxQuoteLossBps <= Number(BPS_DENOMINATOR)),
+      'maxQuoteLossBps must be an integer between 0 and 10000',
+    );
+    this.logger = logger;
+    const defaultSlippageBps = this.getSlippageBps();
+    this.client =
+      client ??
+      new SwapsXyzClient(
+        {
+          apiKey: config.apiKey,
+          apiUrl: config.apiUrl,
+          defaultSlippageBps,
+        },
+        logger,
+      );
+    this.evmProviderFactory =
+      config.evmProviderFactory ??
+      ((rpcUrl) => new providers.StaticJsonRpcProvider(rpcUrl));
+    this.registerTxRetryDelayMs =
+      config.registerTxRetryDelayMs ?? REGISTER_TX_RETRY_DELAY_MS;
+
+    if (config.chainMetadata) {
+      for (const metadata of Object.values(config.chainMetadata)) {
+        if (metadata.chainId !== undefined && isEVMLike(metadata.protocol)) {
+          this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
+        }
+      }
+    }
+  }
+
+  getNativeTokenAddress(): string {
+    return NATIVE_TOKEN_ADDRESS;
+  }
+
+  async quote(
+    params: BridgeQuoteParams,
+  ): Promise<BridgeQuote<SwapsXyzBridgeRoute>> {
+    this.validateQuoteParams(params);
+
+    try {
+      const response = await this.client.getAction(
+        this.buildActionRequest(params),
+      );
+      return this.toBridgeQuote(params, response);
+    } catch (error) {
+      if (
+        params.toAmount !== undefined &&
+        error instanceof SwapsXyzRequestError &&
+        error.code === 'UNSUPPORTED_SWAP_DIRECTION'
+      ) {
+        return this.quoteExactOutWithForwardFallback(params);
+      }
+      throw error;
+    }
+  }
+
+  execute(
+    quote: BridgeQuote,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    const execution = this._executeLock.then(() =>
+      this.executeUnlocked(quote, privateKeys),
+    );
+    this._executeLock = execution.then(
+      () => undefined,
+      () => undefined,
+    );
+    return execution;
+  }
+
+  async getStatus(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+    transferId?: string,
+  ): Promise<BridgeTransferStatus> {
+    let response: SwapsXyzStatusResponse | undefined;
+    let statusError: unknown;
+    const statusRequest = {
+      txHash,
+      chainId: fromChain,
+      ...(transferId === undefined ? {} : { txId: transferId }),
+    };
+    try {
+      response = await this.client.getStatus(statusRequest);
+    } catch (error) {
+      statusError = error;
+    }
+
+    // registerTxs is idempotent. Retrying it here heals transient registration
+    // outages without re-broadcasting the source transaction.
+    if (
+      transferId !== undefined &&
+      (response === undefined ||
+        response.status.toLowerCase() === 'not yet created') &&
+      (await this.registerTransaction(transferId, txHash))
+    ) {
+      try {
+        response = await this.client.getStatus(statusRequest);
+      } catch (error) {
+        statusError = error;
+        response = undefined;
+      }
+    }
+
+    if (response === undefined) {
+      if (isSwapsXyzNotFoundError(statusError)) {
+        return { status: 'not_found' };
+      }
+      this.logger.warn(
+        { txHash, transferId, error: statusError },
+        'Failed to get swaps.xyz status',
+      );
+      throw statusError instanceof Error
+        ? statusError
+        : new Error('Failed to get swaps.xyz status');
+    }
+    return this.toBridgeTransferStatus(response, txHash, fromChain, toChain);
+  }
+
+  private toBridgeTransferStatus(
+    response: SwapsXyzStatusResponse,
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): BridgeTransferStatus {
+    // The API's chainId param is advisory: a hash registered on a different
+    // chain is still returned. Such an entry is not our transfer.
+    if (
+      response.srcChainId !== undefined &&
+      response.srcChainId !== fromChain
+    ) {
+      this.logger.warn(
+        { txHash, fromChain, responseSrcChainId: response.srcChainId },
+        'swaps.xyz status srcChainId does not match requested chain',
+      );
+      return { status: 'not_found' };
+    }
+    if (response.dstChainId !== toChain) {
+      this.logger.warn(
+        { txHash, toChain, responseDstChainId: response.dstChainId },
+        'swaps.xyz status dstChainId does not match requested chain',
+      );
+      return { status: 'not_found' };
+    }
+    const rawStatus = response.status;
+
+    switch (rawStatus.toLowerCase()) {
+      case 'success':
+      case 'completed':
+        return {
+          status: 'complete',
+          receivingTxHash: response.dstTxHash ?? '',
+          receivedAmount: BigInt(
+            response.actionResponse?.amountOut.amount ?? '0',
+          ),
+        };
+      case 'failed':
+        return {
+          status: 'failed',
+          error: 'swaps.xyz reported transfer failed',
+        };
+      case 'refunded':
+        return { status: 'failed', error: 'refunded' };
+      case 'requires refund':
+        return {
+          status: 'failed',
+          error: 'requires refund (claim via swaps.xyz)',
+        };
+      case 'expired':
+        return { status: 'failed', error: 'swaps.xyz transfer expired' };
+      default:
+        return { status: 'pending', substatus: rawStatus };
+    }
+  }
+
+  private validateQuoteParams(params: BridgeQuoteParams): void {
+    if (params.fromAmount !== undefined && params.toAmount !== undefined) {
+      throw new Error(
+        'Cannot specify both fromAmount and toAmount - provide exactly one',
+      );
+    }
+    if (params.fromAmount === undefined && params.toAmount === undefined) {
+      throw new Error('Must specify either fromAmount or toAmount');
+    }
+    assert(
+      params.fromAmount === undefined || params.fromAmount > 0n,
+      'fromAmount must be positive',
+    );
+    assert(
+      params.toAmount === undefined || params.toAmount > 0n,
+      'toAmount must be positive',
+    );
+  }
+
+  private buildActionRequest(params: BridgeQuoteParams): SwapsXyzActionRequest {
+    const amount = params.fromAmount ?? params.toAmount;
+    assert(amount !== undefined, 'Must specify either fromAmount or toAmount');
+    return {
+      actionType: 'swap-action',
+      sender: params.fromAddress,
+      recipient: params.toAddress ?? params.fromAddress,
+      srcChainId: params.fromChain,
+      dstChainId: params.toChain,
+      srcToken: params.fromToken,
+      dstToken: params.toToken,
+      slippage: this.getSlippageBps(params.slippage),
+      amount: amount.toString(),
+      swapDirection:
+        params.fromAmount !== undefined
+          ? 'exact-amount-in'
+          : 'exact-amount-out',
+    };
+  }
+
+  private getSlippageBps(slippage?: number): number {
+    return Math.round(
+      (slippage ?? this.config.defaultSlippage ?? DEFAULT_SLIPPAGE) * 10_000,
+    );
+  }
+
+  private async quoteExactOutWithForwardFallback(
+    params: BridgeQuoteParams,
+  ): Promise<BridgeQuote<SwapsXyzBridgeRoute>> {
+    const toAmount = params.toAmount;
+    assert(toAmount !== undefined, 'Reverse quote requires toAmount');
+    const slippageBps = this.getSlippageBps(params.slippage);
+    const [sourceDecimals, destinationDecimals] = await Promise.all([
+      this.getTokenDecimals(params.fromChain, params.fromToken),
+      this.getTokenDecimals(params.toChain, params.toToken),
+    ]);
+    let fromAmount = ceilDiv(
+      toAmount * 10n ** BigInt(sourceDecimals),
+      10n ** BigInt(destinationDecimals),
+    );
+    fromAmount =
+      (fromAmount *
+        (BPS_DENOMINATOR + BigInt(slippageBps) + REVERSE_QUOTE_HEADROOM_BPS)) /
+      BPS_DENOMINATOR;
+
+    let lastAmountOutMin = 0n;
+    for (let attempt = 1; attempt <= REVERSE_QUOTE_ATTEMPTS; attempt++) {
+      const forwardParams: BridgeQuoteParams = {
+        ...params,
+        fromAmount,
+        toAmount: undefined,
+      };
+      const response = await this.client.getAction(
+        this.buildActionRequest(forwardParams),
+      );
+      lastAmountOutMin = BigInt(response.amountOutMin.amount);
+      this.logger.debug(
+        {
+          attempt,
+          fromAmount: fromAmount.toString(),
+          amountOutMin: lastAmountOutMin.toString(),
+          requestedToAmount: toAmount.toString(),
+        },
+        'swaps.xyz reverse quote forward fallback attempt',
+      );
+      if (lastAmountOutMin >= toAmount) {
+        return this.toBridgeQuote(forwardParams, response);
+      }
+      assert(
+        lastAmountOutMin > 0n,
+        'SwapsXyzBridge reverse quote fallback returned zero amountOutMin',
+      );
+      fromAmount = ceilDiv(fromAmount * toAmount, lastAmountOutMin) + 1n;
+    }
+
+    throw new Error(
+      `SwapsXyzBridge reverse quote fallback exhausted after ${REVERSE_QUOTE_ATTEMPTS} attempts; last amountOutMin ${lastAmountOutMin.toString()} was short of requested ${toAmount.toString()}`,
+    );
+  }
+
+  private getTokenDecimals(chainId: number, token: string): Promise<number> {
+    const cacheKey = `${chainId}:${token}`;
+    const cached = this.tokenDecimalsCache.get(cacheKey);
+    if (cached) return cached;
+
+    const decimals = this.fetchTokenDecimals(chainId, token);
+    this.tokenDecimalsCache.set(cacheKey, decimals);
+    void decimals.catch(() => {
+      if (this.tokenDecimalsCache.get(cacheKey) === decimals) {
+        this.tokenDecimalsCache.delete(cacheKey);
+      }
+    });
+    return decimals;
+  }
+
+  private async fetchTokenDecimals(
+    chainId: number,
+    token: string,
+  ): Promise<number> {
+    const metadata = this.chainMetadataByChainId.get(chainId);
+    assert(
+      metadata,
+      `SwapsXyzBridge: no chain metadata configured for chainId ${chainId}`,
+    );
+    if (token.toLowerCase() === NATIVE_TOKEN_ADDRESS) {
+      return metadata.nativeToken?.decimals ?? 18;
+    }
+    assert(
+      isEVMLike(metadata.protocol),
+      `SwapsXyzBridge: unsupported token decimals protocol ${metadata.protocol}`,
+    );
+    const rpcUrl = metadata.rpcUrls[0]?.http;
+    assert(
+      rpcUrl,
+      `SwapsXyzBridge: no RPC URL configured for chainId ${chainId}`,
+    );
+    const provider = this.evmProviderFactory(rpcUrl);
+    const tokenContract = new Contract(token, ERC20_DECIMALS_ABI, provider);
+    return Number(await tokenContract.decimals());
+  }
+
+  private async toBridgeQuote(
+    params: BridgeQuoteParams,
+    response: SwapsXyzActionResponse,
+  ): Promise<BridgeQuote<SwapsXyzBridgeRoute>> {
+    let feeCosts = 0n;
+    for (const fee of [
+      response.protocolFee,
+      response.applicationFee,
+      response.bridgeFee,
+    ]) {
+      if (fee?.amount) feeCosts += BigInt(fee.amount);
+    }
+
+    const fromAmount = BigInt(
+      (response.amountInMax ?? response.amountIn).amount,
+    );
+    const toAmountMin = BigInt(response.amountOutMin.amount);
+    await this.validateQuoteLoss(params, response, fromAmount, toAmountMin);
+
+    return {
+      id: response.txId,
+      tool: response.bridgeIds?.join('+') || 'swapsxyz',
+      fromAmount,
+      toAmount: BigInt(response.amountOut.amount),
+      toAmountMin,
+      executionDuration: response.estimatedTxTime ?? 0,
+      gasCosts: 0n,
+      feeCosts,
+      route: { actionResponse: response },
+      requestParams: params,
+    };
+  }
+
+  private async executeUnlocked(
+    quote: BridgeQuote,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    const { fromChain, toChain } = quote.requestParams;
+    const metadata = this.chainMetadataByChainId.get(fromChain);
+    assert(
+      metadata,
+      `SwapsXyzBridge.execute: no chain metadata configured for chainId ${fromChain}`,
+    );
+    const rpcUrl = metadata.rpcUrls[0]?.http;
+    assert(
+      rpcUrl,
+      `SwapsXyzBridge.execute: no RPC URL configured for chainId ${fromChain}`,
+    );
+    const privateKey = privateKeys[ProtocolType.Ethereum];
+    assert(
+      privateKey,
+      'SwapsXyzBridge.execute requires an Ethereum (EVM) private key',
+    );
+
+    const provider = this.evmProviderFactory(rpcUrl);
+    const signer = new Wallet(ensure0x(privateKey), provider);
+    assert(
+      this.addressesEqual(
+        await signer.getAddress(),
+        quote.requestParams.fromAddress,
+        fromChain,
+      ),
+      'SwapsXyzBridge.execute signer does not match quote fromAddress',
+    );
+
+    const fresh = await this.client.getAction(
+      this.buildActionRequest(quote.requestParams),
+    );
+    assert(isEvmTx(fresh.tx), 'SwapsXyzBridge.execute requires an EVM tx');
+    this.validateActionResponse(fresh, quote, 'evm');
+
+    if (fresh.requiresTokenApproval) {
+      await approveErc20IfNeeded(
+        signer,
+        quote.requestParams.fromToken,
+        fresh.tx.to,
+        BigInt((fresh.amountInMax ?? fresh.amountIn).amount),
+        this.logger,
+        { contractFactory: this.config.erc20ContractFactory },
+      );
+    }
+
+    const txResponse = await signer.sendTransaction({
+      to: fresh.tx.to,
+      data: fresh.tx.data,
+      value: fresh.tx.value ? BigNumber.from(fresh.tx.value) : undefined,
+    });
+    // Persistable tracking identity takes priority over waiting here: once a
+    // source transaction is broadcast, receipt/status failures must not cause
+    // the planner to send the same movement again.
+    void this.registerIfRequired(fresh, txResponse.hash);
+    return {
+      txHash: txResponse.hash,
+      fromChain,
+      toChain,
+      transferId: fresh.txId,
+    };
+  }
+
+  private validateActionResponse(
+    response: SwapsXyzActionResponse,
+    quote: BridgeQuote,
+    expectedVmId: 'evm',
+  ): void {
+    const params = quote.requestParams;
+    assert(
+      response.vmId === undefined || response.vmId === expectedVmId,
+      `SwapsXyzBridge.execute vmId ${response.vmId} does not match ${expectedVmId}`,
+    );
+    if (response.tx.chainId !== undefined) {
+      assert(
+        response.tx.chainId === params.fromChain,
+        `SwapsXyzBridge.execute tx chainId ${response.tx.chainId} does not match requested ${params.fromChain}`,
+      );
+    }
+    if (response.amountIn.chainId !== undefined) {
+      assert(
+        response.amountIn.chainId === params.fromChain,
+        `SwapsXyzBridge.execute amountIn chainId ${response.amountIn.chainId} does not match requested ${params.fromChain}`,
+      );
+    }
+    if (response.amountOut.chainId !== undefined) {
+      assert(
+        response.amountOut.chainId === params.toChain,
+        `SwapsXyzBridge.execute amountOut chainId ${response.amountOut.chainId} does not match requested ${params.toChain}`,
+      );
+    }
+    if (response.amountIn.address !== undefined) {
+      assert(
+        this.addressesEqual(
+          response.amountIn.address,
+          params.fromToken,
+          params.fromChain,
+        ),
+        `SwapsXyzBridge.execute amountIn token ${response.amountIn.address} does not match requested ${params.fromToken}`,
+      );
+    }
+    if (response.amountOut.address !== undefined) {
+      assert(
+        this.addressesEqual(
+          response.amountOut.address,
+          params.toToken,
+          params.toChain,
+        ),
+        `SwapsXyzBridge.execute amountOut token ${response.amountOut.address} does not match requested ${params.toToken}`,
+      );
+    }
+    const tx = response.tx;
+    assert(isEvmTx(tx), 'SwapsXyzBridge.execute EVM transaction is invalid');
+    if (this.addressesEqual(tx.to, params.fromToken, params.fromChain)) {
+      const selector = transactionSelector(
+        tx.data,
+        'SwapsXyzBridge.execute fresh',
+      );
+      assert(
+        !UNSAFE_SOURCE_TOKEN_SELECTORS.has(selector),
+        `SwapsXyzBridge.execute rejects direct source-token selector 0x${selector}`,
+      );
+    }
+
+    const freshFromAmount = BigInt(
+      (response.amountInMax ?? response.amountIn).amount,
+    );
+    assert(
+      freshFromAmount <= quote.fromAmount,
+      `SwapsXyzBridge.execute fresh input ${freshFromAmount} exceeds accepted input cap ${quote.fromAmount}`,
+    );
+    const freshToAmountMin = BigInt(response.amountOutMin.amount);
+    assert(
+      freshToAmountMin >= quote.toAmountMin,
+      `SwapsXyzBridge.execute fresh minimum output ${freshToAmountMin} is below accepted minimum ${quote.toAmountMin}`,
+    );
+    assert(
+      isRecord(quote.route) && isRecord(quote.route.actionResponse),
+      'SwapsXyzBridge.execute accepted action response is missing',
+    );
+    const acceptedTx = quote.route.actionResponse.tx;
+    assert(
+      isEvmTx(acceptedTx),
+      'SwapsXyzBridge.execute accepted EVM transaction is invalid',
+    );
+    assert(
+      this.addressesEqual(tx.to, acceptedTx.to, params.fromChain),
+      `SwapsXyzBridge.execute fresh target ${tx.to} does not match accepted target ${acceptedTx.to}`,
+    );
+    assert(
+      transactionSelector(tx.data, 'SwapsXyzBridge.execute fresh') ===
+        transactionSelector(acceptedTx.data, 'SwapsXyzBridge.execute accepted'),
+      'SwapsXyzBridge.execute fresh calldata selector does not match accepted selector',
+    );
+    const freshValue = transactionValue(
+      response.tx,
+      'SwapsXyzBridge.execute fresh',
+    );
+    const acceptedValue = transactionValue(
+      quote.route.actionResponse.tx,
+      'SwapsXyzBridge.execute accepted',
+    );
+    assert(
+      freshValue >= 0n && freshValue <= acceptedValue,
+      `SwapsXyzBridge.execute fresh native value ${freshValue} exceeds accepted native value ${acceptedValue}`,
+    );
+    if (
+      !this.addressesEqual(
+        params.fromToken,
+        NATIVE_TOKEN_ADDRESS,
+        params.fromChain,
+      )
+    ) {
+      assert(
+        acceptedValue === 0n && freshValue === 0n,
+        'SwapsXyzBridge.execute ERC20 routes must not send native value',
+      );
+    }
+  }
+
+  private async validateQuoteLoss(
+    params: BridgeQuoteParams,
+    response: SwapsXyzActionResponse,
+    fromAmount: bigint,
+    toAmountMin: bigint,
+  ): Promise<void> {
+    const maxQuoteLossBps = this.config.maxQuoteLossBps;
+    if (maxQuoteLossBps === undefined) return;
+
+    const [sourceDecimals, destinationDecimals] = await Promise.all([
+      response.amountInMax?.decimals ??
+        response.amountIn.decimals ??
+        this.getTokenDecimals(params.fromChain, params.fromToken),
+      response.amountOutMin.decimals ??
+        response.amountOut.decimals ??
+        this.getTokenDecimals(params.toChain, params.toToken),
+    ]);
+    assert(
+      sourceDecimals <= 255 && destinationDecimals <= 255,
+      'swaps.xyz quote token decimals must be at most 255',
+    );
+    const commonDecimals = Math.max(sourceDecimals, destinationDecimals);
+    const normalizedFromAmount =
+      fromAmount * 10n ** BigInt(commonDecimals - sourceDecimals);
+    const normalizedToAmountMin =
+      toAmountMin * 10n ** BigInt(commonDecimals - destinationDecimals);
+    const lossBps =
+      normalizedToAmountMin >= normalizedFromAmount
+        ? 0n
+        : ceilDiv(
+            (normalizedFromAmount - normalizedToAmountMin) * BPS_DENOMINATOR,
+            normalizedFromAmount,
+          );
+    assert(
+      lossBps <= BigInt(maxQuoteLossBps),
+      `swaps.xyz quote loss ${lossBps} bps exceeds configured maximum ${maxQuoteLossBps} bps`,
+    );
+  }
+
+  private addressesEqual(
+    left: string,
+    right: string,
+    _chainId: number,
+  ): boolean {
+    if (left.startsWith('0x') && right.startsWith('0x')) {
+      return left.toLowerCase() === right.toLowerCase();
+    }
+    return left === right;
+  }
+
+  private async registerIfRequired(
+    response: SwapsXyzActionResponse,
+    txHash: string,
+  ): Promise<void> {
+    if (response.requiresRegisterTransaction !== true) return;
+    await this.registerTransaction(response.txId, txHash);
+  }
+
+  private async registerTransaction(
+    txId: string,
+    txHash: string,
+  ): Promise<boolean> {
+    try {
+      await retryAsync(
+        async () => {
+          const results = await this.client.registerTxs([{ txId, txHash }]);
+          const failed = results.find((result) => !result.success);
+          if (failed) {
+            throw new Error(
+              `swaps.xyz registerTxs failed: ${failed.error ?? 'unknown error'}`,
+            );
+          }
+        },
+        3,
+        this.registerTxRetryDelayMs,
+      );
+      return true;
+    } catch (error) {
+      this.logger.error(
+        { txId, txHash, error },
+        'Failed to register swaps.xyz transaction',
+      );
+      return false;
+    }
+  }
+}

--- a/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzBridge.ts
@@ -708,7 +708,7 @@ export class SwapsXyzBridge implements IExternalBridge {
       data: fresh.tx.data,
       value: fresh.tx.value ? BigNumber.from(fresh.tx.value) : undefined,
     });
-    // Persistable tracking identity takes priority over waiting here: once a
+    // Source-action tracking takes priority over waiting here: once a
     // source transaction is broadcast, receipt/status failures must not cause
     // the planner to send the same movement again.
     void this.registerIfRequired(fresh, txResponse.hash);

--- a/typescript/rebalancer/src/bridges/SwapsXyzClient.test.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzClient.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import {
   SwapsXyzClient,
   SwapsXyzRequestError,
+  isTronTx,
   isSwapsXyzTerminalError,
   type SwapsXyzActionRequest,
 } from './SwapsXyzClient.js';
@@ -73,6 +74,25 @@ function statusResponseBody(): unknown {
     txId: 'tx-1',
     srcChainId: 1,
     dstChainId: 8453,
+  };
+}
+
+function tronActionResponseBody(toExtra: string | null = null): unknown {
+  return {
+    tx: {
+      to: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+      toExtra,
+      value: '1000000',
+      chainId: 728126428,
+      chainKey: 'trx',
+    },
+    txId: 'tron-tx-1',
+    vmId: 'alt-vm',
+    amountIn: { amount: '1000000' },
+    amountOut: { amount: '995000' },
+    amountOutMin: { amount: '990000' },
+    requiresTokenApproval: false,
+    requiresRegisterTransaction: true,
   };
 }
 
@@ -224,6 +244,42 @@ describe('SwapsXyzClient', () => {
 
     expect(response.vmId).to.equal('solana');
     expect(response.tx).to.deep.include({ base64Tx: 'AQID' });
+  });
+
+  it('validates Tron alt-vm transaction responses', async () => {
+    fetchStub.resolves(makeResponse({ body: tronActionResponseBody() }));
+
+    const response = await client.getAction(actionRequest());
+
+    expect(isTronTx(response.tx)).to.equal(true);
+    if (!isTronTx(response.tx)) {
+      throw new Error('Expected a Tron transaction');
+    }
+    expect(response.tx.toExtra).to.equal(null);
+    expect(response.tx.chainKey).to.equal('trx');
+  });
+
+  it('rejects malformed Tron transaction objects in the type guard', () => {
+    expect(
+      isTronTx({
+        to: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        toExtra: '0xabc',
+        value: '-1',
+        chainId: 728126428.5,
+        chainKey: 'trx',
+      }),
+    ).to.equal(false);
+  });
+
+  it('rejects malformed Tron calldata without retrying', async () => {
+    fetchStub.resolves(makeResponse({ body: tronActionResponseBody('0xabc') }));
+
+    const error = await captureError(client.getAction(actionRequest()));
+
+    expect(error).to.be.instanceOf(Error);
+    if (!(error instanceof Error)) throw new Error('Expected Error');
+    expect(error.message).to.include('Invalid swaps.xyz response');
+    expect(fetchStub.callCount).to.equal(1);
   });
 
   it('parses the error envelope and exposes its code', async () => {

--- a/typescript/rebalancer/src/bridges/SwapsXyzClient.test.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzClient.test.ts
@@ -1,0 +1,303 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import sinon from 'sinon';
+
+import {
+  SwapsXyzClient,
+  SwapsXyzRequestError,
+  isSwapsXyzTerminalError,
+  type SwapsXyzActionRequest,
+} from './SwapsXyzClient.js';
+
+const logger = pino({ level: 'silent' });
+
+type FetchStub = sinon.SinonStub<
+  Parameters<typeof globalThis.fetch>,
+  ReturnType<typeof globalThis.fetch>
+>;
+
+function makeResponse(options: {
+  status?: number;
+  statusText?: string;
+  body?: unknown;
+}): Response {
+  const status = options.status ?? 200;
+  return new Response(JSON.stringify(options.body ?? {}), {
+    status,
+    statusText: options.statusText ?? 'OK',
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function getRequest(
+  fetchStub: FetchStub,
+  callIndex = 0,
+): { url: string; init: RequestInit } {
+  const call = fetchStub.getCall(callIndex);
+  if (!call) throw new Error(`Missing fetch call ${callIndex}`);
+  const [input, init] = call.args;
+  if (typeof input !== 'string') throw new Error('Expected string fetch URL');
+  if (!init) throw new Error('Expected fetch request init');
+  return { url: input, init };
+}
+
+function actionRequest(): SwapsXyzActionRequest {
+  return {
+    actionType: 'swap-action',
+    sender: '0xabc',
+    srcChainId: 1,
+    srcToken: '0x1111',
+    dstChainId: 8453,
+    dstToken: '0x2222',
+    slippage: 50,
+    amount: '1000000',
+    swapDirection: 'exact-amount-in',
+  };
+}
+
+function actionResponseBody(): Record<string, unknown> {
+  return {
+    tx: { to: '0x1111', data: '0xdeadbeef', value: '0', chainId: 1 },
+    txId: 'tx-1',
+    vmId: 'evm',
+    amountIn: { amount: '1000000' },
+    amountOut: { amount: '995000' },
+    amountOutMin: { amount: '990000' },
+    requiresTokenApproval: false,
+  };
+}
+
+function statusResponseBody(): unknown {
+  return {
+    status: 'pending',
+    txId: 'tx-1',
+    srcChainId: 1,
+    dstChainId: 8453,
+  };
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected promise to reject');
+}
+
+describe('SwapsXyzClient', () => {
+  let client: SwapsXyzClient;
+  let fetchStub: FetchStub;
+
+  beforeEach(() => {
+    client = new SwapsXyzClient(
+      { apiKey: 'test-key', defaultSlippageBps: 50 },
+      logger,
+    );
+    fetchStub = sinon.stub(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('sends x-api-key on every endpoint request', async () => {
+    fetchStub.onCall(0).resolves(makeResponse({ body: actionResponseBody() }));
+    fetchStub.onCall(1).resolves(makeResponse({ body: statusResponseBody() }));
+    fetchStub
+      .onCall(2)
+      .resolves(makeResponse({ body: [{ success: true, error: null }] }));
+
+    await client.getAction(actionRequest());
+    await client.getStatus({ txId: 'tx-1' });
+    await client.registerTxs([{ txId: 'tx-1', txHash: '0xabc' }]);
+
+    expect(fetchStub.callCount).to.equal(3);
+    for (let index = 0; index < fetchStub.callCount; index++) {
+      const { init } = getRequest(fetchStub, index);
+      expect(new Headers(init.headers).get('x-api-key')).to.equal('test-key');
+    }
+  });
+
+  it('bounds each request with an AbortSignal timeout', async () => {
+    fetchStub.resolves(makeResponse({ body: actionResponseBody() }));
+    await client.getAction(actionRequest());
+
+    const { init } = getRequest(fetchStub);
+    expect(init.signal).to.be.instanceOf(AbortSignal);
+  });
+
+  it('builds /getAction query params and skips undefined values', async () => {
+    fetchStub.resolves(makeResponse({ body: actionResponseBody() }));
+    await client.getAction({
+      ...actionRequest(),
+      srcChainId: 8453,
+      dstChainId: 42161,
+      slippage: 100,
+      recipient: undefined,
+    });
+
+    const { url } = getRequest(fetchStub);
+    const parsedUrl = new URL(url);
+    expect(parsedUrl.origin + parsedUrl.pathname).to.equal(
+      'https://api-v2.swaps.xyz/api/getAction',
+    );
+    expect(parsedUrl.searchParams.get('srcChainId')).to.equal('8453');
+    expect(parsedUrl.searchParams.get('dstChainId')).to.equal('42161');
+    expect(parsedUrl.searchParams.get('swapDirection')).to.equal(
+      'exact-amount-in',
+    );
+    expect(parsedUrl.searchParams.get('slippage')).to.equal('100');
+    expect(parsedUrl.searchParams.has('recipient')).to.equal(false);
+  });
+
+  it('honors apiUrl override and strips its trailing slash', async () => {
+    const customClient = new SwapsXyzClient(
+      { apiKey: 'test-key', apiUrl: 'https://example.test/api/' },
+      logger,
+    );
+    fetchStub.resolves(makeResponse({ body: statusResponseBody() }));
+
+    await customClient.getStatus({ txId: 'tx-1' });
+
+    const { url } = getRequest(fetchStub);
+    expect(url.startsWith('https://example.test/api/getStatus?')).to.equal(
+      true,
+    );
+  });
+
+  it('getStatus throws synchronously without txHash or txId', () => {
+    expect(() => client.getStatus({})).to.throw('txHash or txId');
+    expect(fetchStub.callCount).to.equal(0);
+  });
+
+  it('rejects non-HTTPS API URLs', () => {
+    expect(
+      () =>
+        new SwapsXyzClient(
+          { apiKey: 'test-key', apiUrl: 'http://example.test/api' },
+          logger,
+        ),
+    ).to.throw('must use HTTPS');
+  });
+
+  it('rejects malformed API responses without retrying', async () => {
+    fetchStub.resolves(makeResponse({ body: { txId: 'missing-fields' } }));
+
+    const error = await captureError(client.getAction(actionRequest()));
+
+    expect(error).to.be.instanceOf(Error);
+    if (!(error instanceof Error)) throw new TypeError('Expected Error');
+    expect(error.message).to.include('Invalid swaps.xyz response');
+    expect(fetchStub.callCount).to.equal(1);
+  });
+
+  it('accepts a null estimated price impact', async () => {
+    fetchStub.resolves(
+      makeResponse({
+        body: { ...actionResponseBody(), estimatedPriceImpact: null },
+      }),
+    );
+
+    const response = await client.getAction(actionRequest());
+
+    expect(response.estimatedPriceImpact).to.be.null;
+  });
+
+  it('parses the error envelope and exposes its code', async () => {
+    fetchStub.resolves(
+      makeResponse({
+        status: 400,
+        statusText: 'Bad Request',
+        body: {
+          success: false,
+          error: { code: 'NO_AVAILABLE_ROUTE', message: 'no route' },
+        },
+      }),
+    );
+
+    const error = await captureError(client.getAction(actionRequest()));
+    expect(error).to.be.instanceOf(SwapsXyzRequestError);
+    if (!(error instanceof SwapsXyzRequestError)) {
+      throw new Error('Expected SwapsXyzRequestError');
+    }
+    expect(error.code).to.equal('NO_AVAILABLE_ROUTE');
+    expect(error.message).to.include('no route');
+  });
+
+  it('does not retry terminal NO_AVAILABLE_ROUTE errors', async () => {
+    fetchStub.resolves(
+      makeResponse({
+        status: 400,
+        body: { error: { code: 'NO_AVAILABLE_ROUTE' } },
+      }),
+    );
+
+    const error = await captureError(client.getAction(actionRequest()));
+    expect(error).to.be.instanceOf(SwapsXyzRequestError);
+    expect(fetchStub.callCount).to.equal(1);
+  });
+
+  it('retries transient errors and succeeds on the third attempt', async function () {
+    this.timeout(10_000);
+    fetchStub
+      .onCall(0)
+      .resolves(makeResponse({ status: 500, statusText: 'Internal' }));
+    fetchStub
+      .onCall(1)
+      .resolves(makeResponse({ status: 502, statusText: 'Bad Gateway' }));
+    fetchStub.onCall(2).resolves(makeResponse({ body: actionResponseBody() }));
+
+    const response = await client.getAction(actionRequest());
+    expect(response.txId).to.equal('tx-1');
+    expect(fetchStub.callCount).to.equal(3);
+  });
+
+  it('classifies 408 as retriable and request errors as terminal', () => {
+    expect(
+      isSwapsXyzTerminalError(
+        new SwapsXyzRequestError('timeout', 408, 'Request Timeout'),
+      ),
+    ).to.equal(false);
+    expect(
+      isSwapsXyzTerminalError(
+        new SwapsXyzRequestError(
+          'unauthorized',
+          401,
+          'Unauthorized',
+          'INVALID_API_KEY',
+        ),
+      ),
+    ).to.equal(true);
+    expect(
+      isSwapsXyzTerminalError(
+        new SwapsXyzRequestError(
+          'unsupported',
+          400,
+          'Bad Request',
+          'UNSUPPORTED_SWAP_DIRECTION',
+        ),
+      ),
+    ).to.equal(true);
+  });
+
+  it('registerTxs posts a JSON body with content-type', async () => {
+    fetchStub.resolves(
+      makeResponse({ body: [{ success: true, error: null }] }),
+    );
+    const entries = [{ txId: 'tx-1', txHash: '0xabc' }];
+
+    const results = await client.registerTxs(entries);
+
+    const { url, init } = getRequest(fetchStub);
+    expect(url).to.equal('https://api-v2.swaps.xyz/api/registerTxs');
+    expect(init.method).to.equal('POST');
+    expect(init.body).to.equal(JSON.stringify(entries));
+    expect(new Headers(init.headers).get('content-type')).to.equal(
+      'application/json',
+    );
+    const [result] = results;
+    if (!result) throw new Error('Expected registration result');
+    expect(result.success).to.equal(true);
+  });
+});

--- a/typescript/rebalancer/src/bridges/SwapsXyzClient.test.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzClient.test.ts
@@ -204,6 +204,28 @@ describe('SwapsXyzClient', () => {
     expect(response.estimatedPriceImpact).to.be.null;
   });
 
+  it('accepts a Solana source transaction response', async () => {
+    fetchStub.resolves(
+      makeResponse({
+        body: {
+          ...actionResponseBody(),
+          tx: {
+            base64Tx: 'AQID',
+            payer: 'solana-payer',
+            chainId: 1399811149,
+          },
+          vmId: 'solana',
+          requiresRegisterTransaction: true,
+        },
+      }),
+    );
+
+    const response = await client.getAction(actionRequest());
+
+    expect(response.vmId).to.equal('solana');
+    expect(response.tx).to.deep.include({ base64Tx: 'AQID' });
+  });
+
   it('parses the error envelope and exposes its code', async () => {
     fetchStub.resolves(
       makeResponse({

--- a/typescript/rebalancer/src/bridges/SwapsXyzClient.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzClient.ts
@@ -1,0 +1,447 @@
+import type { Logger } from 'pino';
+import { z } from 'zod';
+
+const DEFAULT_API_URL = 'https://api-v2.swaps.xyz/api';
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1_000;
+
+/**
+ * Error returned by the swaps.xyz API.
+ *
+ * The `code` field is the machine-readable error label from the API error
+ * envelope and is used to decide whether a request should be retried.
+ */
+export class SwapsXyzRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly statusText: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'SwapsXyzRequestError';
+  }
+}
+
+export class SwapsXyzResponseValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SwapsXyzResponseValidationError';
+  }
+}
+
+export const TERMINAL_ERROR_CODES = new Set<string>([
+  'INVALID_API_KEY',
+  'MISSING_API_KEY',
+  'GEO_BLOCKED',
+  'WALLET_SCREENED',
+  'NO_AVAILABLE_ROUTE',
+  'INSUFFICIENT_LIQUIDITY',
+  'AMOUNT_TOO_HIGH',
+  'AMOUNT_TOO_LOW',
+  'INVALID_PARAMETER',
+  'INVALID_AMOUNT_ZERO',
+  'INVALID_ADDRESS_FORMAT',
+  'INVALID_SOURCE_TOKEN',
+  'INVALID_DESTINATION_TOKEN',
+  'MISSING_REQUIRED_FIELD',
+  'CROSS_VM_RECEIVER_REQUIRED',
+  'EXCESSIVE_FEE',
+  'UNSUPPORTED_NETWORK',
+  'UNSUPPORTED_NETWORK_PAIR',
+  'UNSUPPORTED_NETWORK_TOKEN_PAIR',
+  'UNSUPPORTED_SWAP_DIRECTION',
+]);
+
+export function isSwapsXyzTerminalError(error: unknown): boolean {
+  if (error instanceof SwapsXyzResponseValidationError) return true;
+  if (!(error instanceof SwapsXyzRequestError)) return false;
+  if (error.code && TERMINAL_ERROR_CODES.has(error.code)) return true;
+  if (error.status === 408) return false;
+  return error.status >= 400 && error.status < 500;
+}
+
+const NOT_FOUND_ERROR_CODES = new Set([
+  'NOT_FOUND',
+  'TRANSACTION_NOT_FOUND',
+  'TX_NOT_FOUND',
+]);
+
+export function isSwapsXyzNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof SwapsXyzRequestError &&
+    (error.status === 404 ||
+      (error.code !== undefined && NOT_FOUND_ERROR_CODES.has(error.code)))
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export type SwapsXyzVmId = 'evm' | 'alt-vm' | 'hypercore';
+export type SwapsXyzStatus = string;
+
+export interface SwapsXyzEvmTx {
+  to: string;
+  data: string;
+  value?: string;
+  chainId?: number;
+}
+
+export function isEvmTx(tx: unknown): tx is SwapsXyzEvmTx {
+  return (
+    isRecord(tx) && typeof tx.to === 'string' && typeof tx.data === 'string'
+  );
+}
+
+export interface SwapsXyzTokenAmount {
+  amount: string;
+  decimals?: number;
+  chainId?: number;
+  address?: string;
+}
+
+export interface SwapsXyzPayment {
+  amount: string;
+  token?: {
+    chainId: number;
+    address: string;
+    decimals?: number;
+    symbol?: string;
+  };
+  usdAmount?: number;
+}
+
+export interface SwapsXyzBridgeRouteHop {
+  srcChainId: number;
+  dstChainId: number;
+  srcBridgeToken: string;
+  dstBridgeToken: string;
+  bridgeId: string;
+}
+
+export interface SwapsXyzActionResponse {
+  tx: SwapsXyzEvmTx;
+  txId: string;
+  vmId: SwapsXyzVmId;
+  amountIn: SwapsXyzTokenAmount;
+  amountInMax?: SwapsXyzTokenAmount;
+  amountOut: SwapsXyzTokenAmount;
+  amountOutMin: SwapsXyzTokenAmount;
+  protocolFee?: SwapsXyzPayment;
+  applicationFee?: SwapsXyzPayment;
+  bridgeFee?: SwapsXyzPayment;
+  bridgeIds?: string[];
+  bridgeRoute?: SwapsXyzBridgeRouteHop[];
+  exchangeRate?: number;
+  estimatedTxTime?: number;
+  estimatedPriceImpact?: number | null;
+  requiresTokenApproval: boolean;
+  requiresRegisterTransaction?: boolean;
+  executionsType?: 'DEFAULT' | 'GASLESS';
+}
+
+export interface SwapsXyzActionRequest {
+  actionType: 'swap-action';
+  sender: string;
+  srcChainId: number;
+  srcToken: string;
+  dstChainId: number;
+  dstToken: string;
+  slippage: number;
+  amount?: string;
+  swapDirection?: 'exact-amount-in' | 'exact-amount-out';
+  recipient?: string;
+}
+
+export interface SwapsXyzStatusRequest {
+  txId?: string;
+  txHash?: string;
+  chainId?: number;
+}
+
+export interface SwapsXyzStatusResponse {
+  status: SwapsXyzStatus;
+  txId: string;
+  srcChainId: number;
+  dstChainId: number;
+  srcTxHash?: string;
+  dstTxHash?: string;
+  sender?: string;
+  bridgeDetails?: {
+    isBridge: boolean;
+    bridgeTime?: number;
+    txPath?: Array<{
+      chainId: number;
+      txHash: string;
+      timestamp?: string;
+      nextBridge?: string;
+    }>;
+  };
+  actionResponse?: SwapsXyzActionResponse;
+}
+
+export interface SwapsXyzRegisterTxEntry {
+  txId: string;
+  txHash: string;
+}
+
+export interface SwapsXyzRegisterTxResult {
+  success: boolean;
+  error: string | null;
+}
+
+const IntegerStringSchema = z.string().regex(/^\d+$/);
+const TokenAmountSchema = z
+  .object({
+    amount: IntegerStringSchema,
+    decimals: z.number().int().nonnegative().optional(),
+    chainId: z.number().int().optional(),
+    address: z.string().optional(),
+  })
+  .passthrough();
+const PaymentSchema = z
+  .object({
+    amount: IntegerStringSchema,
+    token: z
+      .object({
+        chainId: z.number().int(),
+        address: z.string(),
+        decimals: z.number().int().nonnegative().optional(),
+        symbol: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    usdAmount: z.number().optional(),
+  })
+  .passthrough();
+const EvmTxSchema = z
+  .object({
+    to: z.string(),
+    data: z.string(),
+    value: IntegerStringSchema.optional(),
+    chainId: z.number().int().optional(),
+  })
+  .passthrough();
+const BridgeRouteHopSchema = z
+  .object({
+    srcChainId: z.number().int(),
+    dstChainId: z.number().int(),
+    srcBridgeToken: z.string(),
+    dstBridgeToken: z.string(),
+    bridgeId: z.string(),
+  })
+  .passthrough();
+const ActionResponseSchema: z.ZodType<SwapsXyzActionResponse> = z
+  .object({
+    tx: EvmTxSchema,
+    txId: z.string().min(1),
+    vmId: z.enum(['evm', 'alt-vm', 'hypercore']),
+    amountIn: TokenAmountSchema,
+    amountInMax: TokenAmountSchema.optional(),
+    amountOut: TokenAmountSchema,
+    amountOutMin: TokenAmountSchema,
+    protocolFee: PaymentSchema.optional(),
+    applicationFee: PaymentSchema.optional(),
+    bridgeFee: PaymentSchema.optional(),
+    bridgeIds: z.array(z.string()).optional(),
+    bridgeRoute: z.array(BridgeRouteHopSchema).optional(),
+    exchangeRate: z.number().optional(),
+    estimatedTxTime: z.number().nonnegative().optional(),
+    estimatedPriceImpact: z.number().nullable().optional(),
+    requiresTokenApproval: z.boolean(),
+    requiresRegisterTransaction: z.boolean().optional(),
+    executionsType: z.enum(['DEFAULT', 'GASLESS']).optional(),
+  })
+  .passthrough();
+const StatusResponseSchema: z.ZodType<SwapsXyzStatusResponse> = z
+  .object({
+    status: z.string().min(1),
+    txId: z.string().min(1),
+    srcChainId: z.number().int(),
+    dstChainId: z.number().int(),
+    srcTxHash: z.string().optional(),
+    dstTxHash: z.string().optional(),
+    sender: z.string().optional(),
+    bridgeDetails: z
+      .object({
+        isBridge: z.boolean(),
+        bridgeTime: z.number().optional(),
+        txPath: z
+          .array(
+            z
+              .object({
+                chainId: z.number().int(),
+                txHash: z.string(),
+                timestamp: z.string().optional(),
+                nextBridge: z.string().optional(),
+              })
+              .passthrough(),
+          )
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    actionResponse: ActionResponseSchema.optional(),
+  })
+  .passthrough();
+const RegisterTxResultsSchema: z.ZodType<SwapsXyzRegisterTxResult[]> = z.array(
+  z
+    .object({
+      success: z.boolean(),
+      error: z.string().nullable(),
+    })
+    .passthrough(),
+);
+
+export interface SwapsXyzClientConfig {
+  apiKey: string;
+  apiUrl?: string;
+  defaultSlippageBps?: number;
+  requestTimeoutMs?: number;
+}
+
+export class SwapsXyzClient {
+  readonly logger: Logger;
+  readonly defaultSlippageBps: number;
+  private readonly apiKey: string;
+  private readonly apiUrl: string;
+  private readonly requestTimeoutMs: number;
+
+  constructor(config: SwapsXyzClientConfig, logger: Logger) {
+    this.apiKey = config.apiKey;
+    const apiUrl = new URL(config.apiUrl ?? DEFAULT_API_URL);
+    if (apiUrl.protocol !== 'https:') {
+      throw new Error('swaps.xyz API URL must use HTTPS');
+    }
+    this.apiUrl = apiUrl.toString().replace(/\/$/, '');
+    this.defaultSlippageBps = config.defaultSlippageBps ?? 50;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? 10_000;
+    this.logger = logger;
+  }
+
+  getAction(req: SwapsXyzActionRequest): Promise<SwapsXyzActionResponse> {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(req)) {
+      if (value === undefined || value === null) continue;
+      query.set(key, String(value));
+    }
+    return this.withRetry(() =>
+      this.request<SwapsXyzActionResponse>(
+        `${this.apiUrl}/getAction?${query.toString()}`,
+        { method: 'GET' },
+        ActionResponseSchema,
+      ),
+    );
+  }
+
+  getStatus(req: SwapsXyzStatusRequest): Promise<SwapsXyzStatusResponse> {
+    if (!req.txHash && !req.txId) {
+      throw new Error('getStatus requires either txHash or txId');
+    }
+    const query = new URLSearchParams();
+    if (req.txHash) query.set('txHash', req.txHash);
+    if (req.txId) query.set('txId', req.txId);
+    if (req.chainId !== undefined) query.set('chainId', String(req.chainId));
+    return this.withRetry(() =>
+      this.request<SwapsXyzStatusResponse>(
+        `${this.apiUrl}/getStatus?${query.toString()}`,
+        { method: 'GET' },
+        StatusResponseSchema,
+      ),
+    );
+  }
+
+  registerTxs(
+    entries: SwapsXyzRegisterTxEntry[],
+  ): Promise<SwapsXyzRegisterTxResult[]> {
+    return this.withRetry(() =>
+      this.request<SwapsXyzRegisterTxResult[]>(
+        `${this.apiUrl}/registerTxs`,
+        {
+          method: 'POST',
+          body: JSON.stringify(entries),
+          headers: { 'content-type': 'application/json' },
+        },
+        RegisterTxResultsSchema,
+      ),
+    );
+  }
+
+  private async request<T>(
+    url: string,
+    init: { method: string; body?: string; headers?: Record<string, string> },
+    schema: z.ZodType<T>,
+  ): Promise<T> {
+    const response = await globalThis.fetch(url, {
+      method: init.method,
+      headers: {
+        'x-api-key': this.apiKey,
+        ...init.headers,
+      },
+      body: init.body,
+      signal: AbortSignal.timeout(this.requestTimeoutMs),
+    });
+    if (!response.ok) {
+      let code: string | undefined;
+      let message = `${init.method} ${url} failed: ${response.status} ${response.statusText}`;
+      try {
+        const body: unknown = await response.json();
+        if (isRecord(body) && isRecord(body.error)) {
+          if (typeof body.error.code === 'string') code = body.error.code;
+          if (typeof body.error.message === 'string') {
+            message = `${message}: ${body.error.message}`;
+          }
+        }
+      } catch {
+        // Keep the status-derived error when the response is not JSON.
+      }
+      throw new SwapsXyzRequestError(
+        message,
+        response.status,
+        response.statusText,
+        code,
+      );
+    }
+    const body: unknown = await response.json();
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      throw new SwapsXyzResponseValidationError(
+        `Invalid swaps.xyz response for ${init.method} ${new URL(url).pathname}: ${result.error.message}`,
+      );
+    }
+    return result.data;
+  }
+
+  private async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (isSwapsXyzTerminalError(lastError)) {
+          this.logger.debug(
+            { error: lastError.message },
+            'swaps.xyz terminal error — not retrying',
+          );
+          throw lastError;
+        }
+        this.logger.warn(
+          { attempt, error: lastError.message },
+          'swaps.xyz request failed, retrying',
+        );
+        if (attempt < MAX_RETRIES - 1) {
+          await sleep(RETRY_DELAY_MS * (attempt + 1));
+        }
+      }
+    }
+    if (lastError) throw lastError;
+    throw new Error('swaps.xyz request failed without an error');
+  }
+}

--- a/typescript/rebalancer/src/bridges/SwapsXyzClient.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzClient.ts
@@ -83,7 +83,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-export type SwapsXyzVmId = 'evm' | 'alt-vm' | 'hypercore';
+export type SwapsXyzVmId = 'evm' | 'solana' | 'alt-vm' | 'hypercore';
 export type SwapsXyzStatus = string;
 
 export interface SwapsXyzEvmTx {
@@ -93,10 +93,21 @@ export interface SwapsXyzEvmTx {
   chainId?: number;
 }
 
+export interface SwapsXyzSolanaTx {
+  base64Tx: string;
+  recentBlockhash?: string;
+  payer?: string;
+  chainId?: number;
+}
+
 export function isEvmTx(tx: unknown): tx is SwapsXyzEvmTx {
   return (
     isRecord(tx) && typeof tx.to === 'string' && typeof tx.data === 'string'
   );
+}
+
+export function isSolanaTx(tx: unknown): tx is SwapsXyzSolanaTx {
+  return isRecord(tx) && typeof tx.base64Tx === 'string';
 }
 
 export interface SwapsXyzTokenAmount {
@@ -126,7 +137,7 @@ export interface SwapsXyzBridgeRouteHop {
 }
 
 export interface SwapsXyzActionResponse {
-  tx: SwapsXyzEvmTx;
+  tx: SwapsXyzEvmTx | SwapsXyzSolanaTx;
   txId: string;
   vmId: SwapsXyzVmId;
   amountIn: SwapsXyzTokenAmount;
@@ -228,6 +239,14 @@ const EvmTxSchema = z
     chainId: z.number().int().optional(),
   })
   .passthrough();
+const SolanaTxSchema = z
+  .object({
+    base64Tx: z.string().min(1),
+    recentBlockhash: z.string().optional(),
+    payer: z.string().optional(),
+    chainId: z.number().int().optional(),
+  })
+  .passthrough();
 const BridgeRouteHopSchema = z
   .object({
     srcChainId: z.number().int(),
@@ -239,9 +258,9 @@ const BridgeRouteHopSchema = z
   .passthrough();
 const ActionResponseSchema: z.ZodType<SwapsXyzActionResponse> = z
   .object({
-    tx: EvmTxSchema,
+    tx: z.union([EvmTxSchema, SolanaTxSchema]),
     txId: z.string().min(1),
-    vmId: z.enum(['evm', 'alt-vm', 'hypercore']),
+    vmId: z.enum(['evm', 'solana', 'alt-vm', 'hypercore']),
     amountIn: TokenAmountSchema,
     amountInMax: TokenAmountSchema.optional(),
     amountOut: TokenAmountSchema,

--- a/typescript/rebalancer/src/bridges/SwapsXyzClient.ts
+++ b/typescript/rebalancer/src/bridges/SwapsXyzClient.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 const DEFAULT_API_URL = 'https://api-v2.swaps.xyz/api';
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1_000;
+const INTEGER_STRING_REGEX = /^\d+$/;
+const TRON_CALLDATA_REGEX = /^(?:0x)?(?:[0-9a-fA-F]{2}){4,}$/;
 
 /**
  * Error returned by the swaps.xyz API.
@@ -100,6 +102,14 @@ export interface SwapsXyzSolanaTx {
   chainId?: number;
 }
 
+export interface SwapsXyzTronTx {
+  to: string;
+  toExtra: string | null;
+  value: string;
+  chainId: number;
+  chainKey: 'trx';
+}
+
 export function isEvmTx(tx: unknown): tx is SwapsXyzEvmTx {
   return (
     isRecord(tx) && typeof tx.to === 'string' && typeof tx.data === 'string'
@@ -108,6 +118,23 @@ export function isEvmTx(tx: unknown): tx is SwapsXyzEvmTx {
 
 export function isSolanaTx(tx: unknown): tx is SwapsXyzSolanaTx {
   return isRecord(tx) && typeof tx.base64Tx === 'string';
+}
+
+export function isTronTx(tx: unknown): tx is SwapsXyzTronTx {
+  return (
+    isRecord(tx) &&
+    typeof tx.to === 'string' &&
+    tx.to.length > 0 &&
+    (tx.toExtra === null ||
+      (typeof tx.toExtra === 'string' &&
+        TRON_CALLDATA_REGEX.test(tx.toExtra))) &&
+    typeof tx.value === 'string' &&
+    INTEGER_STRING_REGEX.test(tx.value) &&
+    typeof tx.chainId === 'number' &&
+    Number.isInteger(tx.chainId) &&
+    tx.chainId > 0 &&
+    tx.chainKey === 'trx'
+  );
 }
 
 export interface SwapsXyzTokenAmount {
@@ -137,7 +164,7 @@ export interface SwapsXyzBridgeRouteHop {
 }
 
 export interface SwapsXyzActionResponse {
-  tx: SwapsXyzEvmTx | SwapsXyzSolanaTx;
+  tx: SwapsXyzEvmTx | SwapsXyzSolanaTx | SwapsXyzTronTx;
   txId: string;
   vmId: SwapsXyzVmId;
   amountIn: SwapsXyzTokenAmount;
@@ -207,7 +234,7 @@ export interface SwapsXyzRegisterTxResult {
   error: string | null;
 }
 
-const IntegerStringSchema = z.string().regex(/^\d+$/);
+const IntegerStringSchema = z.string().regex(INTEGER_STRING_REGEX);
 const TokenAmountSchema = z
   .object({
     amount: IntegerStringSchema,
@@ -247,6 +274,15 @@ const SolanaTxSchema = z
     chainId: z.number().int().optional(),
   })
   .passthrough();
+const TronTxSchema = z
+  .object({
+    to: z.string().min(1),
+    toExtra: z.string().regex(TRON_CALLDATA_REGEX).nullable(),
+    value: IntegerStringSchema,
+    chainId: z.number().int().positive(),
+    chainKey: z.literal('trx'),
+  })
+  .passthrough();
 const BridgeRouteHopSchema = z
   .object({
     srcChainId: z.number().int(),
@@ -258,7 +294,7 @@ const BridgeRouteHopSchema = z
   .passthrough();
 const ActionResponseSchema: z.ZodType<SwapsXyzActionResponse> = z
   .object({
-    tx: z.union([EvmTxSchema, SolanaTxSchema]),
+    tx: z.union([EvmTxSchema, SolanaTxSchema, TronTxSchema]),
     txId: z.string().min(1),
     vmId: z.enum(['evm', 'solana', 'alt-vm', 'hypercore']),
     amountIn: TokenAmountSchema,

--- a/typescript/rebalancer/src/bridges/deBridgeUtils.ts
+++ b/typescript/rebalancer/src/bridges/deBridgeUtils.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+
+import {
+  addressToBytesTron,
+  assert,
+  bytesToAddressTron,
+  isValidAddressEvm,
+  isValidAddressSealevel,
+  isValidAddressTron,
+} from '@hyperlane-xyz/utils';
+
+export const DEBRIDGE_API_BASE = 'https://dln.debridge.finance/v1.0';
+export const DEBRIDGE_STATUS_API = 'https://api.dln.trade/v1.0';
+export const DEBRIDGE_TOOL = 'debridge';
+
+export const HYPERLANE_TO_DEBRIDGE_CHAIN_ID: Record<number, number> = {
+  1: 1,
+  56: 56,
+  42161: 42161,
+  728126428: 100000026,
+  1399811149: 7565164,
+};
+
+export const DEBRIDGE_TRON_CHAIN_ID = 100000026;
+export const DEBRIDGE_SOLANA_CHAIN_ID = 7565164;
+
+const DecimalStringSchema = z.string().max(78).regex(/^\d+$/);
+const Bytes32Schema = z.string().regex(/^0x[0-9a-fA-F]{64}$/);
+const TransactionDataSchema = z
+  .string()
+  .max(1_000_000)
+  .regex(/^0x(?:[0-9a-fA-F]{2})+$/);
+
+export const DeBridgeTokenEstimationSchema = z.object({
+  chainId: z.number().int().positive(),
+  address: z.string().min(1),
+  name: z.string(),
+  symbol: z.string(),
+  decimals: z.number().int().min(0).max(255),
+  amount: DecimalStringSchema,
+  approximateUsdValue: z.number().finite().optional(),
+});
+
+export const DeBridgeQuoteResponseSchema = z.object({
+  estimation: z.object({
+    srcChainTokenIn: DeBridgeTokenEstimationSchema,
+    dstChainTokenOut: DeBridgeTokenEstimationSchema,
+  }),
+  orderId: Bytes32Schema.optional(),
+  fixFee: DecimalStringSchema.optional(),
+  protocolFee: DecimalStringSchema.optional(),
+});
+
+export const DeBridgeCreateTxResponseSchema =
+  DeBridgeQuoteResponseSchema.extend({
+    orderId: Bytes32Schema,
+    fixFee: DecimalStringSchema,
+    tx: z.object({
+      to: z.string().optional(),
+      data: TransactionDataSchema,
+      value: DecimalStringSchema.optional(),
+    }),
+  });
+
+export const DeBridgeOrderStatusResponseSchema = z.object({
+  orderId: Bytes32Schema,
+  status: z.enum([
+    'None',
+    'Created',
+    'Fulfilled',
+    'SentUnlock',
+    'OrderCancelled',
+    'SentOrderCancel',
+    'ClaimedUnlock',
+    'ClaimedOrderCancel',
+  ]),
+  fulfilledDstEventMetadata: z
+    .object({
+      transactionHash: z
+        .object({ stringValue: z.string().min(1).optional() })
+        .optional(),
+      receivedAmount: z
+        .object({ bigIntegerValue: DecimalStringSchema.optional() })
+        .optional(),
+    })
+    .optional(),
+});
+
+export const DeBridgeApiErrorSchema = z.object({
+  errorCode: z.number().optional(),
+  errorId: z.string().optional(),
+  errorMessage: z.string().min(1),
+});
+
+export type DeBridgeTokenEstimation = z.infer<
+  typeof DeBridgeTokenEstimationSchema
+>;
+export type DeBridgeQuoteResponse = z.infer<typeof DeBridgeQuoteResponseSchema>;
+export type DeBridgeCreateTxResponse = z.infer<
+  typeof DeBridgeCreateTxResponseSchema
+>;
+export type DeBridgeOrderStatusResponse = z.infer<
+  typeof DeBridgeOrderStatusResponseSchema
+>;
+
+export function hyperlaneChainIdToDebridge(chainId: number): number {
+  const debridgeChainId = HYPERLANE_TO_DEBRIDGE_CHAIN_ID[chainId];
+  assert(
+    debridgeChainId !== undefined,
+    `Chain ${chainId} is not supported by deBridge integration`,
+  );
+  return debridgeChainId;
+}
+
+export function isDebridgeTronChain(debridgeChainId: number): boolean {
+  return debridgeChainId === DEBRIDGE_TRON_CHAIN_ID;
+}
+
+export function isDebridgeSolanaChain(debridgeChainId: number): boolean {
+  return debridgeChainId === DEBRIDGE_SOLANA_CHAIN_ID;
+}
+
+export function formatAddressForDebridge(
+  address: string,
+  debridgeChainId: number,
+): string {
+  if (isDebridgeTronChain(debridgeChainId)) {
+    if (address.startsWith('T')) {
+      assert(isValidAddressTron(address), `Invalid Tron address: ${address}`);
+      const canonical = bytesToAddressTron(addressToBytesTron(address));
+      assert(
+        canonical === address,
+        `Invalid Tron address checksum: ${address}`,
+      );
+      return address;
+    }
+
+    const withoutHexPrefix = address.startsWith('0x')
+      ? address.slice(2)
+      : address;
+    const withoutPrefix = /^41[0-9a-fA-F]{40}$/.test(withoutHexPrefix)
+      ? withoutHexPrefix.slice(2)
+      : withoutHexPrefix;
+    assert(
+      /^[0-9a-fA-F]{40}$/.test(withoutPrefix),
+      `Invalid Tron hex address: ${address}`,
+    );
+    return bytesToAddressTron(Buffer.from(withoutPrefix, 'hex'));
+  }
+
+  if (isDebridgeSolanaChain(debridgeChainId)) {
+    assert(
+      isValidAddressSealevel(address),
+      `Invalid Solana address: ${address}`,
+    );
+    return address;
+  }
+
+  assert(isValidAddressEvm(address), `Invalid EVM address: ${address}`);
+  return address;
+}
+
+export function parseDeBridgeQuoteResponse(
+  input: unknown,
+): DeBridgeQuoteResponse {
+  throwIfDeBridgeApiError(input);
+  return DeBridgeQuoteResponseSchema.parse(input);
+}
+
+export function parseDeBridgeCreateTxResponse(
+  input: unknown,
+): DeBridgeCreateTxResponse {
+  throwIfDeBridgeApiError(input);
+  return DeBridgeCreateTxResponseSchema.parse(input);
+}
+
+export function parseDeBridgeOrderStatusResponse(
+  input: unknown,
+): DeBridgeOrderStatusResponse {
+  throwIfDeBridgeApiError(input);
+  return DeBridgeOrderStatusResponseSchema.parse(input);
+}
+
+function throwIfDeBridgeApiError(input: unknown): void {
+  const result = DeBridgeApiErrorSchema.safeParse(input);
+  if (result.success) {
+    const details = result.data.errorId
+      ? `${result.data.errorId}: ${result.data.errorMessage}`
+      : result.data.errorMessage;
+    throw new Error(`deBridge API error: ${details}`);
+  }
+}

--- a/typescript/rebalancer/src/bridges/erc20Approve.test.ts
+++ b/typescript/rebalancer/src/bridges/erc20Approve.test.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import sinon from 'sinon';
+
+import { Erc20ApprovalMode, approveErc20IfNeeded } from './erc20Approve.js';
+
+const logger = pino({ level: 'silent' });
+const token = '0x1111111111111111111111111111111111111111';
+const spender = '0x2222222222222222222222222222222222222222';
+
+interface TestTransaction {
+  hash: string;
+  wait: sinon.SinonStub<[], Promise<{ status: number }>>;
+}
+
+function makeTransaction(hash: string): TestTransaction {
+  return {
+    hash,
+    wait: sinon.stub<[], Promise<{ status: number }>>().resolves({ status: 1 }),
+  };
+}
+
+class TestErc20Contract extends ethers.Contract {
+  readonly allowanceStub = sinon.stub<
+    [string, string],
+    Promise<ethers.BigNumber>
+  >();
+  readonly approveStub = sinon.stub<
+    [string, ethers.BigNumberish],
+    Promise<TestTransaction>
+  >();
+
+  constructor(signer: ethers.Signer) {
+    super(token, [], signer);
+  }
+
+  allowance(owner: string, approvedSpender: string): Promise<ethers.BigNumber> {
+    return this.allowanceStub(owner, approvedSpender);
+  }
+
+  approve(
+    approvedSpender: string,
+    amount: ethers.BigNumberish,
+  ): Promise<TestTransaction> {
+    return this.approveStub(approvedSpender, amount);
+  }
+}
+
+describe('approveErc20IfNeeded', () => {
+  const signer = ethers.Wallet.createRandom();
+  let contract: TestErc20Contract;
+  let contractFactory: sinon.SinonStub<
+    [string, string[], ethers.Signer],
+    ethers.Contract
+  >;
+
+  beforeEach(() => {
+    contract = new TestErc20Contract(signer);
+    contractFactory = sinon.stub<
+      [string, string[], ethers.Signer],
+      ethers.Contract
+    >();
+    contractFactory.returns(contract);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('rejects non-positive approval amounts before reading allowance', async () => {
+    try {
+      await approveErc20IfNeeded(signer, token, spender, 0n, logger, {
+        contractFactory,
+      });
+      expect.fail('Expected approval amount validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).to.equal(
+          'ERC20 approval amount must be positive',
+        );
+      }
+    }
+    expect(contractFactory.called).to.equal(false);
+  });
+
+  it('returns when the exact allowance already matches', async () => {
+    contract.allowanceStub.resolves(ethers.BigNumber.from(10));
+
+    await approveErc20IfNeeded(signer, token, spender, 10n, logger, {
+      contractFactory,
+    });
+
+    expect(contractFactory.callCount).to.equal(1);
+    expect(contract.approveStub.called).to.equal(false);
+  });
+
+  it('sets a zero allowance to the exact requested amount', async () => {
+    const approvalTx = makeTransaction('0xapprove');
+    contract.allowanceStub.resolves(ethers.constants.Zero);
+    contract.approveStub.resolves(approvalTx);
+
+    await approveErc20IfNeeded(signer, token, spender, 25n, logger, {
+      contractFactory,
+    });
+
+    expect(contract.approveStub.calledOnce).to.equal(true);
+    expect(contract.approveStub.firstCall.args[0]).to.equal(spender);
+    expect(
+      ethers.BigNumber.from(contract.approveStub.firstCall.args[1]).eq(25),
+    ).to.equal(true);
+    expect(approvalTx.wait.calledOnce).to.equal(true);
+  });
+
+  it('resets a differing nonzero allowance before setting the exact amount', async () => {
+    const revokeTx = makeTransaction('0xrevoke');
+    const approvalTx = makeTransaction('0xapprove');
+    contract.allowanceStub.resolves(ethers.BigNumber.from(100));
+    contract.approveStub.onCall(0).resolves(revokeTx);
+    contract.approveStub.onCall(1).resolves(approvalTx);
+
+    await approveErc20IfNeeded(signer, token, spender, 25n, logger, {
+      contractFactory,
+    });
+
+    expect(contract.approveStub.callCount).to.equal(2);
+    expect(contract.approveStub.firstCall.args).to.deep.equal([spender, 0]);
+    expect(contract.approveStub.secondCall.args[0]).to.equal(spender);
+    expect(
+      ethers.BigNumber.from(contract.approveStub.secondCall.args[1]).eq(25),
+    ).to.equal(true);
+    expect(revokeTx.wait.calledOnce).to.equal(true);
+    expect(approvalTx.wait.calledOnce).to.equal(true);
+  });
+
+  it('uses unlimited allowance only when explicitly requested', async () => {
+    contract.allowanceStub.resolves(ethers.constants.Zero);
+    contract.approveStub.resolves(makeTransaction('0xapprove'));
+
+    await approveErc20IfNeeded(signer, token, spender, 1n, logger, {
+      contractFactory,
+      mode: Erc20ApprovalMode.Infinite,
+    });
+
+    expect(contract.approveStub.callCount).to.equal(1);
+    expect(
+      ethers.BigNumber.from(contract.approveStub.firstCall.args[1]).eq(
+        ethers.constants.MaxUint256,
+      ),
+    ).to.equal(true);
+  });
+});

--- a/typescript/rebalancer/src/bridges/erc20Approve.test.ts
+++ b/typescript/rebalancer/src/bridges/erc20Approve.test.ts
@@ -3,7 +3,12 @@ import { ethers } from 'ethers';
 import { pino } from 'pino';
 import sinon from 'sinon';
 
-import { Erc20ApprovalMode, approveErc20IfNeeded } from './erc20Approve.js';
+import {
+  Erc20ApprovalMode,
+  approveErc20IfNeeded,
+  revokeErc20Approval,
+  revokeErc20ApprovalIfNeeded,
+} from './erc20Approve.js';
 
 const logger = pino({ level: 'silent' });
 const token = '0x1111111111111111111111111111111111111111';
@@ -149,5 +154,67 @@ describe('approveErc20IfNeeded', () => {
         ethers.constants.MaxUint256,
       ),
     ).to.equal(true);
+  });
+});
+
+describe('revokeErc20ApprovalIfNeeded', () => {
+  const signer = ethers.Wallet.createRandom();
+  let contract: TestErc20Contract;
+  let contractFactory: sinon.SinonStub<
+    [string, string[], ethers.Signer],
+    ethers.Contract
+  >;
+
+  beforeEach(() => {
+    contract = new TestErc20Contract(signer);
+    contractFactory = sinon.stub<
+      [string, string[], ethers.Signer],
+      ethers.Contract
+    >();
+    contractFactory.returns(contract);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('skips cleanup when the allowance is zero', async () => {
+    contract.allowanceStub.resolves(ethers.constants.Zero);
+
+    await revokeErc20ApprovalIfNeeded(signer, token, spender, logger, {
+      contractFactory,
+    });
+
+    expect(contract.approveStub.called).to.equal(false);
+  });
+
+  it('revokes residue and waits for its receipt', async () => {
+    const revokeTx = makeTransaction('0xrevoke');
+    contract.allowanceStub.resolves(ethers.BigNumber.from(3));
+    contract.approveStub.resolves(revokeTx);
+
+    await revokeErc20ApprovalIfNeeded(signer, token, spender, logger, {
+      contractFactory,
+    });
+
+    expect(contract.approveStub.calledOnceWithExactly(spender, 0)).to.equal(
+      true,
+    );
+    expect(revokeTx.wait.calledOnce).to.equal(true);
+  });
+
+  it('can force a revocation without reading allowance', async () => {
+    const revokeTx = makeTransaction('0xrevoke');
+    contract.approveStub.resolves(revokeTx);
+
+    await revokeErc20Approval(signer, token, spender, logger, {
+      contractFactory,
+    });
+
+    expect(contract.allowanceStub.called).to.equal(false);
+    expect(contract.approveStub.calledOnceWithExactly(spender, 0)).to.equal(
+      true,
+    );
+    expect(revokeTx.wait.calledOnce).to.equal(true);
   });
 });

--- a/typescript/rebalancer/src/bridges/erc20Approve.ts
+++ b/typescript/rebalancer/src/bridges/erc20Approve.ts
@@ -36,6 +36,20 @@ export interface Erc20ApprovalOptions {
 const defaultContractFactory: Erc20ContractFactory = (address, abi, signer) =>
   new ethers.Contract(address, abi, signer);
 
+async function revokeApproval(
+  contract: ethers.Contract,
+  spender: string,
+  operation: string,
+): Promise<void> {
+  const revokeTx = await contract.approve(spender, 0);
+  await waitForReceiptWithTimeout(revokeTx.wait(), {
+    txHash: revokeTx.hash,
+    operation,
+    timeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS,
+    role: 'approval',
+  });
+}
+
 /** Set an ERC20 allowance to the exact requested target when it differs. */
 export async function approveErc20IfNeeded(
   signer: ethers.Signer,
@@ -77,13 +91,7 @@ export async function approveErc20IfNeeded(
   );
 
   if (!currentAllowance.isZero()) {
-    const revokeTx = await writeContract.approve(spender, 0);
-    await waitForReceiptWithTimeout(revokeTx.wait(), {
-      txHash: revokeTx.hash,
-      operation: 'erc20 revoke approval',
-      timeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS,
-      role: 'approval',
-    });
+    await revokeApproval(writeContract, spender, 'erc20 revoke approval');
   }
 
   const approveTx = await writeContract.approve(spender, targetAllowance);
@@ -93,4 +101,49 @@ export async function approveErc20IfNeeded(
     timeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS,
     role: 'approval',
   });
+}
+
+/** Revoke a nonzero ERC20 allowance and wait for a bounded receipt. */
+export async function revokeErc20ApprovalIfNeeded(
+  signer: ethers.Signer,
+  token: string,
+  spender: string,
+  logger: Logger,
+  options: Pick<Erc20ApprovalOptions, 'contractFactory'> = {},
+): Promise<void> {
+  const contractFactory = options.contractFactory ?? defaultContractFactory;
+  const contract = contractFactory(token, ERC20_ABI, signer);
+  const ownerAddress = await signer.getAddress();
+  const currentAllowance: ethers.BigNumber = await contract.allowance(
+    ownerAddress,
+    spender,
+  );
+
+  if (currentAllowance.isZero()) return;
+
+  logger.info(
+    {
+      token,
+      spender,
+      currentAllowance: currentAllowance.toString(),
+    },
+    'Revoking ERC20 approval residue',
+  );
+
+  await revokeApproval(contract, spender, 'erc20 residue cleanup');
+}
+
+/** Queue an ERC20 revocation without relying on a potentially stale read. */
+export async function revokeErc20Approval(
+  signer: ethers.Signer,
+  token: string,
+  spender: string,
+  logger: Logger,
+  options: Pick<Erc20ApprovalOptions, 'contractFactory'> = {},
+): Promise<void> {
+  const contractFactory = options.contractFactory ?? defaultContractFactory;
+  const contract = contractFactory(token, ERC20_ABI, signer);
+
+  logger.info({ token, spender }, 'Forcing ERC20 approval revocation');
+  await revokeApproval(contract, spender, 'erc20 forced cleanup');
 }

--- a/typescript/rebalancer/src/bridges/erc20Approve.ts
+++ b/typescript/rebalancer/src/bridges/erc20Approve.ts
@@ -1,0 +1,96 @@
+import { ethers } from 'ethers';
+import type { Logger } from 'pino';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  DEFAULT_RECEIPT_TIMEOUT_MS,
+  waitForReceiptWithTimeout,
+} from '../utils/receiptTimeout.js';
+
+const ERC20_ABI = [
+  'function allowance(address owner, address spender) external view returns (uint256)',
+  'function approve(address spender, uint256 amount) external returns (bool)',
+];
+
+export enum Erc20ApprovalMode {
+  Exact = 'exact',
+  Infinite = 'infinite',
+}
+
+export type Erc20ContractFactory = (
+  address: string,
+  abi: string[],
+  signer: ethers.Signer,
+) => ethers.Contract;
+
+export interface Erc20ApprovalOptions {
+  /**
+   * Exact is required for dynamic, API-provided spenders. Infinite is reserved
+   * for trusted, fixed contracts such as an OFT endpoint.
+   */
+  mode?: Erc20ApprovalMode;
+  contractFactory?: Erc20ContractFactory;
+}
+
+const defaultContractFactory: Erc20ContractFactory = (address, abi, signer) =>
+  new ethers.Contract(address, abi, signer);
+
+/** Set an ERC20 allowance to the exact requested target when it differs. */
+export async function approveErc20IfNeeded(
+  signer: ethers.Signer,
+  token: string,
+  spender: string,
+  amount: bigint,
+  logger: Logger,
+  options: Erc20ApprovalOptions = {},
+): Promise<void> {
+  assert(amount > 0n, 'ERC20 approval amount must be positive');
+
+  const contractFactory = options.contractFactory ?? defaultContractFactory;
+  const mode = options.mode ?? Erc20ApprovalMode.Exact;
+  const readContract = contractFactory(token, ERC20_ABI, signer);
+  const ownerAddress = await signer.getAddress();
+  const currentAllowance: ethers.BigNumber = await readContract.allowance(
+    ownerAddress,
+    spender,
+  );
+  const requiredAllowance = ethers.BigNumber.from(amount.toString());
+  const targetAllowance =
+    mode === Erc20ApprovalMode.Infinite
+      ? ethers.constants.MaxUint256
+      : requiredAllowance;
+
+  if (currentAllowance.eq(targetAllowance)) return;
+
+  const writeContract = contractFactory(token, ERC20_ABI, signer);
+
+  logger.info(
+    {
+      token,
+      spender,
+      approvalMode: mode,
+      currentAllowance: currentAllowance.toString(),
+      targetAllowance: targetAllowance.toString(),
+    },
+    'Refreshing ERC20 approval',
+  );
+
+  if (!currentAllowance.isZero()) {
+    const revokeTx = await writeContract.approve(spender, 0);
+    await waitForReceiptWithTimeout(revokeTx.wait(), {
+      txHash: revokeTx.hash,
+      operation: 'erc20 revoke approval',
+      timeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS,
+      role: 'approval',
+    });
+  }
+
+  const approveTx = await writeContract.approve(spender, targetAllowance);
+  await waitForReceiptWithTimeout(approveTx.wait(), {
+    txHash: approveTx.hash,
+    operation: 'erc20 approve',
+    timeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS,
+    role: 'approval',
+  });
+}

--- a/typescript/rebalancer/src/bridges/status/HyperlaneMessageStatusAdapter.ts
+++ b/typescript/rebalancer/src/bridges/status/HyperlaneMessageStatusAdapter.ts
@@ -1,0 +1,82 @@
+import type { Logger } from 'pino';
+
+import { HyperlaneCore } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import { TokenBridgeStatusAdapterType } from '../../config/types.js';
+import type {
+  ITokenBridgeStatusAdapter,
+  MCRExecutionContext,
+  MCRSettlementStatus,
+  MCRStatusPollContext,
+  MCRStatusRef,
+} from '../../interfaces/ITokenBridgeStatusAdapter.js';
+
+interface HyperlaneMessageRefData extends Record<string, unknown> {
+  messageId: string;
+}
+
+/** Default settlement adapter for bridges that dispatch Hyperlane messages. */
+export class HyperlaneMessageStatusAdapter implements ITokenBridgeStatusAdapter {
+  readonly kind = TokenBridgeStatusAdapterType.HyperlaneMessage;
+
+  constructor(readonly logger: Logger) {}
+
+  async initFromReceipt(
+    ctx: MCRExecutionContext,
+  ): Promise<MCRStatusRef | null> {
+    const dispatchedMessages = HyperlaneCore.getDispatchedMessages(ctx.receipt);
+    if (dispatchedMessages.length === 0) {
+      this.logger.error(
+        {
+          origin: ctx.origin,
+          destination: ctx.destination,
+          bridge: ctx.bridge,
+          txHash: ctx.receipt.transactionHash,
+        },
+        'No Dispatch event found in confirmed rebalance receipt',
+      );
+      return null;
+    }
+
+    if (dispatchedMessages.length > 1) {
+      this.logger.warn(
+        {
+          messageCount: dispatchedMessages.length,
+          txHash: ctx.receipt.transactionHash,
+        },
+        'Multiple Dispatch events found in rebalance receipt; using first',
+      );
+    }
+
+    const data: HyperlaneMessageRefData = {
+      messageId: dispatchedMessages[0].id,
+    };
+    return { provider: this.kind, kind: this.kind, data };
+  }
+
+  async pollStatus(
+    ref: MCRStatusRef,
+    ctx: MCRStatusPollContext,
+  ): Promise<MCRSettlementStatus> {
+    const { messageId } = ref.data;
+    assert(
+      typeof messageId === 'string',
+      'Hyperlane settlement ref is missing messageId',
+    );
+
+    try {
+      const chainName = ctx.core.multiProvider.getChainName(ctx.destination);
+      const delivered = await ctx.core
+        .adapter(chainName)
+        .isDelivered(messageId, ctx.blockTag);
+      return { status: delivered ? 'complete' : 'pending', ref };
+    } catch (error) {
+      this.logger.warn(
+        { messageId, destination: ctx.destination, error },
+        'Failed to check Hyperlane message delivery status',
+      );
+      return { status: 'pending', ref };
+    }
+  }
+}

--- a/typescript/rebalancer/src/bridges/status/LzScanStatusAdapter.test.ts
+++ b/typescript/rebalancer/src/bridges/status/LzScanStatusAdapter.test.ts
@@ -1,0 +1,616 @@
+import { expect } from 'chai';
+import { ethers, type providers } from 'ethers';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import type { MultiProtocolCore } from '@hyperlane-xyz/sdk';
+
+import type {
+  MCRStatusPollContext,
+  MCRStatusRef,
+} from '../../interfaces/ITokenBridgeStatusAdapter.js';
+import { LzScanStatusAdapter, normalizeTxHash } from './LzScanStatusAdapter.js';
+
+const logger = pino({ level: 'silent' });
+const GUID = `0x${'11'.repeat(32)}`;
+const OTHER_GUID = `0x${'22'.repeat(32)}`;
+const ORIGIN_TX_HASH = `0x${'aa'.repeat(32)}`;
+const DESTINATION_TX_HASH = `0x${'bb'.repeat(32)}`;
+const SOURCE_EID = 30110;
+const DESTINATION_EID = 30420;
+const BRIDGE = '0x1234567890123456789012345678901234567890';
+const SOURCE_OFT = '0x77652D5aba086137b595875263FC200182919B92';
+const DESTINATION_OFT = '0x3a08f76772e200653bb55c2a92998daca62e0e97';
+const RECIPIENT = '0x3333333333333333333333333333333333333333';
+const OFT_SENT_INTERFACE = new ethers.utils.Interface([
+  'event OFTSent(bytes32 indexed guid,uint32 dstEid,address indexed fromAddress,uint256 amountSentLD,uint256 amountReceivedLD)',
+]);
+const OFT_RECEIVED_INTERFACE = new ethers.utils.Interface([
+  'event OFTReceived(bytes32 indexed guid,uint32 srcEid,address indexed toAddress,uint256 amountReceivedLD)',
+]);
+
+function createAdapter(
+  options: {
+    maxRetries?: number;
+    requestTimeoutMs?: number;
+    retryDelayMs?: number;
+  } = {},
+): LzScanStatusAdapter {
+  return new LzScanStatusAdapter({
+    apiUrl: 'https://example.test/v1',
+    logger,
+    maxRetries: 1,
+    ...options,
+  });
+}
+
+function createRef(overrides: Record<string, unknown> = {}): MCRStatusRef {
+  return {
+    provider: 'lz_scan',
+    kind: 'lz_scan',
+    data: {
+      originTxHash: ORIGIN_TX_HASH,
+      destination: 'tron',
+      destinationDomain: 728126428,
+      guid: GUID,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      amountReceivedLD: '99',
+      ...overrides,
+    },
+  };
+}
+
+function createMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    guid: GUID,
+    pathway: {
+      srcEid: SOURCE_EID,
+      dstEid: DESTINATION_EID,
+      sender: { address: SOURCE_OFT },
+      receiver: { address: DESTINATION_OFT },
+    },
+    source: { tx: { txHash: ORIGIN_TX_HASH } },
+    status: { name: 'DELIVERED' },
+    destination: {
+      status: 'SUCCEEDED',
+      tx: { txHash: DESTINATION_TX_HASH },
+      lzCompose: { status: 'N/A' },
+    },
+    ...overrides,
+  };
+}
+
+function stubResponse(body: unknown, status = 200): Sinon.SinonStub {
+  return Sinon.stub(globalThis, 'fetch').callsFake(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+  );
+}
+
+function createOftSentLog({
+  amountReceivedLD = 99,
+  destinationEid = DESTINATION_EID,
+  emitter = SOURCE_OFT,
+  fromAddress = BRIDGE,
+}: {
+  amountReceivedLD?: bigint | number | string;
+  destinationEid?: number;
+  emitter?: string;
+  fromAddress?: string;
+} = {}): providers.Log {
+  const encoded = OFT_SENT_INTERFACE.encodeEventLog(
+    OFT_SENT_INTERFACE.getEvent('OFTSent'),
+    [GUID, destinationEid, fromAddress, 100, amountReceivedLD],
+  );
+  // CAST: Tests only require address, topics, and data log fields.
+  return {
+    address: emitter,
+    topics: encoded.topics,
+    data: encoded.data,
+  } as providers.Log;
+}
+
+function createReceipt(logs: providers.Log[]): providers.TransactionReceipt {
+  // CAST: Tests only exercise receipt hash/log parsing.
+  return {
+    transactionHash: ORIGIN_TX_HASH.slice(2),
+    logs,
+  } as providers.TransactionReceipt;
+}
+
+function createDestinationReceipt({
+  amountReceivedLD = 99,
+  blockNumber = 100,
+  confirmations = 100,
+  emitter = DESTINATION_OFT,
+  guid = GUID,
+  recipient = RECIPIENT,
+  sourceEid = SOURCE_EID,
+  status = 1,
+}: {
+  amountReceivedLD?: number;
+  blockNumber?: number;
+  confirmations?: number;
+  emitter?: string;
+  guid?: string;
+  recipient?: string;
+  sourceEid?: number;
+  status?: number;
+} = {}): providers.TransactionReceipt {
+  const encoded = OFT_RECEIVED_INTERFACE.encodeEventLog(
+    OFT_RECEIVED_INTERFACE.getEvent('OFTReceived'),
+    [guid, sourceEid, recipient, amountReceivedLD],
+  );
+  // CAST: Tests only exercise destination receipt status, confirmation, and logs.
+  return {
+    blockNumber,
+    status,
+    confirmations,
+    logs: [
+      {
+        address: emitter,
+        topics: encoded.topics,
+        data: encoded.data,
+      } as providers.Log,
+    ],
+  } as providers.TransactionReceipt;
+}
+
+function createPollContext(
+  receipt: providers.TransactionReceipt | null = createDestinationReceipt(),
+  {
+    blockTag,
+    confirmedBlockNumber = 100,
+    confirmations = 1,
+    reorgPeriod = 'finalized',
+  }: {
+    blockTag?: string | number;
+    confirmedBlockNumber?: number;
+    confirmations?: number;
+    reorgPeriod?: number | string;
+  } = {},
+): MCRStatusPollContext {
+  const provider = {
+    getTransactionReceipt: Sinon.stub().resolves(receipt),
+    getBlock: Sinon.stub().resolves({ number: confirmedBlockNumber }),
+  };
+  // CAST: The adapter only consumes these MultiProtocolCore methods.
+  const core = {
+    multiProvider: {
+      getChainName: Sinon.stub().returns('tron'),
+      getEthersV5Provider: Sinon.stub().returns(provider),
+    },
+    metadata: Sinon.stub().returns({
+      blocks: { confirmations, reorgPeriod },
+    }),
+  } as unknown as MultiProtocolCore;
+  return { core, destination: 728126428, blockTag };
+}
+
+describe('LzScanStatusAdapter', () => {
+  afterEach(() => Sinon.restore());
+
+  it('extracts the exact OFTSent GUID and destination EID', async () => {
+    const ref = await createAdapter().initFromReceipt({
+      origin: 'arbitrum',
+      destination: 'tron',
+      originDomain: 42161,
+      destinationDomain: 728126428,
+      bridge: BRIDGE,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      sourceTokenDecimals: 6,
+      destinationTokenDecimals: 6,
+      minimumDestinationAmount: 99n,
+      receipt: createReceipt([createOftSentLog()]),
+    });
+
+    expect(ref.data).to.include({
+      originTxHash: ORIGIN_TX_HASH,
+      guid: GUID,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      amountReceivedLD: '99',
+      minimumDestinationAmount: '99',
+    });
+    expect(normalizeTxHash(`0X${'AA'.repeat(32)}`)).to.equal(
+      `0x${'AA'.repeat(32)}`,
+    );
+
+    stubResponse({ data: [createMessage()] });
+    expect(
+      await createAdapter().pollStatus(ref, createPollContext()),
+    ).to.include({
+      status: 'complete',
+      receivingTxHash: DESTINATION_TX_HASH,
+    });
+  });
+
+  it('rejects OFTSent events not bound to the configured route', async () => {
+    const logs = [
+      createOftSentLog({ emitter: DESTINATION_OFT }),
+      createOftSentLog({ fromAddress: RECIPIENT }),
+      createOftSentLog({ destinationEid: SOURCE_EID }),
+    ];
+
+    for (const log of logs) {
+      const ref = await createAdapter().initFromReceipt({
+        origin: 'arbitrum',
+        destination: 'tron',
+        originDomain: 42161,
+        destinationDomain: 728126428,
+        bridge: BRIDGE,
+        sourceEid: SOURCE_EID,
+        destinationEid: DESTINATION_EID,
+        sourceOft: SOURCE_OFT,
+        destinationOft: DESTINATION_OFT,
+        destinationRecipient: RECIPIENT,
+        sourceTokenDecimals: 6,
+        destinationTokenDecimals: 6,
+        minimumDestinationAmount: 99n,
+        receipt: createReceipt([log]),
+      });
+      expect(ref.data.guid).to.be.undefined;
+      expect(ref.data.trackingError).to.equal(
+        'Matching OFTSent event not found',
+      );
+    }
+  });
+
+  it('normalizes the received amount across local token decimals', async () => {
+    const ref = await createAdapter().initFromReceipt({
+      origin: 'arbitrum',
+      destination: 'tron',
+      originDomain: 42161,
+      destinationDomain: 728126428,
+      bridge: BRIDGE,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      sourceTokenDecimals: 18,
+      destinationTokenDecimals: 6,
+      minimumDestinationAmount: 99n,
+      receipt: createReceipt([
+        createOftSentLog({ amountReceivedLD: 99_000_000_000_000n }),
+      ]),
+    });
+
+    expect(ref.data.amountReceivedLD).to.equal('99');
+    stubResponse({ data: [createMessage()] });
+    expect(
+      await createAdapter().pollStatus(ref, createPollContext()),
+    ).to.include({ status: 'complete' });
+  });
+
+  it('rejects a source event below the intended destination amount', async () => {
+    const ref = await createAdapter().initFromReceipt({
+      origin: 'arbitrum',
+      destination: 'tron',
+      originDomain: 42161,
+      destinationDomain: 728126428,
+      bridge: BRIDGE,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      sourceTokenDecimals: 6,
+      destinationTokenDecimals: 6,
+      minimumDestinationAmount: 99n,
+      receipt: createReceipt([createOftSentLog({ amountReceivedLD: 98 })]),
+    });
+
+    expect(ref.data.guid).to.be.undefined;
+    expect(ref.data.trackingError).to.equal('Matching OFTSent event not found');
+  });
+
+  it('rejects ambiguous matching OFTSent events', async () => {
+    const ref = await createAdapter().initFromReceipt({
+      origin: 'arbitrum',
+      destination: 'tron',
+      originDomain: 42161,
+      destinationDomain: 728126428,
+      bridge: BRIDGE,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      sourceTokenDecimals: 6,
+      destinationTokenDecimals: 6,
+      minimumDestinationAmount: 99n,
+      receipt: createReceipt([createOftSentLog(), createOftSentLog()]),
+    });
+
+    expect(ref.data.guid).to.be.undefined;
+    expect(ref.data.trackingError).to.equal('Multiple OFTSent events found');
+  });
+
+  it('keeps a confirmed source transaction suppressed when its GUID is unavailable', async () => {
+    const adapter = createAdapter();
+    const ref = await adapter.initFromReceipt({
+      origin: 'arbitrum',
+      destination: 'tron',
+      originDomain: 42161,
+      destinationDomain: 728126428,
+      bridge: BRIDGE,
+      sourceEid: SOURCE_EID,
+      destinationEid: DESTINATION_EID,
+      sourceOft: SOURCE_OFT,
+      destinationOft: DESTINATION_OFT,
+      destinationRecipient: RECIPIENT,
+      sourceTokenDecimals: 6,
+      destinationTokenDecimals: 6,
+      minimumDestinationAmount: 99n,
+      receipt: createReceipt([]),
+    });
+    const fetchStub = Sinon.stub(globalThis, 'fetch');
+
+    expect(await adapter.pollStatus(ref, createPollContext())).to.include({
+      status: 'pending',
+      substatus: 'MANUAL_RECONCILIATION_REQUIRED',
+    });
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it('completes only the exact GUID, destination EID, and origin transaction', async () => {
+    stubResponse({ data: [createMessage()] });
+
+    const status = await createAdapter().pollStatus(
+      createRef(),
+      createPollContext(),
+    );
+
+    expect(status).to.include({
+      status: 'complete',
+      receivingTxHash: DESTINATION_TX_HASH,
+    });
+  });
+
+  it('does not select a different message in a multi-message response', async () => {
+    stubResponse({
+      data: [
+        createMessage({ guid: OTHER_GUID }),
+        createMessage({
+          pathway: {
+            srcEid: SOURCE_EID,
+            dstEid: SOURCE_EID,
+            sender: { address: SOURCE_OFT },
+            receiver: { address: DESTINATION_OFT },
+          },
+        }),
+        createMessage({
+          source: { tx: { txHash: `0x${'cc'.repeat(32)}` } },
+        }),
+        createMessage({
+          pathway: {
+            srcEid: SOURCE_EID,
+            dstEid: DESTINATION_EID,
+            sender: { address: DESTINATION_OFT },
+            receiver: { address: DESTINATION_OFT },
+          },
+        }),
+        createMessage({
+          pathway: {
+            srcEid: SOURCE_EID,
+            dstEid: DESTINATION_EID,
+            sender: { address: SOURCE_OFT },
+            receiver: { address: SOURCE_OFT },
+          },
+        }),
+      ],
+    });
+
+    expect(
+      await createAdapter().pollStatus(createRef(), createPollContext()),
+    ).to.include({
+      status: 'pending',
+      substatus: 'EXACT_MESSAGE_NOT_FOUND',
+    });
+  });
+
+  it('waits for destination success and a destination transaction hash', async () => {
+    stubResponse({
+      data: [
+        createMessage({
+          destination: { status: 'VALIDATING_TX' },
+        }),
+      ],
+    });
+    expect(
+      await createAdapter().pollStatus(createRef(), createPollContext()),
+    ).to.include({
+      status: 'pending',
+      substatus: 'DELIVERED/VALIDATING_TX',
+    });
+
+    Sinon.restore();
+    stubResponse({
+      data: [
+        createMessage({
+          destination: { status: 'SUCCEEDED' },
+        }),
+      ],
+    });
+    expect(
+      await createAdapter().pollStatus(createRef(), createPollContext()),
+    ).to.include({
+      status: 'pending',
+      substatus: 'DELIVERED/SUCCEEDED',
+    });
+  });
+
+  it('keeps LayerZero failure states pending for the process lifetime', async () => {
+    stubResponse({
+      data: [
+        createMessage({
+          status: { name: 'FAILED' },
+          destination: { status: 'SIMULATION_REVERTED' },
+        }),
+      ],
+    });
+
+    expect(
+      await createAdapter().pollStatus(createRef(), createPollContext()),
+    ).to.include({
+      status: 'pending',
+      substatus: 'FAILED/SIMULATION_REVERTED',
+    });
+  });
+
+  it('requires an exact, successful, confirmed OFTReceived receipt', async () => {
+    const cases: Array<providers.TransactionReceipt | null> = [
+      null,
+      createDestinationReceipt({ status: 0 }),
+      createDestinationReceipt({ confirmations: 0 }),
+      createDestinationReceipt({ emitter: SOURCE_OFT }),
+      createDestinationReceipt({ guid: OTHER_GUID }),
+      createDestinationReceipt({ sourceEid: DESTINATION_EID }),
+      createDestinationReceipt({ recipient: BRIDGE }),
+      createDestinationReceipt({ amountReceivedLD: 98 }),
+    ];
+
+    for (const receipt of cases) {
+      Sinon.restore();
+      stubResponse({ data: [createMessage()] });
+      const status = await createAdapter().pollStatus(
+        createRef(),
+        createPollContext(receipt),
+      );
+      expect(status).to.include({
+        status: 'pending',
+        substatus: 'DESTINATION_RECEIPT_UNVERIFIED',
+      });
+    }
+  });
+
+  it('requires the destination receipt at the confirmed block tag', async () => {
+    stubResponse({ data: [createMessage()] });
+    expect(
+      await createAdapter().pollStatus(
+        createRef(),
+        createPollContext(createDestinationReceipt({ blockNumber: 101 }), {
+          blockTag: 100,
+        }),
+      ),
+    ).to.include({
+      status: 'pending',
+      substatus: 'DESTINATION_RECEIPT_UNVERIFIED',
+    });
+
+    Sinon.restore();
+    stubResponse({ data: [createMessage()] });
+    expect(
+      await createAdapter().pollStatus(
+        createRef(),
+        createPollContext(createDestinationReceipt({ blockNumber: 101 }), {
+          blockTag: 'finalized',
+          confirmedBlockNumber: 100,
+        }),
+      ),
+    ).to.include({
+      status: 'pending',
+      substatus: 'DESTINATION_RECEIPT_UNVERIFIED',
+    });
+  });
+
+  it('enforces the metadata finality tag without a caller block tag', async () => {
+    stubResponse({ data: [createMessage()] });
+
+    expect(
+      await createAdapter().pollStatus(
+        createRef(),
+        createPollContext(createDestinationReceipt({ blockNumber: 101 }), {
+          confirmedBlockNumber: 100,
+          reorgPeriod: 'finalized',
+        }),
+      ),
+    ).to.include({
+      status: 'pending',
+      substatus: 'DESTINATION_RECEIPT_UNVERIFIED',
+    });
+  });
+
+  it('treats 404, malformed responses, and API outages as pending', async () => {
+    stubResponse({}, 404);
+    expect(
+      (await createAdapter().pollStatus(createRef(), createPollContext()))
+        .status,
+    ).to.equal('pending');
+
+    Sinon.restore();
+    stubResponse({ data: [{ status: 'DELIVERED' }] });
+    expect(
+      (await createAdapter().pollStatus(createRef(), createPollContext()))
+        .status,
+    ).to.equal('pending');
+
+    Sinon.restore();
+    Sinon.stub(globalThis, 'fetch').rejects(new Error('temporary outage'));
+    expect(
+      (await createAdapter().pollStatus(createRef(), createPollContext()))
+        .status,
+    ).to.equal('pending');
+  });
+
+  it('queries LayerZero Scan by exact GUID', async () => {
+    const fetchStub = stubResponse({ data: [] });
+
+    await createAdapter().pollStatus(createRef(), createPollContext());
+
+    expect(fetchStub.firstCall.args[0]).to.equal(
+      `https://example.test/v1/messages/guid/${GUID}`,
+    );
+  });
+
+  it('retries transient API errors', async () => {
+    const fetchStub = Sinon.stub(globalThis, 'fetch');
+    fetchStub.onFirstCall().resolves(new Response('', { status: 503 }));
+    fetchStub.onSecondCall().resolves(
+      new Response(JSON.stringify({ data: [createMessage()] }), {
+        status: 200,
+      }),
+    );
+
+    const status = await createAdapter({
+      maxRetries: 2,
+      retryDelayMs: 0,
+    }).pollStatus(createRef(), createPollContext());
+
+    expect(fetchStub.callCount).to.equal(2);
+    expect(status.status).to.equal('complete');
+  });
+
+  it('aborts timed-out API requests and remains pending', async () => {
+    const fetchStub = Sinon.stub(globalThis, 'fetch').callsFake(
+      async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          );
+        }),
+    );
+
+    const status = await createAdapter({
+      requestTimeoutMs: 1,
+    }).pollStatus(createRef(), createPollContext());
+
+    expect(fetchStub.calledOnce).to.equal(true);
+    expect(status.status).to.equal('pending');
+  });
+});

--- a/typescript/rebalancer/src/bridges/status/LzScanStatusAdapter.ts
+++ b/typescript/rebalancer/src/bridges/status/LzScanStatusAdapter.ts
@@ -1,0 +1,576 @@
+import { ethers } from 'ethers';
+import type { Logger } from 'pino';
+import { z } from 'zod';
+
+import { assert, eqAddress, isAddressEvm } from '@hyperlane-xyz/utils';
+
+import { TokenBridgeStatusAdapterType } from '../../config/types.js';
+import type {
+  ITokenBridgeStatusAdapter,
+  MCRExecutionContext,
+  MCRSettlementStatus,
+  MCRStatusPollContext,
+  MCRStatusRef,
+} from '../../interfaces/ITokenBridgeStatusAdapter.js';
+
+const DEFAULT_API_URL = 'https://scan.layerzero-api.com/v1';
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+const BYTES32_SCHEMA = z.string().regex(/^0x[0-9a-fA-F]{64}$/);
+const EVM_ADDRESS_SCHEMA = z.string().refine(isAddressEvm);
+
+const OFT_SENT_INTERFACE = new ethers.utils.Interface([
+  'event OFTSent(bytes32 indexed guid,uint32 dstEid,address indexed fromAddress,uint256 amountSentLD,uint256 amountReceivedLD)',
+]);
+const OFT_SENT_TOPIC =
+  OFT_SENT_INTERFACE.getEventTopic('OFTSent').toLowerCase();
+const OFT_RECEIVED_INTERFACE = new ethers.utils.Interface([
+  'event OFTReceived(bytes32 indexed guid,uint32 srcEid,address indexed toAddress,uint256 amountReceivedLD)',
+]);
+const OFT_RECEIVED_TOPIC =
+  OFT_RECEIVED_INTERFACE.getEventTopic('OFTReceived').toLowerCase();
+
+interface LzScanRefData extends Record<string, unknown> {
+  originTxHash: string;
+  destination: string;
+  destinationDomain: number;
+  guid?: string;
+  sourceEid?: number;
+  destinationEid?: number;
+  sourceOft?: string;
+  destinationOft?: string;
+  destinationRecipient?: string;
+  amountReceivedLD?: string;
+  minimumDestinationAmount?: string;
+  trackingError?: string;
+  lastObservedStatus?: string;
+  lastPolledAt?: number;
+}
+
+const LayerZeroStatusSchema = z.union([
+  z.string(),
+  z.object({ name: z.string() }).passthrough(),
+]);
+
+const LayerZeroMessageSchema = z
+  .object({
+    guid: BYTES32_SCHEMA,
+    pathway: z
+      .object({
+        srcEid: z.number().int().positive(),
+        dstEid: z.number().int().positive(),
+        sender: z.object({ address: EVM_ADDRESS_SCHEMA }).passthrough(),
+        receiver: z.object({ address: EVM_ADDRESS_SCHEMA }).passthrough(),
+      })
+      .passthrough(),
+    source: z
+      .object({
+        tx: z.object({ txHash: BYTES32_SCHEMA }).passthrough().optional(),
+      })
+      .passthrough()
+      .optional(),
+    status: LayerZeroStatusSchema,
+    destination: z
+      .object({
+        status: z.string().optional(),
+        tx: z.object({ txHash: BYTES32_SCHEMA }).passthrough().optional(),
+        lzCompose: z
+          .object({
+            status: z.string(),
+            txs: z
+              .array(z.object({ txHash: z.string() }).passthrough())
+              .optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .nullish(),
+  })
+  .passthrough();
+
+const LayerZeroResponseSchema = z
+  .object({
+    data: z.array(LayerZeroMessageSchema).optional(),
+    messages: z.array(LayerZeroMessageSchema).optional(),
+  })
+  .passthrough();
+
+type LayerZeroMessage = z.infer<typeof LayerZeroMessageSchema>;
+type LayerZeroResponse = z.infer<typeof LayerZeroResponseSchema>;
+
+export interface LzScanStatusAdapterOptions {
+  apiUrl?: string;
+  logger: Logger;
+  maxRetries?: number;
+  requestTimeoutMs?: number;
+  retryDelayMs?: number;
+}
+
+/** Tracks a source-committed LayerZero OFT movement through destination execution. */
+export class LzScanStatusAdapter implements ITokenBridgeStatusAdapter {
+  readonly kind = TokenBridgeStatusAdapterType.LayerZeroScan;
+  readonly logger: Logger;
+  private readonly apiUrl: string;
+  private readonly maxRetries: number;
+  private readonly requestTimeoutMs: number;
+  private readonly retryDelayMs: number;
+
+  constructor(options: LzScanStatusAdapterOptions) {
+    this.apiUrl = options.apiUrl ?? DEFAULT_API_URL;
+    this.logger = options.logger;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    assert(this.maxRetries > 0, 'LayerZero Scan maxRetries must be positive');
+    assert(
+      this.requestTimeoutMs > 0,
+      'LayerZero Scan requestTimeoutMs must be positive',
+    );
+    assert(
+      this.retryDelayMs >= 0,
+      'LayerZero Scan retryDelayMs must be non-negative',
+    );
+  }
+
+  async initFromReceipt(ctx: MCRExecutionContext): Promise<MCRStatusRef> {
+    const originTxHash = normalizeTxHash(ctx.receipt.transactionHash);
+    const {
+      sourceEid,
+      destinationEid,
+      sourceOft,
+      destinationOft,
+      destinationRecipient,
+      sourceTokenDecimals,
+      destinationTokenDecimals,
+      minimumDestinationAmount,
+    } = ctx;
+    const hasRouteIdentity =
+      sourceEid !== undefined &&
+      destinationEid !== undefined &&
+      sourceOft !== undefined &&
+      destinationOft !== undefined &&
+      destinationRecipient !== undefined &&
+      sourceTokenDecimals !== undefined &&
+      destinationTokenDecimals !== undefined &&
+      minimumDestinationAmount !== undefined;
+    const oftSentEvents = (ctx.receipt.logs ?? [])
+      .filter(
+        (log) =>
+          hasRouteIdentity &&
+          log.topics[0]?.toLowerCase() === OFT_SENT_TOPIC &&
+          sourceOft !== undefined &&
+          eqAddress(log.address, sourceOft),
+      )
+      .flatMap((log) => {
+        try {
+          if (
+            sourceTokenDecimals === undefined ||
+            destinationTokenDecimals === undefined
+          ) {
+            return [];
+          }
+          const parsed = OFT_SENT_INTERFACE.parseLog(log);
+          const parsedDestinationEid = Number(parsed.args.dstEid);
+          const fromAddress = String(parsed.args.fromAddress);
+          if (
+            parsedDestinationEid !== destinationEid ||
+            !eqAddress(fromAddress, ctx.bridge)
+          ) {
+            return [];
+          }
+          const amountReceivedLD = scaleLocalAmount(
+            String(parsed.args.amountReceivedLD),
+            sourceTokenDecimals,
+            destinationTokenDecimals,
+          );
+          if (
+            minimumDestinationAmount === undefined ||
+            BigInt(amountReceivedLD) < minimumDestinationAmount
+          ) {
+            return [];
+          }
+          return [
+            {
+              amountReceivedLD,
+              destinationEid: parsedDestinationEid,
+              guid: String(parsed.args.guid),
+            },
+          ];
+        } catch {
+          return [];
+        }
+      });
+
+    const event = oftSentEvents.length === 1 ? oftSentEvents[0] : undefined;
+    const data: LzScanRefData = {
+      originTxHash,
+      destination: ctx.destination,
+      destinationDomain: ctx.destinationDomain,
+      sourceEid,
+      destinationEid,
+      sourceOft,
+      destinationOft,
+      destinationRecipient,
+      minimumDestinationAmount: minimumDestinationAmount?.toString(),
+      ...(event
+        ? {
+            guid: event.guid,
+            amountReceivedLD: event.amountReceivedLD,
+          }
+        : {
+            trackingError: !hasRouteIdentity
+              ? 'LayerZero route identity missing'
+              : oftSentEvents.length === 0
+                ? 'Matching OFTSent event not found'
+                : 'Multiple OFTSent events found',
+          }),
+    };
+
+    if (!event) {
+      this.logger.error(
+        {
+          originTxHash,
+          oftSentEventCount: oftSentEvents.length,
+          destination: ctx.destination,
+        },
+        'LayerZero transfer is source-committed but cannot be tracked automatically',
+      );
+    }
+
+    return { provider: this.kind, kind: this.kind, data };
+  }
+
+  async pollStatus(
+    ref: MCRStatusRef,
+    ctx: MCRStatusPollContext,
+  ): Promise<MCRSettlementStatus> {
+    const data = parseRefData(ref);
+    const now = Date.now();
+
+    // A confirmed source transaction must remain suppressed if its exact GUID
+    // cannot be recovered. Keep it suppressed for this process lifetime rather
+    // than risk a duplicate send.
+    if (
+      !data.guid ||
+      data.sourceEid === undefined ||
+      data.destinationEid === undefined ||
+      !data.sourceOft ||
+      !data.destinationOft ||
+      !data.destinationRecipient ||
+      !data.amountReceivedLD
+    ) {
+      return {
+        status: 'pending',
+        substatus: 'MANUAL_RECONCILIATION_REQUIRED',
+        ref: this.refreshRef(ref, data, now),
+      };
+    }
+
+    const { guid, sourceEid, destinationEid, sourceOft, destinationOft } = data;
+
+    let response: LayerZeroResponse;
+    try {
+      response = await this.fetchMessage(guid);
+    } catch (error) {
+      this.logger.warn(
+        { guid, originTxHash: data.originTxHash, error },
+        'LayerZero Scan lookup failed; treating settlement as pending',
+      );
+      return { status: 'pending', ref: this.refreshRef(ref, data, now) };
+    }
+
+    const messages = response.data ?? response.messages ?? [];
+    const message = messages.find(
+      (candidate) =>
+        equalHex(candidate.guid, guid) &&
+        candidate.pathway.srcEid === sourceEid &&
+        candidate.pathway.dstEid === destinationEid &&
+        eqAddress(candidate.pathway.sender.address, sourceOft) &&
+        eqAddress(candidate.pathway.receiver.address, destinationOft) &&
+        candidate.source?.tx?.txHash !== undefined &&
+        equalHex(candidate.source.tx.txHash, data.originTxHash),
+    );
+    if (!message) {
+      return {
+        status: 'pending',
+        substatus: 'EXACT_MESSAGE_NOT_FOUND',
+        ref: this.refreshRef(ref, data, now),
+      };
+    }
+
+    return this.evaluateMessage(ref, data, message, now, ctx);
+  }
+
+  protected async fetchMessage(guid: string): Promise<LayerZeroResponse> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < this.maxRetries; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, this.retryDelayMs * Math.pow(2, attempt - 1)),
+        );
+      }
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(),
+        this.requestTimeoutMs,
+      );
+      try {
+        const response = await fetch(
+          `${this.apiUrl}/messages/guid/${encodeURIComponent(guid)}`,
+          {
+            headers: { Accept: 'application/json' },
+            signal: controller.signal,
+          },
+        );
+        if (response.status === 404) return { data: [] };
+        if (!response.ok) {
+          throw new Error(
+            `LayerZero Scan API error: ${response.status} ${response.statusText}`,
+          );
+        }
+        return LayerZeroResponseSchema.parse(await response.json());
+      } catch (error) {
+        lastError = error;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    throw lastError;
+  }
+
+  private async evaluateMessage(
+    ref: MCRStatusRef,
+    data: LzScanRefData,
+    message: LayerZeroMessage,
+    now: number,
+    ctx: MCRStatusPollContext,
+  ): Promise<MCRSettlementStatus> {
+    const overallStatus = normalizeStatus(message.status);
+    const destinationStatus = normalizeStatus(message.destination?.status);
+    const composeStatus = normalizeStatus(
+      message.destination?.lzCompose?.status,
+    );
+    const observedStatus = [overallStatus, destinationStatus, composeStatus]
+      .filter(Boolean)
+      .join('/');
+    const refreshed = this.refreshRef(
+      ref,
+      data,
+      now,
+      observedStatus || 'UNKNOWN',
+    );
+
+    const composeSatisfied =
+      !composeStatus ||
+      composeStatus === 'N/A' ||
+      composeStatus === 'SUCCEEDED';
+    const receivingTxHash = message.destination?.tx?.txHash;
+    if (
+      overallStatus === 'DELIVERED' &&
+      destinationStatus === 'SUCCEEDED' &&
+      composeSatisfied &&
+      receivingTxHash
+    ) {
+      if (
+        await this.verifyDestinationReceipt(receivingTxHash, data, message, ctx)
+      ) {
+        return { status: 'complete', receivingTxHash, ref: refreshed };
+      }
+      return {
+        status: 'pending',
+        substatus: 'DESTINATION_RECEIPT_UNVERIFIED',
+        ref: refreshed,
+      };
+    }
+
+    // The source collateral move is already committed. Even irrecoverable or
+    // retryable LayerZero failures remain suppressed for this process lifetime;
+    // releasing the intent here could debit collateral a second time.
+    return {
+      status: 'pending',
+      substatus: observedStatus || 'UNKNOWN',
+      ref: refreshed,
+    };
+  }
+
+  private async verifyDestinationReceipt(
+    receivingTxHash: string,
+    data: LzScanRefData,
+    message: LayerZeroMessage,
+    ctx: MCRStatusPollContext,
+  ): Promise<boolean> {
+    if (
+      !data.guid ||
+      data.sourceEid === undefined ||
+      !data.destinationOft ||
+      !data.destinationRecipient ||
+      !data.amountReceivedLD
+    ) {
+      return false;
+    }
+    const {
+      guid,
+      sourceEid,
+      destinationOft,
+      destinationRecipient,
+      amountReceivedLD,
+    } = data;
+
+    try {
+      const chainName = ctx.core.multiProvider.getChainName(ctx.destination);
+      const provider = ctx.core.multiProvider.getEthersV5Provider(chainName);
+      const receipt = await provider.getTransactionReceipt(
+        normalizeTxHash(receivingTxHash),
+      );
+      if (!receipt || receipt.status !== 1) return false;
+
+      const blocks = ctx.core.metadata(chainName).blocks;
+      const minimumConfirmations = blocks?.confirmations ?? 1;
+      if (receipt.confirmations < minimumConfirmations) return false;
+
+      if (
+        typeof ctx.blockTag === 'number' &&
+        receipt.blockNumber > ctx.blockTag
+      ) {
+        return false;
+      }
+
+      const reorgPeriod = blocks?.reorgPeriod;
+      const finalityTag =
+        typeof ctx.blockTag === 'string'
+          ? ctx.blockTag
+          : typeof reorgPeriod === 'string'
+            ? reorgPeriod
+            : undefined;
+      if (finalityTag) {
+        const confirmedBlock = await provider.getBlock(finalityTag);
+        if (!confirmedBlock || receipt.blockNumber > confirmedBlock.number) {
+          return false;
+        }
+      }
+
+      if (
+        typeof reorgPeriod === 'number' &&
+        receipt.confirmations < reorgPeriod
+      ) {
+        return false;
+      }
+
+      const matchingEvents = receipt.logs.filter((log) => {
+        if (
+          log.topics[0]?.toLowerCase() !== OFT_RECEIVED_TOPIC ||
+          !eqAddress(log.address, destinationOft)
+        ) {
+          return false;
+        }
+        try {
+          const parsed = OFT_RECEIVED_INTERFACE.parseLog(log);
+          return (
+            equalHex(String(parsed.args.guid), guid) &&
+            Number(parsed.args.srcEid) === message.pathway.srcEid &&
+            Number(parsed.args.srcEid) === sourceEid &&
+            eqAddress(String(parsed.args.toAddress), destinationRecipient) &&
+            String(parsed.args.amountReceivedLD) === amountReceivedLD
+          );
+        } catch {
+          return false;
+        }
+      });
+      return matchingEvents.length === 1;
+    } catch (error) {
+      this.logger.warn(
+        { receivingTxHash, destination: data.destination, error },
+        'Failed to verify LayerZero destination receipt',
+      );
+      return false;
+    }
+  }
+
+  private refreshRef(
+    ref: MCRStatusRef,
+    data: LzScanRefData,
+    lastPolledAt: number,
+    lastObservedStatus?: string,
+  ): MCRStatusRef {
+    return {
+      ...ref,
+      data: {
+        ...data,
+        lastPolledAt,
+        ...(lastObservedStatus ? { lastObservedStatus } : {}),
+      },
+    };
+  }
+}
+
+function parseRefData(ref: MCRStatusRef): LzScanRefData {
+  return z
+    .object({
+      originTxHash: BYTES32_SCHEMA,
+      destination: z.string().min(1),
+      destinationDomain: z.number(),
+      guid: BYTES32_SCHEMA.optional(),
+      sourceEid: z.number().int().positive().optional(),
+      destinationEid: z.number().int().positive().optional(),
+      sourceOft: EVM_ADDRESS_SCHEMA.optional(),
+      destinationOft: EVM_ADDRESS_SCHEMA.optional(),
+      destinationRecipient: EVM_ADDRESS_SCHEMA.optional(),
+      amountReceivedLD: z.string().regex(/^\d+$/).optional(),
+      minimumDestinationAmount: z.string().regex(/^\d+$/).optional(),
+      trackingError: z.string().optional(),
+      lastObservedStatus: z.string().optional(),
+      lastPolledAt: z.number().optional(),
+    })
+    .passthrough()
+    .parse(ref.data);
+}
+
+function normalizeStatus(status?: string | { name: string }): string {
+  return (
+    (typeof status === 'string' ? status : status?.name)
+      ?.trim()
+      .toUpperCase() ?? ''
+  );
+}
+
+function equalHex(left: string, right: string): boolean {
+  return (
+    left.replace(/^0x/i, '').toLowerCase() ===
+    right.replace(/^0x/i, '').toLowerCase()
+  );
+}
+
+function scaleLocalAmount(
+  amount: string,
+  sourceDecimals: number,
+  destinationDecimals: number,
+): string {
+  assert(
+    Number.isInteger(sourceDecimals) && sourceDecimals >= 0,
+    'Invalid source token decimals',
+  );
+  assert(
+    Number.isInteger(destinationDecimals) && destinationDecimals >= 0,
+    'Invalid destination token decimals',
+  );
+
+  const value = BigInt(amount);
+  if (sourceDecimals === destinationDecimals) return value.toString();
+  if (sourceDecimals < destinationDecimals) {
+    return (
+      value *
+      10n ** BigInt(destinationDecimals - sourceDecimals)
+    ).toString();
+  }
+
+  const divisor = 10n ** BigInt(sourceDecimals - destinationDecimals);
+  assert(value % divisor === 0n, 'LayerZero OFT amount contains local dust');
+  return (value / divisor).toString();
+}
+
+export function normalizeTxHash(txHash: string): string {
+  return /^0x/i.test(txHash) ? `0x${txHash.slice(2)}` : `0x${txHash}`;
+}

--- a/typescript/rebalancer/src/bridges/status/index.ts
+++ b/typescript/rebalancer/src/bridges/status/index.ts
@@ -1,0 +1,21 @@
+import type { Logger } from 'pino';
+
+import type { StatusAdaptersByKind } from '../../interfaces/ITokenBridgeStatusAdapter.js';
+import { HyperlaneMessageStatusAdapter } from './HyperlaneMessageStatusAdapter.js';
+import { LzScanStatusAdapter } from './LzScanStatusAdapter.js';
+
+export function createStatusAdapters(logger: Logger): StatusAdaptersByKind {
+  const adapters = [
+    new HyperlaneMessageStatusAdapter(
+      logger.child({ class: HyperlaneMessageStatusAdapter.name }),
+    ),
+    new LzScanStatusAdapter({
+      logger: logger.child({ class: LzScanStatusAdapter.name }),
+    }),
+  ];
+
+  return new Map(adapters.map((adapter) => [adapter.kind, adapter]));
+}
+
+export { HyperlaneMessageStatusAdapter } from './HyperlaneMessageStatusAdapter.js';
+export { LzScanStatusAdapter } from './LzScanStatusAdapter.js';

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -895,6 +895,7 @@ describe('per-chain bridge configuration', () => {
           apiUrl: 'https://api-v2.swaps.xyz/api',
           defaultSlippage: 0.005,
           maxQuoteLossBps: 250,
+          maxSolanaNativeSpendLamports: 10_000_000,
         },
       },
     };
@@ -906,6 +907,7 @@ describe('per-chain bridge configuration', () => {
       apiUrl: 'https://api-v2.swaps.xyz/api',
       defaultSlippage: 0.005,
       maxQuoteLossBps: 250,
+      maxSolanaNativeSpendLamports: 10_000_000,
     });
     expect(config.externalBridges?.lifi).to.be.undefined;
   });
@@ -943,6 +945,9 @@ describe('per-chain bridge configuration', () => {
     { maxQuoteLossBps: -1 },
     { maxQuoteLossBps: 10_001 },
     { maxQuoteLossBps: 1.5 },
+    { maxSolanaNativeSpendLamports: -1 },
+    { maxSolanaNativeSpendLamports: 1.5 },
+    { maxSolanaNativeSpendLamports: Number.MAX_SAFE_INTEGER + 1 },
   ]) {
     it(`should reject unsafe swapsxyz config ${JSON.stringify(swapsxyz)}`, () => {
       const data: RebalancerConfigFileInput = {

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -788,7 +788,7 @@ describe('per-chain bridge configuration', () => {
     });
   });
 
-  it('should require externalBridges.lifi when executionType is inventory', () => {
+  it('should require externalBridge when executionType is inventory', () => {
     const data = {
       warpRouteId: 'test-route',
       strategy: [
@@ -810,7 +810,65 @@ describe('per-chain bridge configuration', () => {
     writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
 
     expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
-      /externalBridges\.lifi.*required/i,
+      /inventory execution.*externalBridge/i,
+    );
+  });
+
+  it('should accept deBridge inventory execution without LiFi config', () => {
+    const data = {
+      warpRouteId: 'test-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            ethereum: {
+              weighted: { weight: 100, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.DeBridge,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        ethereum: '0x1234567890123456789012345678901234567890',
+      },
+      externalBridges: {
+        debridge: { maxFeePercent: 2.5 },
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+    const config = RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE);
+
+    expect(config.externalBridges?.debridge).to.deep.equal({
+      maxFeePercent: 2.5,
+    });
+  });
+
+  it('should require externalBridges.debridge when selected', () => {
+    const data = {
+      warpRouteId: 'test-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            ethereum: {
+              weighted: { weight: 100, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.DeBridge,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        ethereum: '0x1234567890123456789012345678901234567890',
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
+      /externalBridges\.debridge.*not configured/i,
     );
   });
 

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -872,6 +872,105 @@ describe('per-chain bridge configuration', () => {
     );
   });
 
+  it('should accept swapsxyz inventory config without LiFi config', () => {
+    const data: RebalancerConfigFileInput = {
+      warpRouteId: 'test-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            ethereum: {
+              weighted: { weight: 100, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.SwapsXyz,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        ethereum: '0x1234567890123456789012345678901234567890',
+      },
+      externalBridges: {
+        swapsxyz: {
+          apiUrl: 'https://api-v2.swaps.xyz/api',
+          defaultSlippage: 0.005,
+          maxQuoteLossBps: 250,
+        },
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+    const config = RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE);
+
+    expect(config.externalBridges?.swapsxyz).to.deep.equal({
+      apiUrl: 'https://api-v2.swaps.xyz/api',
+      defaultSlippage: 0.005,
+      maxQuoteLossBps: 250,
+    });
+    expect(config.externalBridges?.lifi).to.be.undefined;
+  });
+
+  it('should require externalBridges.swapsxyz when selected', () => {
+    const data: RebalancerConfigFileInput = {
+      warpRouteId: 'test-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            ethereum: {
+              weighted: { weight: 100, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.SwapsXyz,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        ethereum: '0x1234567890123456789012345678901234567890',
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
+      /externalBridges\.swapsxyz.*not configured/i,
+    );
+  });
+
+  for (const swapsxyz of [
+    { apiUrl: 'http://api.swaps.xyz' },
+    { defaultSlippage: 50 },
+    { maxQuoteLossBps: -1 },
+    { maxQuoteLossBps: 10_001 },
+    { maxQuoteLossBps: 1.5 },
+  ]) {
+    it(`should reject unsafe swapsxyz config ${JSON.stringify(swapsxyz)}`, () => {
+      const data: RebalancerConfigFileInput = {
+        warpRouteId: 'test-route',
+        strategy: [
+          {
+            rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+            chains: {
+              ethereum: {
+                weighted: { weight: 100, tolerance: 5 },
+                executionType: ExecutionType.Inventory,
+                externalBridge: ExternalBridgeType.SwapsXyz,
+              },
+            },
+          },
+        ],
+        inventorySigners: {
+          ethereum: '0x1234567890123456789012345678901234567890',
+        },
+        externalBridges: { swapsxyz },
+      };
+
+      writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+
+      expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw();
+    });
+  }
+
   it('should require externalBridges.lifi when externalBridge is lifi', () => {
     const data = {
       warpRouteId: 'test-route',

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -15,6 +15,7 @@ import {
   type RebalancerConfigFileInput,
   RebalancerMinAmountType,
   RebalancerStrategyOptions,
+  TokenBridgeStatusAdapterType,
   type StrategyConfig,
   getAllBridges,
 } from './types.js';
@@ -105,6 +106,77 @@ describe('RebalancerConfig', () => {
       inventorySigners: undefined,
       externalBridges: undefined,
     });
+  });
+
+  it('should load LayerZero settlement adapters on chains and overrides', () => {
+    const strategy = getStrategyArray(data)[0];
+    strategy.chains.chain1.statusAdapter = {
+      kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+      sourceEid: 30110,
+      destinationEid: 30420,
+      sourceOft: '0x1111111111111111111111111111111111111111',
+      destinationOft: '0x2222222222222222222222222222222222222222',
+    };
+    strategy.chains.chain1.override = {
+      chain2: {
+        statusAdapter: {
+          kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+          sourceEid: 30110,
+          destinationEid: 30420,
+          sourceOft: '0x1111111111111111111111111111111111111111',
+          destinationOft: '0x2222222222222222222222222222222222222222',
+        },
+      },
+    };
+    writeYamlOrJson(TEST_CONFIG_PATH, data);
+
+    const chainConfig =
+      RebalancerConfig.load(TEST_CONFIG_PATH).strategyConfig[0].chains.chain1;
+    expect(chainConfig.statusAdapter?.kind).to.equal(
+      TokenBridgeStatusAdapterType.LayerZeroScan,
+    );
+    expect(chainConfig.override?.chain2.statusAdapter?.kind).to.equal(
+      TokenBridgeStatusAdapterType.LayerZeroScan,
+    );
+  });
+
+  it('should reject unknown settlement adapter kinds', () => {
+    // CAST: This fixture is intentionally invalid to exercise runtime schema validation.
+    getStrategyArray(data)[0].chains.chain1.statusAdapter = {
+      kind: 'unknown',
+    } as any;
+    writeYamlOrJson(TEST_CONFIG_PATH, data);
+
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH)).to.throw(
+      'statusAdapter.kind',
+    );
+  });
+
+  it('should require LayerZero route identity', () => {
+    // CAST: This fixture is intentionally incomplete to exercise runtime schema validation.
+    getStrategyArray(data)[0].chains.chain1.statusAdapter = {
+      kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+    } as any;
+    writeYamlOrJson(TEST_CONFIG_PATH, data);
+
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH)).to.throw(
+      'statusAdapter.sourceEid',
+    );
+  });
+
+  it('should reject LayerZero EIDs outside uint32', () => {
+    getStrategyArray(data)[0].chains.chain1.statusAdapter = {
+      kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+      sourceEid: 0x1_0000_0000,
+      destinationEid: 30420,
+      sourceOft: '0x1111111111111111111111111111111111111111',
+      destinationOft: '0x2222222222222222222222222222222222222222',
+    };
+    writeYamlOrJson(TEST_CONFIG_PATH, data);
+
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH)).to.throw(
+      'statusAdapter.sourceEid',
+    );
   });
 
   it('should throw if chains are not configured', () => {

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -37,6 +37,7 @@ export enum ExecutionType {
 export enum ExternalBridgeType {
   LiFi = 'lifi',
   DeBridge = 'debridge',
+  SwapsXyz = 'swapsxyz',
 }
 
 export const RebalancerMinAmountConfigSchema = z.object({
@@ -131,9 +132,16 @@ export const DeBridgeBridgeConfigSchema = z.object({
   maxFeePercent: z.number().min(0).max(100).optional(),
 });
 
+export const SwapsXyzBridgeConfigSchema = z.object({
+  apiUrl: z.string().url().startsWith('https://').optional(),
+  defaultSlippage: z.number().positive().max(0.1).optional(),
+  maxQuoteLossBps: z.number().int().min(0).max(10_000).optional(),
+});
+
 export const ExternalBridgesConfigSchema = z.object({
   lifi: LiFiBridgeConfigSchema.optional(),
   debridge: DeBridgeBridgeConfigSchema.optional(),
+  swapsxyz: SwapsXyzBridgeConfigSchema.optional(),
 });
 
 export const RebalancerConfigSchema = z
@@ -397,7 +405,9 @@ export const RebalancerConfigSchema = z
             (externalBridge === ExternalBridgeType.LiFi &&
               !!config.externalBridges?.lifi?.integrator) ||
             (externalBridge === ExternalBridgeType.DeBridge &&
-              config.externalBridges?.debridge !== undefined);
+              config.externalBridges?.debridge !== undefined) ||
+            (externalBridge === ExternalBridgeType.SwapsXyz &&
+              config.externalBridges?.swapsxyz !== undefined);
           if (!isConfigured) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -74,6 +74,7 @@ export const RebalancerMinAmountConfigSchema = z.object({
 });
 
 const RebalancerBridgeConfigSchema = z.object({
+  enabled: z.boolean().optional(),
   bridge: z
     .string()
     .regex(/0x[a-fA-F0-9]{40}/)

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -36,6 +36,7 @@ export enum ExecutionType {
 
 export enum ExternalBridgeType {
   LiFi = 'lifi',
+  DeBridge = 'debridge',
 }
 
 export const RebalancerMinAmountConfigSchema = z.object({
@@ -126,8 +127,13 @@ export const LiFiBridgeConfigSchema = z.object({
   defaultSlippage: z.number().optional(),
 });
 
+export const DeBridgeBridgeConfigSchema = z.object({
+  maxFeePercent: z.number().min(0).max(100).optional(),
+});
+
 export const ExternalBridgesConfigSchema = z.object({
   lifi: LiFiBridgeConfigSchema.optional(),
+  debridge: DeBridgeBridgeConfigSchema.optional(),
 });
 
 export const RebalancerConfigSchema = z
@@ -373,15 +379,6 @@ export const RebalancerConfigSchema = z
           // Other protocols: accept any non-empty string (future-proof)
         }
       }
-
-      if (!config.externalBridges?.lifi?.integrator) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'externalBridges.lifi is required when using inventory execution',
-          path: ['externalBridges', 'lifi'],
-        });
-      }
     }
 
     for (
@@ -391,37 +388,41 @@ export const RebalancerConfigSchema = z
     ) {
       const strategy = config.strategy[strategyIndex];
       for (const [chainName, chainConfig] of Object.entries(strategy.chains)) {
-        const checkLifiBridge = (
+        const checkExternalBridge = (
           externalBridge: ExternalBridgeType | undefined,
           path: (string | number)[],
         ) => {
-          if (
-            externalBridge === ExternalBridgeType.LiFi &&
-            !config.externalBridges?.lifi?.integrator
-          ) {
+          const isConfigured =
+            externalBridge === undefined ||
+            (externalBridge === ExternalBridgeType.LiFi &&
+              !!config.externalBridges?.lifi?.integrator) ||
+            (externalBridge === ExternalBridgeType.DeBridge &&
+              config.externalBridges?.debridge !== undefined);
+          if (!isConfigured) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: `Chain '${chainName}' uses externalBridge: 'lifi' but externalBridges.lifi is not configured`,
+              message: `Chain '${chainName}' uses externalBridge: '${externalBridge}' but externalBridges.${externalBridge} is not configured`,
               path,
             });
           }
         };
 
-        checkLifiBridge(chainConfig.externalBridge, [
-          'externalBridges',
-          'lifi',
+        checkExternalBridge(chainConfig.externalBridge, [
+          'strategy',
+          strategyIndex,
+          'chains',
+          chainName,
+          'externalBridge',
         ]);
 
         if (chainConfig.override) {
           for (const [destination, overrideConfig] of Object.entries(
             chainConfig.override,
           )) {
-            const merged = {
-              ...chainConfig,
-              ...(overrideConfig as Record<string, unknown>),
-            };
-            checkLifiBridge(
-              merged.externalBridge as ExternalBridgeType | undefined,
+            const parsedOverride =
+              RebalancerBridgeConfigSchema.partial().parse(overrideConfig);
+            checkExternalBridge(
+              parsedOverride.externalBridge ?? chainConfig.externalBridge,
               [
                 'strategy',
                 strategyIndex,

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -40,6 +40,33 @@ export enum ExternalBridgeType {
   SwapsXyz = 'swapsxyz',
 }
 
+export enum TokenBridgeStatusAdapterType {
+  HyperlaneMessage = 'hyperlane_message',
+  LayerZeroScan = 'lz_scan',
+}
+
+export const TokenBridgeStatusAdapterConfigSchema = z.discriminatedUnion(
+  'kind',
+  [
+    z.object({
+      kind: z.literal(TokenBridgeStatusAdapterType.HyperlaneMessage),
+    }),
+    z.object({
+      kind: z.literal(TokenBridgeStatusAdapterType.LayerZeroScan),
+      sourceEid: z.number().int().positive().max(0xffffffff),
+      destinationEid: z.number().int().positive().max(0xffffffff),
+      sourceOft: z.string().refine(isAddressEvm, 'Invalid source OFT address'),
+      destinationOft: z
+        .string()
+        .refine(isAddressEvm, 'Invalid destination OFT address'),
+    }),
+  ],
+);
+
+export type TokenBridgeStatusAdapterConfig = z.infer<
+  typeof TokenBridgeStatusAdapterConfigSchema
+>;
+
 export const RebalancerMinAmountConfigSchema = z.object({
   min: z.string().or(z.number()),
   target: z.string().or(z.number()),
@@ -53,6 +80,7 @@ const RebalancerBridgeConfigSchema = z.object({
     .optional(),
   executionType: z.nativeEnum(ExecutionType).optional(),
   externalBridge: z.nativeEnum(ExternalBridgeType).optional(),
+  statusAdapter: TokenBridgeStatusAdapterConfigSchema.optional(),
   bridgeMinAcceptedAmount: z.string().or(z.number()).optional(),
   bridgeLockTime: z
     .number()

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -136,6 +136,12 @@ export const SwapsXyzBridgeConfigSchema = z.object({
   apiUrl: z.string().url().startsWith('https://').optional(),
   defaultSlippage: z.number().positive().max(0.1).optional(),
   maxQuoteLossBps: z.number().int().min(0).max(10_000).optional(),
+  maxSolanaNativeSpendLamports: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(Number.MAX_SAFE_INTEGER)
+    .optional(),
 });
 
 export const ExternalBridgesConfigSchema = z.object({

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -294,6 +294,7 @@ describe('InventoryRebalancer E2E', () => {
       txHash: '0xBridgeTxHash',
       fromChain: 42161,
       toChain: 1399811149,
+      transferId: 'provider-transfer-id',
     });
   }
 
@@ -740,6 +741,9 @@ describe('InventoryRebalancer E2E', () => {
       const actionParams =
         actionTracker.createRebalanceAction.firstCall.args[0];
       expect(actionParams.type).to.equal('inventory_movement');
+      expect(actionParams.externalBridgeTransferId).to.equal(
+        'provider-transfer-id',
+      );
     });
 
     it('returns failure for unrelated fee-aware probe errors', async () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -82,6 +82,7 @@ describe('InventoryRebalancer E2E', () => {
       getInflightInventoryMovements: Sinon.stub(),
       getPartiallyFulfilledInventoryIntents: Sinon.stub(),
       createRebalanceAction: Sinon.stub(),
+      updateRebalanceActionExecution: Sinon.stub(),
       completeRebalanceAction: Sinon.stub(),
       failRebalanceAction: Sinon.stub(),
       logStoreContents: Sinon.stub(),
@@ -89,6 +90,17 @@ describe('InventoryRebalancer E2E', () => {
 
     // Default: No active (partial) inventory intents
     actionTracker.getPartiallyFulfilledInventoryIntents.resolves([]);
+    actionTracker.createRebalanceAction.resolves({
+      id: 'action-1',
+      status: 'in_progress',
+      type: 'inventory_movement',
+      intentId: 'intent-1',
+      origin: 1,
+      destination: 2,
+      amount: 1n,
+      createdAt: 1,
+      updatedAt: 1,
+    });
 
     bridge = {
       bridgeId: 'lifi',
@@ -340,7 +352,13 @@ describe('InventoryRebalancer E2E', () => {
       expect(actionParams.intentId).to.equal('intent-1');
       expect(actionParams.type).to.equal('inventory_deposit');
       expect(actionParams.amount).to.equal(10000000000n);
-      expect(actionParams.txHash).to.equal('0xTransferRemoteTxHash');
+      expect(actionParams.txHash).to.be.undefined;
+      expect(
+        actionTracker.updateRebalanceActionExecution.calledWith(
+          'action-1',
+          Sinon.match({ txHash: '0xTransferRemoteTxHash' }),
+        ),
+      ).to.be.true;
     });
 
     it('executes transferRemote with correct parameters (swapped direction)', async () => {
@@ -414,8 +432,12 @@ describe('InventoryRebalancer E2E', () => {
       expect(sendAndConfirmStub.firstCall.args[0]).to.equal(SOLANA_CHAIN);
       expect(multiProvider.sendTransaction.called).to.be.false;
 
-      const actionParams = actionTracker.createRebalanceAction.lastCall.args[0];
-      expect(actionParams.txHash).to.equal('0xSolanaTxHash');
+      expect(
+        actionTracker.updateRebalanceActionExecution.calledWith(
+          'action-1',
+          Sinon.match({ txHash: '0xSolanaTxHash' }),
+        ),
+      ).to.be.true;
     });
 
     it('denormalizes inventory execution amounts but records canonical deposit amount', async () => {
@@ -741,9 +763,13 @@ describe('InventoryRebalancer E2E', () => {
       const actionParams =
         actionTracker.createRebalanceAction.firstCall.args[0];
       expect(actionParams.type).to.equal('inventory_movement');
-      expect(actionParams.externalBridgeTransferId).to.equal(
-        'provider-transfer-id',
-      );
+      expect(actionParams.externalBridgeTransferId).to.be.undefined;
+      expect(
+        actionTracker.updateRebalanceActionExecution.calledWith(
+          'action-1',
+          Sinon.match({ externalBridgeTransferId: 'provider-transfer-id' }),
+        ),
+      ).to.be.true;
     });
 
     it('returns failure for unrelated fee-aware probe errors', async () => {
@@ -1006,6 +1032,12 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.false;
       expect(results[0].error).to.include('Transaction failed');
+      expect(
+        actionTracker.createRebalanceAction.calledBefore(
+          multiProvider.sendTransaction,
+        ),
+      ).to.be.true;
+      expect(actionTracker.updateRebalanceActionExecution.called).to.be.false;
     });
 
     it('handles missing token for chain', async () => {
@@ -2237,6 +2269,7 @@ describe('InventoryRebalancer E2E', () => {
       expect(results[0].error).to.include('LiFi API timeout');
       expect(bridge.quote.callCount).to.equal(2);
       expect(bridge.execute.called).to.be.false;
+      expect(actionTracker.createRebalanceAction.called).to.be.false;
     });
 
     it('preserves non-Error rejection reasons from parallel bridge execution', async () => {
@@ -2463,6 +2496,12 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.false;
       expect(results[0].error).to.include('All inventory movements failed');
+      expect(
+        actionTracker.createRebalanceAction.firstCall.calledBefore(
+          bridge.execute.firstCall,
+        ),
+      ).to.be.true;
+      expect(actionTracker.updateRebalanceActionExecution.called).to.be.false;
     });
   });
 

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -84,6 +84,7 @@ type BridgeQuoteMode = 'forward' | 'reverse';
 
 type InventoryMovementExecutionResult =
   | {
+      /** The adapter returned a source transaction identity for status polling. */
       success: true;
       txHash: string;
       inputRequired: bigint;
@@ -1627,7 +1628,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           txHash: result.txHash,
           intentId: intent.id,
         },
-        'Inventory movement transaction executed',
+        'Inventory movement execution returned',
       );
 
       // Keep bridge consumption in source-local units; intent fulfillment only
@@ -1639,6 +1640,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         amount: inputRequired,
         type: 'inventory_movement',
         txHash: result.txHash,
+        externalBridgeTransferId: result.transferId,
         externalBridgeId: externalBridgeType,
       });
 

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1117,6 +1117,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       'Expected at least one transaction from WarpCore',
     );
 
+    const action = await this.actionTracker.createRebalanceAction({
+      intentId: intent.id,
+      origin: this.multiProvider.getDomainId(origin),
+      destination: destinationDomain,
+      amount: fulfilledCanonicalAmount,
+      type: 'inventory_deposit',
+    });
+
     this.logger.info(
       {
         origin,
@@ -1133,6 +1141,9 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       const { txHash } = await this.sendAndConfirmInventoryTx(origin, tx);
       if (tx.category === WarpTxCategory.Transfer) {
         transferTxHash = txHash;
+        await this.actionTracker.updateRebalanceActionExecution(action.id, {
+          txHash,
+        });
       }
     }
 
@@ -1165,13 +1176,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       'TransferRemote transaction confirmed',
     );
 
-    // Create the inventory_deposit action with messageId for tracking
-    await this.actionTracker.createRebalanceAction({
-      intentId: intent.id,
-      origin: this.multiProvider.getDomainId(origin),
-      destination: destinationDomain,
-      amount: fulfilledCanonicalAmount,
-      type: 'inventory_deposit',
+    await this.actionTracker.updateRebalanceActionExecution(action.id, {
       txHash: transferTxHash,
       messageId,
     });
@@ -1621,6 +1626,15 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         privateKeys[sourceProtocol],
         `Missing inventory signer key for protocol ${sourceProtocol} (chain ${sourceChain})`,
       );
+
+      const action = await this.actionTracker.createRebalanceAction({
+        intentId: intent.id,
+        origin: this.multiProvider.getDomainId(sourceChain),
+        destination: this.multiProvider.getDomainId(targetChain),
+        amount: inputRequired,
+        type: 'inventory_movement',
+        externalBridgeId: externalBridgeType,
+      });
       const result = await externalBridge.execute(quote, privateKeys);
 
       this.logger.info(
@@ -1633,17 +1647,9 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         'Inventory movement execution returned',
       );
 
-      // Keep bridge consumption in source-local units; intent fulfillment only
-      // advances from canonical inventory_deposit amounts after transferRemote.
-      await this.actionTracker.createRebalanceAction({
-        intentId: intent.id,
-        origin: this.multiProvider.getDomainId(sourceChain),
-        destination: this.multiProvider.getDomainId(targetChain),
-        amount: inputRequired,
-        type: 'inventory_movement',
+      await this.actionTracker.updateRebalanceActionExecution(action.id, {
         txHash: result.txHash,
         externalBridgeTransferId: result.transferId,
-        externalBridgeId: externalBridgeType,
       });
 
       // Track consumed inventory on source chain for this cycle

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1344,22 +1344,24 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     assert(sourceToken, `No token found for source chain: ${sourceChain}`);
     assert(targetToken, `No token found for target chain: ${targetChain}`);
 
-    // Convert HypNative token addresses to the external bridge's native token representation
-    const fromTokenAddress = getExternalBridgeTokenAddress(
-      sourceToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-    const toTokenAddress = getExternalBridgeTokenAddress(
-      targetToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-
-    const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
-    const targetChainId = Number(this.multiProvider.getChainId(targetChain));
-
     try {
+      // Resolve the actual asset used by the external bridge.
+      const fromTokenAddress = await getExternalBridgeTokenAddress(
+        sourceToken,
+        this.warpCore.multiProvider,
+        externalBridgeType,
+        this.getNativeTokenAddress.bind(this),
+      );
+      const toTokenAddress = await getExternalBridgeTokenAddress(
+        targetToken,
+        this.warpCore.multiProvider,
+        externalBridgeType,
+        this.getNativeTokenAddress.bind(this),
+      );
+
+      const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
+      const targetChainId = Number(this.multiProvider.getChainId(targetChain));
+
       const externalBridge = this.getExternalBridge(externalBridgeType);
       const initialQuote = await externalBridge.quote({
         fromChain: sourceChainId,
@@ -1477,36 +1479,36 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       };
     }
 
-    // Get chain IDs for the external bridge (not domain IDs)
-    // Convert to number since getChainId can return string | number
-    const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
-    const targetChainId = Number(this.multiProvider.getChainId(targetChain));
-
-    // Convert HypNative token addresses to the external bridge's native token representation
-    // For HypNative tokens, addressOrDenom is the warp route contract, not the native token
-    const fromTokenAddress = getExternalBridgeTokenAddress(
-      sourceToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-
-    const toTokenAddress = getExternalBridgeTokenAddress(
-      targetToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-
-    this.logger.debug(
-      {
-        sourceTokenStandard: sourceToken.standard,
-        targetTokenStandard: targetToken.standard,
-        fromTokenAddress,
-        toTokenAddress,
-      },
-      'Resolved token addresses for LiFi bridge',
-    );
-
     try {
+      // Get chain IDs for the external bridge (not domain IDs).
+      const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
+      const targetChainId = Number(this.multiProvider.getChainId(targetChain));
+
+      // Resolve the actual asset used by the external bridge.
+      const fromTokenAddress = await getExternalBridgeTokenAddress(
+        sourceToken,
+        this.warpCore.multiProvider,
+        externalBridgeType,
+        this.getNativeTokenAddress.bind(this),
+      );
+
+      const toTokenAddress = await getExternalBridgeTokenAddress(
+        targetToken,
+        this.warpCore.multiProvider,
+        externalBridgeType,
+        this.getNativeTokenAddress.bind(this),
+      );
+
+      this.logger.debug(
+        {
+          sourceTokenStandard: sourceToken.standard,
+          targetTokenStandard: targetToken.standard,
+          fromTokenAddress,
+          toTokenAddress,
+        },
+        'Resolved token addresses for LiFi bridge',
+      );
+
       const externalBridge = this.getExternalBridge(externalBridgeType);
       const fromAddress = this.getInventorySignerAddress(sourceChain);
       const toAddress = this.getInventorySignerAddress(targetChain);

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -7,6 +7,7 @@ import Sinon from 'sinon';
 import { HyperlaneCore } from '@hyperlane-xyz/sdk';
 
 import type { Erc20ContractFactory } from '../bridges/erc20Approve.js';
+import { TokenBridgeStatusAdapterType } from '../config/types.js';
 import {
   TEST_ADDRESSES,
   buildTestMovableCollateralRoute,
@@ -18,6 +19,7 @@ import { Rebalancer } from './Rebalancer.js';
 
 type TestActionTracker = IActionTracker & {
   createRebalanceAction: Sinon.SinonStub;
+  updateRebalanceActionExecution: Sinon.SinonStub;
   failRebalanceIntent: Sinon.SinonStub;
 };
 
@@ -197,7 +199,7 @@ describe('Rebalancer', () => {
         ctx.warpCore,
         ctx.chainMetadata,
         ctx.tokensByChainName,
-        ctx.multiProvider as any,
+        ctx.multiProvider,
         createMockActionTracker(),
         testLogger,
       );
@@ -1014,6 +1016,71 @@ describe('Rebalancer', () => {
   });
 
   describe('result building', () => {
+    it('tracks LayerZero settlement without requiring a Dispatch event', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+      const dispatchStub = sandbox
+        .stub(HyperlaneCore, 'getDispatchedMessages')
+        .returns([]);
+      const actionTracker = createMockActionTracker();
+
+      const rebalancer = new Rebalancer(
+        ctx.warpCore,
+        ctx.chainMetadata,
+        ctx.tokensByChainName,
+        ctx.multiProvider as any,
+        actionTracker,
+        testLogger,
+      );
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({
+          statusAdapter: {
+            kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+            sourceEid: 30110,
+            destinationEid: 30420,
+            sourceOft: '0x1111111111111111111111111111111111111111',
+            destinationOft: '0x2222222222222222222222222222222222222222',
+          },
+        }),
+      ]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(results[0].messageId).to.equal('');
+      expect(results[0].externalExecutionRef).to.deep.include({
+        provider: TokenBridgeStatusAdapterType.LayerZeroScan,
+        kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+      });
+      expect(results[0].externalExecutionRef?.data.originTxHash).to.equal(
+        `0x${'11'.repeat(32)}`,
+      );
+      expect(
+        results[0].externalExecutionRef?.data.destinationRecipient,
+      ).to.equal(ctx.tokensByChainName.arbitrum.addressOrDenom);
+      expect(
+        results[0].externalExecutionRef?.data.minimumDestinationAmount,
+      ).to.equal(ethers.utils.parseEther('100').toString());
+      expect(dispatchStub.called).to.be.false;
+
+      const createAction = actionTracker.createRebalanceAction;
+      const updateAction = actionTracker.updateRebalanceActionExecution;
+      expect(createAction.calledOnce).to.be.true;
+      expect(
+        createAction.calledBefore(
+          // CAST: The test helper returns a Sinon stub behind MultiProvider's method type.
+          ctx.multiProvider.sendTransaction as Sinon.SinonStub,
+        ),
+      ).to.be.true;
+      expect(createAction.firstCall.args[0].messageId).to.be.undefined;
+      expect(createAction.firstCall.args[0].externalExecutionRef).to.be
+        .undefined;
+      expect(
+        updateAction.calledWithMatch('action-1', {
+          externalExecutionRef: results[0].externalExecutionRef,
+        }),
+      ).to.be.true;
+    });
+
     it('should include messageId when dispatch message found', async () => {
       const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
 
@@ -1045,12 +1112,13 @@ describe('Rebalancer', () => {
 
       sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([]);
 
+      const actionTracker = createMockActionTracker();
       const rebalancer = new Rebalancer(
         ctx.warpCore,
         ctx.chainMetadata,
         ctx.tokensByChainName,
         ctx.multiProvider as any,
-        createMockActionTracker(),
+        actionTracker,
         testLogger,
       );
 
@@ -1061,6 +1129,8 @@ describe('Rebalancer', () => {
       expect(results[0].success).to.be.false;
       expect(results[0].error).to.include('no Dispatch event found');
       expect(results[0].messageId).to.equal('');
+      expect(actionTracker.createRebalanceAction.calledOnce).to.be.true;
+      expect(actionTracker.failRebalanceIntent.called).to.be.false;
     });
 
     it('should include txHash in result', async () => {

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -6,7 +6,9 @@ import Sinon from 'sinon';
 
 import { HyperlaneCore } from '@hyperlane-xyz/sdk';
 
+import type { Erc20ContractFactory } from '../bridges/erc20Approve.js';
 import {
+  TEST_ADDRESSES,
   buildTestMovableCollateralRoute,
   createRebalancerTestContext,
 } from '../test/helpers.js';
@@ -53,6 +55,113 @@ function createMockActionTracker(): IActionTracker {
 chai.use(chaiAsPromised);
 
 const testLogger = pino({ level: 'silent' });
+
+interface TestApprovalTransaction {
+  hash: string;
+  wait: Sinon.SinonStub<[], Promise<{ status: number }>>;
+}
+
+class StatefulErc20Contract extends ethers.Contract {
+  allowanceValue: ethers.BigNumber;
+  readonly allowanceStub = Sinon.stub<
+    [string, string],
+    Promise<ethers.BigNumber>
+  >();
+  readonly approveStub = Sinon.stub<
+    [string, ethers.BigNumberish],
+    Promise<TestApprovalTransaction>
+  >();
+
+  constructor(
+    address: string,
+    signer: ethers.Signer,
+    initialAllowance: ethers.BigNumberish = 0,
+  ) {
+    super(address, [], signer);
+    this.allowanceValue = ethers.BigNumber.from(initialAllowance);
+    this.allowanceStub.callsFake(async () => this.allowanceValue);
+    this.approveStub.callsFake(async (_spender, amount) => {
+      const target = ethers.BigNumber.from(amount);
+      const wait = Sinon.stub<[], Promise<{ status: number }>>().callsFake(
+        async () => {
+          this.allowanceValue = target;
+          return { status: 1 };
+        },
+      );
+      return {
+        hash: `0xapproval${this.approveStub.callCount}`,
+        wait,
+      };
+    });
+  }
+
+  allowance(owner: string, spender: string): Promise<ethers.BigNumber> {
+    return this.allowanceStub(owner, spender);
+  }
+
+  approve(
+    spender: string,
+    amount: ethers.BigNumberish,
+  ): Promise<TestApprovalTransaction> {
+    return this.approveStub(spender, amount);
+  }
+}
+
+function createApprovalHarness(
+  initialAllowances: Record<string, ethers.BigNumberish> = {},
+  failingApprovalTokens: string[] = [],
+  failingCleanupTokens: string[] = [],
+): {
+  contractFactory: Erc20ContractFactory;
+  getContract: (token: string) => StatefulErc20Contract;
+} {
+  const contracts = new Map<string, StatefulErc20Contract>();
+  const contractFactory: Erc20ContractFactory = (token, _abi, signer) => {
+    const key = token.toLowerCase();
+    let contract = contracts.get(key);
+    if (!contract) {
+      contract = new StatefulErc20Contract(
+        token,
+        signer,
+        initialAllowances[key] ?? 0,
+      );
+      if (failingApprovalTokens.some((value) => value.toLowerCase() === key)) {
+        contract.approveStub.onCall(0).rejects(new Error('approval failed'));
+      } else if (
+        failingCleanupTokens.some((value) => value.toLowerCase() === key)
+      ) {
+        contract.approveStub.onCall(1).rejects(new Error('cleanup failed'));
+      }
+      contracts.set(key, contract);
+    }
+    return contract;
+  };
+
+  return {
+    contractFactory,
+    getContract: (token) => {
+      const contract = contracts.get(token.toLowerCase());
+      if (!contract) throw new Error(`No approval contract for ${token}`);
+      return contract;
+    },
+  };
+}
+
+function createApprovalRebalancer(
+  ctx: ReturnType<typeof createRebalancerTestContext>,
+  contractFactory: Erc20ContractFactory,
+): Rebalancer {
+  return new Rebalancer(
+    ctx.warpCore,
+    ctx.chainMetadata,
+    ctx.tokensByChainName,
+    ctx.multiProvider,
+    createMockActionTracker(),
+    testLogger,
+    undefined,
+    { contractFactory },
+  );
+}
 
 describe('Rebalancer', () => {
   let sandbox: Sinon.SinonSandbox;
@@ -420,6 +529,201 @@ describe('Rebalancer', () => {
       expect(
         ctx.adapters.ethereum.populateRebalanceTx.firstCall.args[1],
       ).to.equal(1_000_000_000_000_000_000n);
+    });
+  });
+
+  describe('collateral fee approvals', () => {
+    const collateralA = TEST_ADDRESSES.token;
+    const collateralB = TEST_ADDRESSES.polygon;
+
+    function stubSuccessfulSettlement(): void {
+      // CAST: tests only need the message ID consumed by buildResult.
+      sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([
+        {
+          id: '0xMessageId111111111111111111111111111111111111111111111111111111',
+        } as any,
+      ]);
+    }
+
+    function feeQuote(token: string, total: bigint) {
+      return [{ igpQuote: { addressOrDenom: token, amount: total } }];
+    }
+
+    it('approves the exact aggregate for a same-router batch', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
+        ethereum: {
+          wrappedTokenAddress: collateralA,
+          quotes: feeQuote(collateralA, 103n),
+        },
+      });
+      const harness = createApprovalHarness();
+      const rebalancer = createApprovalRebalancer(ctx, harness.contractFactory);
+      stubSuccessfulSettlement();
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({ amount: 100n }),
+        buildTestMovableCollateralRoute({ amount: 100n }),
+      ]);
+
+      expect(results.every((result) => result.success)).to.equal(true);
+      const amounts = harness
+        .getContract(collateralA)
+        .approveStub.getCalls()
+        .map((call) => ethers.BigNumber.from(call.args[1]).toString());
+      expect(amounts).to.deep.equal(['6', '0']);
+      expect(amounts).not.to.include(ethers.constants.MaxUint256.toString());
+    });
+
+    it('zero-resets a prior allowance before setting the exact fee', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
+        ethereum: {
+          wrappedTokenAddress: collateralA,
+          quotes: feeQuote(collateralA, 103n),
+        },
+      });
+      const harness = createApprovalHarness({
+        [collateralA.toLowerCase()]: 99,
+      });
+      const rebalancer = createApprovalRebalancer(ctx, harness.contractFactory);
+      stubSuccessfulSettlement();
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({ amount: 100n }),
+      ]);
+
+      expect(results[0].success).to.equal(true);
+      const amounts = harness
+        .getContract(collateralA)
+        .approveStub.getCalls()
+        .map((call) => ethers.BigNumber.from(call.args[1]).toString());
+      expect(amounts).to.deep.equal(['0', '3', '0']);
+    });
+
+    it('cleans approval residue when a higher quote fails estimation', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
+        ethereum: {
+          wrappedTokenAddress: collateralA,
+          quotes: feeQuote(collateralA, 103n),
+        },
+      });
+      ctx.multiProvider.estimateGas = Sinon.stub().rejects(
+        new Error('quote increased above exact allowance'),
+      );
+      const harness = createApprovalHarness();
+      const rebalancer = createApprovalRebalancer(ctx, harness.contractFactory);
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({ amount: 100n }),
+      ]);
+
+      expect(results[0].success).to.equal(false);
+      expect(results[0].error).to.include('quote increased');
+      const contract = harness.getContract(collateralA);
+      expect(contract.allowanceValue.isZero()).to.equal(true);
+      const amounts = contract.approveStub
+        .getCalls()
+        .map((call) => ethers.BigNumber.from(call.args[1]).toString());
+      expect(amounts).to.deep.equal(['3', '0']);
+    });
+
+    it('isolates one approval failure from another origin', async () => {
+      const ctx = createRebalancerTestContext(
+        ['ethereum', 'arbitrum', 'optimism'],
+        {
+          ethereum: {
+            wrappedTokenAddress: collateralA,
+            quotes: feeQuote(collateralA, 103n),
+          },
+          optimism: {
+            wrappedTokenAddress: collateralB,
+            quotes: feeQuote(collateralB, 104n),
+          },
+        },
+      );
+      const harness = createApprovalHarness({}, [collateralA]);
+      const rebalancer = createApprovalRebalancer(ctx, harness.contractFactory);
+      stubSuccessfulSettlement();
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({ amount: 100n }),
+        buildTestMovableCollateralRoute({
+          origin: 'optimism',
+          destination: 'arbitrum',
+          amount: 100n,
+        }),
+      ]);
+
+      const ethereumResult = results.find(
+        (result) => result.route.origin === 'ethereum',
+      );
+      const optimismResult = results.find(
+        (result) => result.route.origin === 'optimism',
+      );
+      expect(ethereumResult?.success).to.equal(false);
+      expect(ethereumResult?.error).to.include('approval failed');
+      expect(optimismResult?.success).to.equal(true);
+    });
+
+    it('revokes residue after a partial same-origin send failure', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
+        ethereum: {
+          wrappedTokenAddress: collateralA,
+          quotes: feeQuote(collateralA, 103n),
+        },
+      });
+      const harness = createApprovalHarness();
+      let sends = 0;
+      ctx.multiProvider.sendTransaction = Sinon.stub().callsFake(async () => {
+        sends += 1;
+        if (sends === 1) {
+          const contract = harness.getContract(collateralA);
+          contract.allowanceValue = contract.allowanceValue.sub(3);
+          return {
+            transactionHash:
+              '0xTxHash1111111111111111111111111111111111111111111111111111111111',
+            blockNumber: 100,
+            status: 1,
+          };
+        }
+        throw new Error('second send failed');
+      });
+      const rebalancer = createApprovalRebalancer(ctx, harness.contractFactory);
+      stubSuccessfulSettlement();
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({ amount: 100n }),
+        buildTestMovableCollateralRoute({ amount: 100n }),
+      ]);
+
+      expect(results.filter((result) => result.success)).to.have.lengthOf(1);
+      expect(results.filter((result) => !result.success)).to.have.lengthOf(1);
+      const contract = harness.getContract(collateralA);
+      expect(contract.allowanceValue.isZero()).to.equal(true);
+      const amounts = contract.approveStub
+        .getCalls()
+        .map((call) => ethers.BigNumber.from(call.args[1]).toString());
+      expect(amounts).to.deep.equal(['6', '0']);
+    });
+
+    it('does not replace a successful send result with cleanup failure', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
+        ethereum: {
+          wrappedTokenAddress: collateralA,
+          quotes: feeQuote(collateralA, 103n),
+        },
+      });
+      const harness = createApprovalHarness({}, [], [collateralA]);
+      const rebalancer = createApprovalRebalancer(ctx, harness.contractFactory);
+      stubSuccessfulSettlement();
+
+      const results = await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({ amount: 100n }),
+      ]);
+
+      expect(results[0].success).to.equal(true);
+      expect(harness.getContract(collateralA).allowanceValue.eq(3)).to.equal(
+        true,
+      );
     });
   });
 

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -16,14 +16,30 @@ import type { IActionTracker } from '../tracking/IActionTracker.js';
 
 import { Rebalancer } from './Rebalancer.js';
 
-function createMockActionTracker(): IActionTracker {
+type TestActionTracker = IActionTracker & {
+  createRebalanceAction: Sinon.SinonStub;
+  failRebalanceIntent: Sinon.SinonStub;
+};
+
+function createMockActionTracker(): TestActionTracker {
   return {
     initialize: Sinon.stub().resolves(),
     createRebalanceIntent: Sinon.stub().callsFake(async () => ({
       id: `intent-${Date.now()}`,
       status: 'not_started',
     })),
-    createRebalanceAction: Sinon.stub().resolves(),
+    createRebalanceAction: Sinon.stub().resolves({
+      id: 'action-1',
+      status: 'in_progress',
+      type: 'rebalance_message',
+      intentId: 'intent-1',
+      origin: 1,
+      destination: 2,
+      amount: 1n,
+      createdAt: 1,
+      updatedAt: 1,
+    }),
+    updateRebalanceActionExecution: Sinon.stub().resolves(),
     completeRebalanceAction: Sinon.stub().resolves(),
     failRebalanceAction: Sinon.stub().resolves(),
     completeRebalanceIntent: Sinon.stub().resolves(),
@@ -871,16 +887,16 @@ describe('Rebalancer', () => {
   describe('sendTransactionsForChain()', () => {
     it('should return error result when send fails', async () => {
       const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
-      ctx.multiProvider.sendTransaction = Sinon.stub().rejects(
-        new Error('Send failed'),
-      );
+      const sendTransaction = Sinon.stub().rejects(new Error('Send failed'));
+      ctx.multiProvider.sendTransaction = sendTransaction;
+      const actionTracker = createMockActionTracker();
 
       const rebalancer = new Rebalancer(
         ctx.warpCore,
         ctx.chainMetadata,
         ctx.tokensByChainName,
         ctx.multiProvider as any,
-        createMockActionTracker(),
+        actionTracker,
         testLogger,
       );
 
@@ -890,6 +906,9 @@ describe('Rebalancer', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.false;
       expect(results[0].error).to.include('Send failed');
+      expect(actionTracker.createRebalanceAction.calledBefore(sendTransaction))
+        .to.be.true;
+      expect(actionTracker.failRebalanceIntent.called).to.be.false;
     });
 
     it('should continue sending remaining transactions after one fails', async () => {

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -15,6 +15,13 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { eqAddress, isNullish, mapAllSettled } from '@hyperlane-xyz/utils';
 
+import {
+  Erc20ApprovalMode,
+  type Erc20ApprovalOptions,
+  approveErc20IfNeeded,
+  revokeErc20Approval,
+  revokeErc20ApprovalIfNeeded,
+} from '../bridges/erc20Approve.js';
 import type {
   IMovableCollateralRebalancer,
   MovableCollateralExecutionResult,
@@ -38,6 +45,13 @@ type InternalExecutionResult = MovableCollateralExecutionResult & {
 };
 
 type InternalRoute = MovableCollateralRoute & { intentId: string };
+type CollateralFeeApproval = NonNullable<
+  PreparedTransaction['collateralFeeApproval']
+>;
+type CollateralFeeApprovalGroup = CollateralFeeApproval & {
+  origin: ChainName;
+  transactions: PreparedTransaction[];
+};
 
 export class Rebalancer implements IMovableCollateralRebalancer {
   public readonly rebalancerType: RebalancerType = 'movableCollateral';
@@ -51,6 +65,10 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     private readonly actionTracker: IActionTracker,
     logger: Logger,
     private readonly metrics?: Metrics,
+    private readonly approvalOptions: Pick<
+      Erc20ApprovalOptions,
+      'contractFactory'
+    > = {},
   ) {
     this.logger = logger.child({ class: Rebalancer.name });
   }
@@ -307,6 +325,14 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       return null;
     }
 
+    const collateralFeeApproval =
+      await this.getCollateralFeeApprovalRequirement(
+        originHypAdapter,
+        originToken.addressOrDenom,
+        quotes,
+        localAmount,
+      );
+
     // 3. Populate transaction
     let populatedTx: PopulatedTransaction;
     try {
@@ -330,7 +356,41 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       return null;
     }
 
-    return { populatedTx, route, originTokenAmount };
+    return {
+      populatedTx,
+      route,
+      originTokenAmount,
+      collateralFeeApproval,
+    };
+  }
+
+  private async getCollateralFeeApprovalRequirement(
+    originHypAdapter: EvmMovableCollateralAdapter,
+    router: string,
+    quotes: InterchainGasQuote[],
+    localAmount: bigint,
+  ): Promise<PreparedTransaction['collateralFeeApproval']> {
+    if (quotes.every((quote) => !quote.igpQuote.addressOrDenom)) {
+      return undefined;
+    }
+
+    const collateralToken = await originHypAdapter.getWrappedTokenAddress();
+    const quotedCollateral = quotes.reduce(
+      (total, quote) =>
+        quote.igpQuote.addressOrDenom &&
+        eqAddress(quote.igpQuote.addressOrDenom, collateralToken)
+          ? total + quote.igpQuote.amount
+          : total,
+      0n,
+    );
+
+    if (quotedCollateral <= localAmount) return undefined;
+
+    return {
+      token: collateralToken,
+      spender: router,
+      amount: quotedCollateral - localAmount,
+    };
   }
 
   private async validateRoute(route: InternalRoute): Promise<boolean> {
@@ -448,6 +508,37 @@ export class Rebalancer implements IMovableCollateralRebalancer {
   private async executeTransactions(
     transactions: PreparedTransaction[],
   ): Promise<InternalExecutionResult[]> {
+    const approvalGroups = this.groupCollateralFeeApprovals(transactions);
+    const { failures: approvalFailures, failedGroups } =
+      await this.approveCollateralFeeGroups(approvalGroups);
+    const approvedTransactions = transactions.filter(
+      (transaction) => !approvalFailures.has(transaction),
+    );
+    const approvalFailureResults: InternalExecutionResult[] = Array.from(
+      approvalFailures.entries(),
+      ([transaction, error]) => ({
+        route: transaction.route,
+        intentId: transaction.route.intentId,
+        success: false,
+        error: `Collateral fee approval failed: ${String(error)}`,
+        messageId: '',
+      }),
+    );
+
+    try {
+      const executionResults =
+        approvedTransactions.length === 0
+          ? []
+          : await this.executeApprovedTransactions(approvedTransactions);
+      return [...approvalFailureResults, ...executionResults];
+    } finally {
+      await this.cleanupCollateralFeeGroups(approvalGroups, failedGroups);
+    }
+  }
+
+  private async executeApprovedTransactions(
+    transactions: PreparedTransaction[],
+  ): Promise<InternalExecutionResult[]> {
     this.logger.info(
       { numTransactions: transactions.length },
       'Estimating gas for all prepared transactions.',
@@ -455,7 +546,8 @@ export class Rebalancer implements IMovableCollateralRebalancer {
 
     const results: InternalExecutionResult[] = [];
 
-    // 1. Estimate gas for rebalance transactions
+    // The exact allowance deliberately makes a higher on-chain quote fail.
+    // A later cycle will fetch a fresh quote; this cycle never widens it.
     const gasEstimateResults = await Promise.allSettled(
       transactions.map(async (transaction) => {
         await this.multiProvider.estimateGas(
@@ -466,7 +558,6 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       }),
     );
 
-    // 2. Filter out failed transactions and track failures
     const validTransactions: PreparedTransaction[] = [];
     gasEstimateResults.forEach((result, i) => {
       if (result.status === 'fulfilled') {
@@ -489,7 +580,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
           intentId: failedTransaction.route.intentId,
           success: false,
           error: `Gas estimation failed: ${String(result.reason)}`,
-          messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
+          messageId: '',
         });
       }
     });
@@ -499,17 +590,14 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       return results;
     }
 
-    // 3. Group transactions by origin chain
     const txsByOrigin = new Map<ChainName, PreparedTransaction[]>();
     for (const tx of validTransactions) {
       const origin = tx.route.origin;
-      if (!txsByOrigin.has(origin)) {
-        txsByOrigin.set(origin, []);
-      }
-      txsByOrigin.get(origin)!.push(tx);
+      const originTransactions = txsByOrigin.get(origin);
+      if (originTransactions) originTransactions.push(tx);
+      else txsByOrigin.set(origin, [tx]);
     }
 
-    // 4. Send transactions - parallel across chains, sequential within each chain
     this.logger.info(
       {
         numChains: txsByOrigin.size,
@@ -523,8 +611,6 @@ export class Rebalancer implements IMovableCollateralRebalancer {
         this.sendTransactionsForChain(origin, txs),
       ),
     );
-
-    // 5. Collect successful sends and record send failures
     const successfulSends: Array<{
       transaction: PreparedTransaction;
       receipt: providers.TransactionReceipt;
@@ -541,7 +627,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
               intentId: txResult.transaction.route.intentId,
               success: false,
               error: `Transaction send failed: ${txResult.error}`,
-              messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
+              messageId: '',
             });
             this.metrics?.recordActionAttempt(
               txResult.transaction.route,
@@ -550,8 +636,6 @@ export class Rebalancer implements IMovableCollateralRebalancer {
           }
         }
       } else {
-        // This shouldn't happen since sendTransactionsForChain catches errors internally,
-        // but handle it just in case
         this.logger.error(
           { error: chainResult.reason },
           'Unexpected error during chain transaction sending.',
@@ -559,7 +643,6 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       }
     });
 
-    // 6. Build results from confirmed receipts
     for (const { transaction, receipt } of successfulSends) {
       const result = this.buildResult(transaction, receipt);
       results.push(result);
@@ -567,6 +650,142 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     }
 
     return results;
+  }
+
+  private groupCollateralFeeApprovals(
+    transactions: PreparedTransaction[],
+  ): Map<ChainName, CollateralFeeApprovalGroup[]> {
+    const groupsByOrigin = new Map<
+      ChainName,
+      Map<string, CollateralFeeApprovalGroup>
+    >();
+
+    for (const transaction of transactions) {
+      const approval = transaction.collateralFeeApproval;
+      if (!approval) continue;
+
+      const origin = transaction.route.origin;
+      let originGroups = groupsByOrigin.get(origin);
+      if (!originGroups) {
+        originGroups = new Map();
+        groupsByOrigin.set(origin, originGroups);
+      }
+
+      const key = `${approval.token.toLowerCase()}:${approval.spender.toLowerCase()}`;
+      const group = originGroups.get(key);
+      if (group) {
+        group.amount += approval.amount;
+        group.transactions.push(transaction);
+      } else {
+        originGroups.set(key, {
+          ...approval,
+          origin,
+          transactions: [transaction],
+        });
+      }
+    }
+
+    return new Map(
+      Array.from(groupsByOrigin, ([origin, groups]) => [
+        origin,
+        Array.from(groups.values()),
+      ]),
+    );
+  }
+
+  private async approveCollateralFeeGroups(
+    groupsByOrigin: Map<ChainName, CollateralFeeApprovalGroup[]>,
+  ): Promise<{
+    failures: Map<PreparedTransaction, unknown>;
+    failedGroups: Set<CollateralFeeApprovalGroup>;
+  }> {
+    const failures = new Map<PreparedTransaction, unknown>();
+    const failedGroups = new Set<CollateralFeeApprovalGroup>();
+
+    await Promise.all(
+      Array.from(groupsByOrigin, async ([origin, groups]) => {
+        // Sequential per origin avoids approval nonce contention.
+        for (const group of groups) {
+          try {
+            await approveErc20IfNeeded(
+              this.multiProvider.getSigner(origin),
+              group.token,
+              group.spender,
+              group.amount,
+              this.logger,
+              {
+                ...this.approvalOptions,
+                mode: Erc20ApprovalMode.Exact,
+              },
+            );
+          } catch (error) {
+            failedGroups.add(group);
+            this.logger.error(
+              {
+                origin,
+                token: group.token,
+                spender: group.spender,
+                amount: group.amount.toString(),
+                error,
+              },
+              'Collateral fee approval failed',
+            );
+            for (const transaction of group.transactions) {
+              failures.set(transaction, error);
+            }
+          }
+        }
+      }),
+    );
+
+    return { failures, failedGroups };
+  }
+
+  private async cleanupCollateralFeeGroups(
+    groupsByOrigin: Map<ChainName, CollateralFeeApprovalGroup[]>,
+    failedGroups: Set<CollateralFeeApprovalGroup>,
+  ): Promise<void> {
+    await Promise.all(
+      Array.from(groupsByOrigin, async ([origin, groups]) => {
+        // Sequential per origin avoids cleanup nonce contention.
+        for (const group of groups) {
+          try {
+            const signer = this.multiProvider.getSigner(origin);
+            if (failedGroups.has(group)) {
+              // An approval receipt timeout is ambiguous. Queue a zero after
+              // the possibly pending approval instead of trusting a stale read.
+              await revokeErc20Approval(
+                signer,
+                group.token,
+                group.spender,
+                this.logger,
+                this.approvalOptions,
+              );
+            } else {
+              await revokeErc20ApprovalIfNeeded(
+                signer,
+                group.token,
+                group.spender,
+                this.logger,
+                this.approvalOptions,
+              );
+            }
+          } catch (error) {
+            // Execution results remain authoritative even if best-effort
+            // residue cleanup fails after a send or approval failure.
+            this.logger.error(
+              {
+                origin,
+                token: group.token,
+                spender: group.spender,
+                error,
+              },
+              'Failed to clean up collateral fee approval residue',
+            );
+          }
+        }
+      }),
+    );
   }
 
   // === Parallel Transaction Sending Methods ===

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -40,6 +40,7 @@ import {
 // Internal types with intentId for tracking
 type InternalExecutionResult = MovableCollateralExecutionResult & {
   intentId: string;
+  actionId?: string;
   canonicalAmount?: bigint;
   localAmount?: bigint;
 };
@@ -172,26 +173,26 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     for (const result of results) {
       const intentId = result.intentId;
 
-      if (result.success && result.messageId) {
-        await this.actionTracker.createRebalanceAction({
-          intentId,
-          origin: this.multiProvider.getDomainId(result.route.origin),
-          destination: this.multiProvider.getDomainId(result.route.destination),
-          amount: result.canonicalAmount ?? result.route.amount,
-          type: 'rebalance_message',
-          messageId: result.messageId,
-          txHash: result.txHash,
-        });
-
+      if (result.success && result.messageId && result.actionId) {
         this.logger.info(
           {
             intentId,
+            actionId: result.actionId,
             messageId: result.messageId,
             txHash: result.txHash,
             origin: result.route.origin,
             destination: result.route.destination,
           },
           'Rebalance action created successfully',
+        );
+      } else if (result.actionId) {
+        this.logger.warn(
+          {
+            intentId,
+            actionId: result.actionId,
+            error: result.error,
+          },
+          'Source execution may have started; action remains suppressed for this process lifetime',
         );
       } else {
         await this.actionTracker.failRebalanceIntent(intentId);
@@ -614,6 +615,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     const successfulSends: Array<{
       transaction: PreparedTransaction;
       receipt: providers.TransactionReceipt;
+      actionId: string;
     }> = [];
 
     chainSendResults.forEach((chainResult) => {
@@ -625,6 +627,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
             results.push({
               route: txResult.transaction.route,
               intentId: txResult.transaction.route.intentId,
+              actionId: txResult.actionId,
               success: false,
               error: `Transaction send failed: ${txResult.error}`,
               messageId: '',
@@ -643,8 +646,9 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       }
     });
 
-    for (const { transaction, receipt } of successfulSends) {
-      const result = this.buildResult(transaction, receipt);
+    // 6. Build results from confirmed receipts
+    for (const { transaction, receipt, actionId } of successfulSends) {
+      const result = await this.buildResult(transaction, receipt, actionId);
       results.push(result);
       this.metrics?.recordActionAttempt(result.route, result.success);
     }
@@ -802,26 +806,51 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       | {
           transaction: PreparedTransaction;
           receipt: providers.TransactionReceipt;
+          actionId: string;
         }
-      | { transaction: PreparedTransaction; error: string }
+      | {
+          transaction: PreparedTransaction;
+          error: string;
+          actionId?: string;
+        }
     >
   > {
     const results: Array<
       | {
           transaction: PreparedTransaction;
           receipt: providers.TransactionReceipt;
+          actionId: string;
         }
-      | { transaction: PreparedTransaction; error: string }
+      | {
+          transaction: PreparedTransaction;
+          error: string;
+          actionId?: string;
+        }
     > = [];
 
     // Send sequentially to avoid nonce contention
     for (const transaction of transactions) {
+      let actionId: string | undefined;
       try {
         const decimalFormattedAmount =
           transaction.originTokenAmount.getDecimalFormattedAmount();
         const tokenName = transaction.originTokenAmount.token.name;
 
         const reorgPeriod = this.getReorgPeriod(origin);
+
+        const action = await this.actionTracker.createRebalanceAction({
+          intentId: transaction.route.intentId,
+          origin: this.multiProvider.getDomainId(origin),
+          destination: this.multiProvider.getDomainId(
+            transaction.route.destination,
+          ),
+          amount: normalizeToCanonical(
+            transaction.originTokenAmount.amount,
+            transaction.originTokenAmount.token,
+          ),
+          type: 'rebalance_message',
+        });
+        actionId = action.id;
 
         this.logger.info(
           {
@@ -844,6 +873,10 @@ export class Rebalancer implements IMovableCollateralRebalancer {
           },
         );
 
+        await this.actionTracker.updateRebalanceActionExecution(actionId, {
+          txHash: receipt.transactionHash,
+        });
+
         this.logger.info(
           {
             origin,
@@ -855,7 +888,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
           'Rebalance transaction confirmed at reorgPeriod depth.',
         );
 
-        results.push({ transaction, receipt });
+        results.push({ transaction, receipt, actionId });
       } catch (error) {
         this.logger.error(
           {
@@ -867,7 +900,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
           },
           'Transaction send failed for route.',
         );
-        results.push({ transaction, error: String(error) });
+        results.push({ transaction, error: String(error), actionId });
       }
     }
 
@@ -878,10 +911,11 @@ export class Rebalancer implements IMovableCollateralRebalancer {
    * Build the execution result from a confirmed transaction receipt.
    * Receipt is already confirmed at reorgPeriod depth from sendTransaction.
    */
-  private buildResult(
+  private async buildResult(
     transaction: PreparedTransaction,
     receipt: providers.TransactionReceipt,
-  ): InternalExecutionResult {
+    actionId: string,
+  ): Promise<InternalExecutionResult> {
     const { origin, destination } = transaction.route;
     const dispatchedMessages = HyperlaneCore.getDispatchedMessages(receipt);
 
@@ -893,6 +927,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       return {
         route: transaction.route,
         intentId: transaction.route.intentId,
+        actionId,
         success: false,
         error: `Transaction confirmed but no Dispatch event found`,
         messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
@@ -900,9 +935,15 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       };
     }
 
+    await this.actionTracker.updateRebalanceActionExecution(actionId, {
+      messageId: dispatchedMessages[0].id,
+      txHash: receipt.transactionHash,
+    });
+
     return {
       route: transaction.route,
       intentId: transaction.route.intentId,
+      actionId,
       success: true,
       messageId: dispatchedMessages[0].id,
       txHash: receipt.transactionHash,

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -7,7 +7,6 @@ import {
   type ChainName,
   type EthJsonRpcBlockParameterTag,
   EvmMovableCollateralAdapter,
-  HyperlaneCore,
   type InterchainGasQuote,
   type MultiProvider,
   type Token,
@@ -22,6 +21,8 @@ import {
   revokeErc20Approval,
   revokeErc20ApprovalIfNeeded,
 } from '../bridges/erc20Approve.js';
+import { createStatusAdapters } from '../bridges/status/index.js';
+import { TokenBridgeStatusAdapterType } from '../config/types.js';
 import type {
   IMovableCollateralRebalancer,
   MovableCollateralExecutionResult,
@@ -29,6 +30,10 @@ import type {
   RebalancerType,
 } from '../interfaces/IRebalancer.js';
 import { MovableCollateralRoute } from '../interfaces/IStrategy.js';
+import type {
+  MCRStatusRef,
+  StatusAdaptersByKind,
+} from '../interfaces/ITokenBridgeStatusAdapter.js';
 import { type Metrics } from '../metrics/Metrics.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import type { RebalanceIntent } from '../tracking/types.js';
@@ -57,6 +62,7 @@ type CollateralFeeApprovalGroup = CollateralFeeApproval & {
 export class Rebalancer implements IMovableCollateralRebalancer {
   public readonly rebalancerType: RebalancerType = 'movableCollateral';
   private readonly logger: Logger;
+  private readonly statusAdaptersByKind: StatusAdaptersByKind;
 
   constructor(
     private readonly warpCore: WarpCore,
@@ -70,8 +76,11 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       Erc20ApprovalOptions,
       'contractFactory'
     > = {},
+    statusAdaptersByKind?: StatusAdaptersByKind,
   ) {
     this.logger = logger.child({ class: Rebalancer.name });
+    this.statusAdaptersByKind =
+      statusAdaptersByKind ?? createStatusAdapters(this.logger);
   }
 
   async rebalance(
@@ -173,17 +182,18 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     for (const result of results) {
       const intentId = result.intentId;
 
-      if (result.success && result.messageId && result.actionId) {
+      if (result.success && result.externalExecutionRef && result.actionId) {
         this.logger.info(
           {
             intentId,
             actionId: result.actionId,
             messageId: result.messageId,
+            statusAdapter: result.externalExecutionRef.kind,
             txHash: result.txHash,
             origin: result.route.origin,
             destination: result.route.destination,
           },
-          'Rebalance action created successfully',
+          'Rebalance action execution identity recorded',
         );
       } else if (result.actionId) {
         this.logger.warn(
@@ -220,6 +230,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       error: internal.error,
       messageId: internal.messageId || '', // Ensure messageId is always a string
       txHash: internal.txHash,
+      externalExecutionRef: internal.externalExecutionRef,
     }));
   }
 
@@ -917,27 +928,93 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     actionId: string,
   ): Promise<InternalExecutionResult> {
     const { origin, destination } = transaction.route;
-    const dispatchedMessages = HyperlaneCore.getDispatchedMessages(receipt);
+    const statusAdapterKind =
+      transaction.route.statusAdapter?.kind ??
+      TokenBridgeStatusAdapterType.HyperlaneMessage;
+    const statusAdapter = this.statusAdaptersByKind.get(statusAdapterKind);
 
-    if (dispatchedMessages.length === 0) {
+    if (!statusAdapter) {
       this.logger.error(
-        { origin, destination, txHash: receipt.transactionHash },
-        'No Dispatch event found in confirmed rebalance receipt',
+        { origin, destination, statusAdapterKind },
+        'No movable collateral status adapter registered',
       );
       return {
         route: transaction.route,
         intentId: transaction.route.intentId,
         actionId,
         success: false,
-        error: `Transaction confirmed but no Dispatch event found`,
+        error: `No status adapter registered for ${statusAdapterKind}`,
         messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
         txHash: receipt.transactionHash,
       };
     }
 
+    let externalExecutionRef: MCRStatusRef | null;
+    try {
+      externalExecutionRef = await statusAdapter.initFromReceipt({
+        origin,
+        destination,
+        originDomain: this.multiProvider.getDomainId(origin),
+        destinationDomain: this.multiProvider.getDomainId(destination),
+        bridge: transaction.route.bridge,
+        ...(transaction.route.statusAdapter?.kind ===
+        TokenBridgeStatusAdapterType.LayerZeroScan
+          ? {
+              sourceEid: transaction.route.statusAdapter.sourceEid,
+              destinationEid: transaction.route.statusAdapter.destinationEid,
+              sourceOft: transaction.route.statusAdapter.sourceOft,
+              destinationOft: transaction.route.statusAdapter.destinationOft,
+              destinationRecipient:
+                this.tokensByChainName[destination].addressOrDenom,
+              sourceTokenDecimals: this.tokensByChainName[origin].decimals,
+              destinationTokenDecimals:
+                this.tokensByChainName[destination].decimals,
+              minimumDestinationAmount: denormalizeToLocal(
+                normalizeToCanonical(
+                  transaction.originTokenAmount.amount,
+                  transaction.originTokenAmount.token,
+                ),
+                this.tokensByChainName[destination],
+              ),
+            }
+          : {}),
+        receipt,
+      });
+    } catch (error) {
+      this.logger.error(
+        { origin, destination, statusAdapterKind, error },
+        'Failed to initialize movable collateral settlement tracking',
+      );
+      externalExecutionRef = null;
+    }
+
+    if (!externalExecutionRef) {
+      const error =
+        statusAdapterKind === TokenBridgeStatusAdapterType.HyperlaneMessage
+          ? 'Transaction confirmed but no Dispatch event found'
+          : `Transaction confirmed but ${statusAdapterKind} settlement tracking could not be initialized`;
+      return {
+        route: transaction.route,
+        intentId: transaction.route.intentId,
+        actionId,
+        success: false,
+        error,
+        messageId: '',
+        txHash: receipt.transactionHash,
+      };
+    }
+
+    const messageId =
+      externalExecutionRef.kind ===
+        TokenBridgeStatusAdapterType.HyperlaneMessage &&
+      typeof externalExecutionRef.data.messageId === 'string'
+        ? externalExecutionRef.data.messageId
+        : '';
+
     await this.actionTracker.updateRebalanceActionExecution(actionId, {
-      messageId: dispatchedMessages[0].id,
+      messageId: messageId || undefined,
       txHash: receipt.transactionHash,
+      externalExecutionRef,
     });
 
     return {
@@ -945,8 +1022,9 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       intentId: transaction.route.intentId,
       actionId,
       success: true,
-      messageId: dispatchedMessages[0].id,
+      messageId,
       txHash: receipt.transactionHash,
+      externalExecutionRef,
       canonicalAmount: normalizeToCanonical(
         transaction.originTokenAmount.amount,
         transaction.originTokenAmount.token,

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -67,7 +67,13 @@ function createMockStrategy(): IStrategy & {
   };
 }
 
-function createMockActionTracker(): IActionTracker {
+type TestActionTracker = IActionTracker & {
+  syncRebalanceIntents: Sinon.SinonStub;
+  syncRebalanceActions: Sinon.SinonStub;
+  syncInventoryMovementActions: Sinon.SinonStub;
+};
+
+function createMockActionTracker(): TestActionTracker {
   return {
     initialize: Sinon.stub().resolves(),
     createRebalanceIntent: Sinon.stub().callsFake(async () => ({
@@ -75,6 +81,7 @@ function createMockActionTracker(): IActionTracker {
       status: 'not_started',
     })),
     createRebalanceAction: Sinon.stub().resolves(),
+    updateRebalanceActionExecution: Sinon.stub().resolves(),
     completeRebalanceAction: Sinon.stub().resolves(),
     failRebalanceAction: Sinon.stub().resolves(),
     completeRebalanceIntent: Sinon.stub().resolves(),
@@ -723,14 +730,19 @@ describe('RebalancerOrchestrator', () => {
 
       await orchestrator.executeCycle(event);
 
+      expect(actionTracker.syncInventoryMovementActions.calledOnce).to.be.true;
       expect(
-        (actionTracker.syncInventoryMovementActions as Sinon.SinonStub)
-          .calledOnce,
+        actionTracker.syncInventoryMovementActions.calledWith({ lifi: bridge }),
       ).to.be.true;
       expect(
-        (
-          actionTracker.syncInventoryMovementActions as Sinon.SinonStub
-        ).calledWith({ lifi: bridge }),
+        actionTracker.syncRebalanceActions.calledBefore(
+          actionTracker.syncRebalanceIntents,
+        ),
+      ).to.be.true;
+      expect(
+        actionTracker.syncInventoryMovementActions.calledBefore(
+          actionTracker.syncRebalanceIntents,
+        ),
       ).to.be.true;
     });
   });

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -157,7 +157,6 @@ export class RebalancerOrchestrator {
     try {
       await Promise.all([
         this.actionTracker.syncTransfers(confirmedBlockTags),
-        this.actionTracker.syncRebalanceIntents(),
         this.actionTracker.syncRebalanceActions(confirmedBlockTags),
       ]);
 
@@ -167,6 +166,10 @@ export class RebalancerOrchestrator {
           this.externalBridgeRegistry,
         );
       }
+
+      // Settle actions before expiring intents so source-started sends cannot be
+      // released by TTL while their latest delivery state is still being fetched.
+      await this.actionTracker.syncRebalanceIntents();
 
       await this.actionTracker.logStoreContents();
     } catch (error) {

--- a/typescript/rebalancer/src/core/RebalancerService.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.test.ts
@@ -112,6 +112,7 @@ function createMockActionTracker(): IActionTracker {
       status: 'not_started',
     })),
     createRebalanceAction: Sinon.stub().resolves(),
+    updateRebalanceActionExecution: Sinon.stub().resolves(),
     completeRebalanceAction: Sinon.stub().resolves(),
     failRebalanceAction: Sinon.stub().resolves(),
     completeRebalanceIntent: Sinon.stub().resolves(),

--- a/typescript/rebalancer/src/core/RebalancerService.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.ts
@@ -10,6 +10,7 @@ import { ProtocolType, assert } from '@hyperlane-xyz/utils';
 
 import { RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
+  type ExternalBridgeType,
   getStrategyChainConfig,
   getStrategyChainNames,
 } from '../config/types.js';
@@ -49,6 +50,9 @@ export interface RebalancerServiceConfig {
 
   /** CoinGecko API key for token price fetching (required for metrics) */
   coingeckoApiKey?: string;
+
+  /** API keys for configured external bridge providers */
+  externalBridgeApiKeys?: Partial<Record<ExternalBridgeType, string>>;
 
   /** Logger instance */
   logger: Logger;
@@ -156,6 +160,7 @@ export class RebalancerService {
       this.registry,
       this.logger,
       this.inventorySignerKeysByProtocol,
+      this.config.externalBridgeApiKeys,
     );
 
     // Create metrics if enabled

--- a/typescript/rebalancer/src/core/RebalancerService.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.ts
@@ -297,6 +297,9 @@ export class RebalancerService {
     // Use destination-specific bridge override if configured, otherwise use default
     const bridge =
       originConfig.override?.[destination]?.bridge ?? originConfig.bridge;
+    const statusAdapter =
+      originConfig.override?.[destination]?.statusAdapter ??
+      originConfig.statusAdapter;
 
     try {
       const manualRoute: MovableCollateralRoute & { intentId: string } = {
@@ -305,6 +308,7 @@ export class RebalancerService {
         amount: normalizeConfiguredAmount(amount, originToken),
         executionType: 'movableCollateral',
         bridge,
+        statusAdapter,
         intentId: `manual-${Date.now()}`,
       };
       await this.rebalancer.rebalance([manualRoute]);

--- a/typescript/rebalancer/src/e2e/harness/TestRebalancer.ts
+++ b/typescript/rebalancer/src/e2e/harness/TestRebalancer.ts
@@ -349,6 +349,7 @@ export class TestRebalancerBuilder {
       registry,
       this.logger,
       undefined,
+      undefined,
       warpCoreConfig,
     );
 

--- a/typescript/rebalancer/src/e2e/inventory-erc20-minAmount.e2e-test.ts
+++ b/typescript/rebalancer/src/e2e/inventory-erc20-minAmount.e2e-test.ts
@@ -437,7 +437,7 @@ describe('Erc20 InventoryMinAmountStrategy E2E', function () {
     expect(finalIntent!.status).to.equal('complete');
   });
 
-  it('retries after bridge execution failure', async function () {
+  it('suppresses retry after an ambiguous bridge execution failure', async function () {
     const context = await new TestRebalancerBuilder(
       deploymentManager,
       multiProvider,
@@ -455,108 +455,32 @@ describe('Erc20 InventoryMinAmountStrategy E2E', function () {
       .withExecutionMode('execute')
       .build();
 
-    const initialBalances = await getErc20RouterBalances(
-      localProviders,
-      erc20DeployedAddresses,
-    );
-
-    // Cycle 1: Bridge fails — intent created but stays not_started, no actions
+    // A thrown execute call may have broadcast before losing its response.
+    // Keep the source-started action suppressed until this process restarts.
     mockBridge.failNextExecute();
     await executeCycle(context);
 
     const activeIntents = await context.tracker.getActiveRebalanceIntents();
-    expect(activeIntents.length).to.equal(0);
+    expect(activeIntents).to.have.lengthOf(1);
+    expect(activeIntents[0].status).to.equal('in_progress');
 
     const partialIntents =
       await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(partialIntents.length).to.equal(1);
-    expect(partialIntents[0].intent.status).to.equal('not_started');
-    expect(partialIntents[0].completedAmount).to.equal(0n);
-    expect(partialIntents[0].remaining).to.equal(expectedDeficit);
+    expect(partialIntents).to.be.empty;
 
-    const intentId = partialIntents[0].intent.id;
+    const intentId = activeIntents[0].id;
     const actionsAfterFailure =
       await context.tracker.getActionsForIntent(intentId);
-    expect(actionsAfterFailure.length).to.equal(0);
+    expect(actionsAfterFailure).to.have.lengthOf(1);
+    expect(actionsAfterFailure[0].type).to.equal('inventory_movement');
+    expect(actionsAfterFailure[0].status).to.equal('in_progress');
+    expect(actionsAfterFailure[0].txHash).to.be.undefined;
 
-    // Cycle 2: Bridge succeeds — creates movement, intent becomes in_progress
     await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
 
-    const cycle2Active = await context.tracker.getActiveRebalanceIntents();
-    expect(cycle2Active.length).to.equal(1);
-    const cycle2Partial =
-      await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(cycle2Partial.length).to.equal(1);
-
-    const cycle2Actions = await context.tracker.getActionsForIntent(intentId);
-    expect(cycle2Actions.length).to.equal(1);
-    const movementAction = cycle2Actions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(movementAction).to.exist;
-    expect(movementAction!.status).to.equal('complete');
-
-    const cycle2Intent = await context.tracker.getRebalanceIntent(intentId);
-    expect(cycle2Intent!.status).to.equal('in_progress');
-
-    // Cycle 3: Deposit completes the intent
-    await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
-
-    const completedIntent = await context.tracker.getRebalanceIntent(intentId);
-    expect(completedIntent!.status).to.equal('complete');
-
-    const finalActions = await context.tracker.getActionsForIntent(intentId);
-    expect(finalActions.length).to.equal(2);
-    const finalMovement = finalActions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(finalMovement).to.exist;
-    const depositAction = finalActions.find(
-      (a) => a.type === 'inventory_deposit',
-    );
-    expect(depositAction).to.exist;
-
-    const finalBalances = await getErc20RouterBalances(
-      localProviders,
-      erc20DeployedAddresses,
-    );
-    const { surplusChain, neutralChain } = classifyChains(
-      'anvil2',
-      depositAction!,
-    );
-
-    expect(
-      finalBalances.anvil2.gt(initialBalances.anvil2),
-      'Destination router balance should increase',
-    ).to.be.true;
-    expect(
-      finalBalances[surplusChain].lt(initialBalances[surplusChain]),
-      `Surplus router (${surplusChain}) balance should decrease`,
-    ).to.be.true;
-    if (neutralChain) {
-      expect(
-        finalBalances[neutralChain].eq(initialBalances[neutralChain]),
-        'Uninvolved router balance should remain unchanged',
-      ).to.be.true;
-    }
+    const actionsAfterSecondCycle =
+      await context.tracker.getActionsForIntent(intentId);
+    expect(actionsAfterSecondCycle).to.have.lengthOf(1);
   });
 
   it('enforces single active inventory intent when multiple deficit chains exist', async function () {

--- a/typescript/rebalancer/src/e2e/inventory-erc20-weighted.e2e-test.ts
+++ b/typescript/rebalancer/src/e2e/inventory-erc20-weighted.e2e-test.ts
@@ -391,7 +391,7 @@ describe('Erc20 Inventory WeightedStrategy E2E', function () {
     expect(completedIntent?.status).to.equal('complete');
   });
 
-  it('retries after bridge execution failure', async function () {
+  it('suppresses retry after an ambiguous bridge execution failure', async function () {
     const context = await new TestRebalancerBuilder(
       deploymentManager,
       multiProvider,
@@ -407,110 +407,32 @@ describe('Erc20 Inventory WeightedStrategy E2E', function () {
       .withBalances('ERC20_INVENTORY_WEIGHTED_IMBALANCED')
       .build();
 
-    const initialBalances = await getErc20RouterBalances(
-      localProviders,
-      erc20DeployedAddresses,
-    );
-
-    // Cycle 1: Bridge fails — intent created but stays not_started, no actions
+    // A thrown execute call may have broadcast before losing its response.
+    // Keep the source-started action suppressed until this process restarts.
     mockBridge.failNextExecute();
     await executeCycle(context);
 
     const activeIntents = await context.tracker.getActiveRebalanceIntents();
-    expect(activeIntents.length).to.equal(0);
+    expect(activeIntents).to.have.lengthOf(1);
+    expect(activeIntents[0].status).to.equal('in_progress');
 
     const partialIntents =
       await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(partialIntents.length).to.equal(1);
-    expect(partialIntents[0].intent.status).to.equal('not_started');
-    expect(partialIntents[0].completedAmount).to.equal(0n);
-    expect(partialIntents[0].remaining).to.equal(
-      ERC20_WEIGHTED_EXPECTED_DEFICIT_1000USDC.toBigInt(),
-    );
+    expect(partialIntents).to.be.empty;
 
-    const intentId = partialIntents[0].intent.id;
+    const intentId = activeIntents[0].id;
     const actionsAfterFailure =
       await context.tracker.getActionsForIntent(intentId);
-    expect(actionsAfterFailure.length).to.equal(0);
+    expect(actionsAfterFailure).to.have.lengthOf(1);
+    expect(actionsAfterFailure[0].type).to.equal('inventory_movement');
+    expect(actionsAfterFailure[0].status).to.equal('in_progress');
+    expect(actionsAfterFailure[0].txHash).to.be.undefined;
 
-    // Cycle 2: Bridge succeeds — creates movement, intent becomes in_progress
     await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
 
-    const cycle2Active = await context.tracker.getActiveRebalanceIntents();
-    expect(cycle2Active.length).to.equal(1);
-    const cycle2Partial =
-      await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(cycle2Partial.length).to.equal(1);
-
-    const cycle2Actions = await context.tracker.getActionsForIntent(intentId);
-    expect(cycle2Actions.length).to.equal(1);
-    const movementAction = cycle2Actions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(movementAction).to.exist;
-    expect(movementAction!.status).to.equal('complete');
-
-    const cycle2Intent = await context.tracker.getRebalanceIntent(intentId);
-    expect(cycle2Intent!.status).to.equal('in_progress');
-
-    // Cycle 3: Deposit completes the intent
-    await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
-
-    const completedIntent = await context.tracker.getRebalanceIntent(intentId);
-    expect(completedIntent!.status).to.equal('complete');
-
-    const finalActions = await context.tracker.getActionsForIntent(intentId);
-    expect(finalActions.length).to.equal(2);
-    const finalMovement = finalActions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(finalMovement).to.exist;
-    const depositAction = finalActions.find(
-      (a) => a.type === 'inventory_deposit',
-    );
-    expect(depositAction).to.exist;
-
-    const finalBalances = await getErc20RouterBalances(
-      localProviders,
-      erc20DeployedAddresses,
-    );
-    const { surplusChain, neutralChain } = classifyChains(
-      'anvil3',
-      depositAction!,
-    );
-
-    expect(
-      finalBalances.anvil3.gt(initialBalances.anvil3),
-      'Deficit router (anvil3) balance should increase',
-    ).to.be.true;
-    expect(
-      finalBalances[surplusChain].lt(initialBalances[surplusChain]),
-      `Surplus router (${surplusChain}) balance should decrease`,
-    ).to.be.true;
-    if (neutralChain) {
-      expect(
-        finalBalances[neutralChain].eq(initialBalances[neutralChain]),
-        'Uninvolved router balance should remain unchanged',
-      ).to.be.true;
-    }
+    const actionsAfterSecondCycle =
+      await context.tracker.getActionsForIntent(intentId);
+    expect(actionsAfterSecondCycle).to.have.lengthOf(1);
   });
 
   it('enforces single active inventory intent when multiple routes are proposed', async function () {

--- a/typescript/rebalancer/src/e2e/inventory-minAmount.e2e-test.ts
+++ b/typescript/rebalancer/src/e2e/inventory-minAmount.e2e-test.ts
@@ -436,7 +436,7 @@ describe('InventoryMinAmountStrategy E2E', function () {
     expect(finalIntent!.status).to.equal('complete');
   });
 
-  it('retries after bridge execution failure', async function () {
+  it('suppresses retry after an ambiguous bridge execution failure', async function () {
     const context = await new TestRebalancerBuilder(
       deploymentManager,
       multiProvider,
@@ -454,108 +454,32 @@ describe('InventoryMinAmountStrategy E2E', function () {
       .withExecutionMode('execute')
       .build();
 
-    const initialBalances = await getRouterBalances(
-      localProviders,
-      nativeDeployedAddresses,
-    );
-
-    // Cycle 1: Bridge fails — intent created but stays not_started, no actions
+    // A thrown execute call may have broadcast before losing its response.
+    // Keep the source-started action suppressed until this process restarts.
     mockBridge.failNextExecute();
     await executeCycle(context);
 
     const activeIntents = await context.tracker.getActiveRebalanceIntents();
-    expect(activeIntents.length).to.equal(0);
+    expect(activeIntents).to.have.lengthOf(1);
+    expect(activeIntents[0].status).to.equal('in_progress');
 
     const partialIntents =
       await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(partialIntents.length).to.equal(1);
-    expect(partialIntents[0].intent.status).to.equal('not_started');
-    expect(partialIntents[0].completedAmount).to.equal(0n);
-    expect(partialIntents[0].remaining).to.equal(expectedDeficit);
+    expect(partialIntents).to.be.empty;
 
-    const intentId = partialIntents[0].intent.id;
+    const intentId = activeIntents[0].id;
     const actionsAfterFailure =
       await context.tracker.getActionsForIntent(intentId);
-    expect(actionsAfterFailure.length).to.equal(0);
+    expect(actionsAfterFailure).to.have.lengthOf(1);
+    expect(actionsAfterFailure[0].type).to.equal('inventory_movement');
+    expect(actionsAfterFailure[0].status).to.equal('in_progress');
+    expect(actionsAfterFailure[0].txHash).to.be.undefined;
 
-    // Cycle 2: Bridge succeeds — creates movement, intent becomes in_progress
     await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
 
-    const cycle2Active = await context.tracker.getActiveRebalanceIntents();
-    expect(cycle2Active.length).to.equal(1);
-    const cycle2Partial =
-      await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(cycle2Partial.length).to.equal(1);
-
-    const cycle2Actions = await context.tracker.getActionsForIntent(intentId);
-    expect(cycle2Actions.length).to.equal(1);
-    const movementAction = cycle2Actions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(movementAction).to.exist;
-    expect(movementAction!.status).to.equal('complete');
-
-    const cycle2Intent = await context.tracker.getRebalanceIntent(intentId);
-    expect(cycle2Intent!.status).to.equal('in_progress');
-
-    // Cycle 3: Deposit completes the intent
-    await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
-
-    const completedIntent = await context.tracker.getRebalanceIntent(intentId);
-    expect(completedIntent!.status).to.equal('complete');
-
-    const finalActions = await context.tracker.getActionsForIntent(intentId);
-    expect(finalActions.length).to.equal(2);
-    const finalMovement = finalActions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(finalMovement).to.exist;
-    const depositAction = finalActions.find(
-      (a) => a.type === 'inventory_deposit',
-    );
-    expect(depositAction).to.exist;
-
-    const finalBalances = await getRouterBalances(
-      localProviders,
-      nativeDeployedAddresses,
-    );
-    const { surplusChain, neutralChain } = classifyChains(
-      'anvil2',
-      depositAction!,
-    );
-
-    expect(
-      finalBalances.anvil2.gt(initialBalances.anvil2),
-      'Destination router balance should increase',
-    ).to.be.true;
-    expect(
-      finalBalances[surplusChain].lt(initialBalances[surplusChain]),
-      `Surplus router (${surplusChain}) balance should decrease`,
-    ).to.be.true;
-    if (neutralChain) {
-      expect(
-        finalBalances[neutralChain].eq(initialBalances[neutralChain]),
-        'Uninvolved router balance should remain unchanged',
-      ).to.be.true;
-    }
+    const actionsAfterSecondCycle =
+      await context.tracker.getActionsForIntent(intentId);
+    expect(actionsAfterSecondCycle).to.have.lengthOf(1);
   });
 
   it('enforces single active inventory intent when multiple deficit chains exist', async function () {

--- a/typescript/rebalancer/src/e2e/inventory-weighted.e2e-test.ts
+++ b/typescript/rebalancer/src/e2e/inventory-weighted.e2e-test.ts
@@ -390,7 +390,7 @@ describe('Inventory WeightedStrategy E2E', function () {
     expect(completedIntent?.status).to.equal('complete');
   });
 
-  it('retries after bridge execution failure', async function () {
+  it('suppresses retry after an ambiguous bridge execution failure', async function () {
     const context = await new TestRebalancerBuilder(
       deploymentManager,
       multiProvider,
@@ -406,110 +406,32 @@ describe('Inventory WeightedStrategy E2E', function () {
       .withBalances('INVENTORY_WEIGHTED_IMBALANCED')
       .build();
 
-    const initialBalances = await getRouterBalances(
-      localProviders,
-      nativeDeployedAddresses,
-    );
-
-    // Cycle 1: Bridge fails — intent created but stays not_started, no actions
+    // A thrown execute call may have broadcast before losing its response.
+    // Keep the source-started action suppressed until this process restarts.
     mockBridge.failNextExecute();
     await executeCycle(context);
 
     const activeIntents = await context.tracker.getActiveRebalanceIntents();
-    expect(activeIntents.length).to.equal(0);
+    expect(activeIntents).to.have.lengthOf(1);
+    expect(activeIntents[0].status).to.equal('in_progress');
 
     const partialIntents =
       await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(partialIntents.length).to.equal(1);
-    expect(partialIntents[0].intent.status).to.equal('not_started');
-    expect(partialIntents[0].completedAmount).to.equal(0n);
-    expect(partialIntents[0].remaining).to.equal(
-      WEIGHTED_EXPECTED_DEFICIT_1ETH.toBigInt(),
-    );
+    expect(partialIntents).to.be.empty;
 
-    const intentId = partialIntents[0].intent.id;
+    const intentId = activeIntents[0].id;
     const actionsAfterFailure =
       await context.tracker.getActionsForIntent(intentId);
-    expect(actionsAfterFailure.length).to.equal(0);
+    expect(actionsAfterFailure).to.have.lengthOf(1);
+    expect(actionsAfterFailure[0].type).to.equal('inventory_movement');
+    expect(actionsAfterFailure[0].status).to.equal('in_progress');
+    expect(actionsAfterFailure[0].txHash).to.be.undefined;
 
-    // Cycle 2: Bridge succeeds — creates movement, intent becomes in_progress
     await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
 
-    const cycle2Active = await context.tracker.getActiveRebalanceIntents();
-    expect(cycle2Active.length).to.equal(1);
-    const cycle2Partial =
-      await context.tracker.getPartiallyFulfilledInventoryIntents();
-    expect(cycle2Partial.length).to.equal(1);
-
-    const cycle2Actions = await context.tracker.getActionsForIntent(intentId);
-    expect(cycle2Actions.length).to.equal(1);
-    const movementAction = cycle2Actions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(movementAction).to.exist;
-    expect(movementAction!.status).to.equal('complete');
-
-    const cycle2Intent = await context.tracker.getRebalanceIntent(intentId);
-    expect(cycle2Intent!.status).to.equal('in_progress');
-
-    // Cycle 3: Deposit completes the intent
-    await executeCycle(context);
-    await context.tracker.syncInventoryMovementActions({
-      [ExternalBridgeType.LiFi]: mockBridge,
-    });
-    await relayInProgressInventoryDeposits(
-      context,
-      localProviders,
-      multiProvider,
-      hyperlaneCore,
-    );
-
-    const completedIntent = await context.tracker.getRebalanceIntent(intentId);
-    expect(completedIntent!.status).to.equal('complete');
-
-    const finalActions = await context.tracker.getActionsForIntent(intentId);
-    expect(finalActions.length).to.equal(2);
-    const finalMovement = finalActions.find(
-      (a) => a.type === 'inventory_movement',
-    );
-    expect(finalMovement).to.exist;
-    const depositAction = finalActions.find(
-      (a) => a.type === 'inventory_deposit',
-    );
-    expect(depositAction).to.exist;
-
-    const finalBalances = await getRouterBalances(
-      localProviders,
-      nativeDeployedAddresses,
-    );
-    const { surplusChain, neutralChain } = classifyChains(
-      'anvil3',
-      depositAction!,
-    );
-
-    expect(
-      finalBalances.anvil3.gt(initialBalances.anvil3),
-      'Deficit router (anvil3) balance should increase',
-    ).to.be.true;
-    expect(
-      finalBalances[surplusChain].lt(initialBalances[surplusChain]),
-      `Surplus router (${surplusChain}) balance should decrease`,
-    ).to.be.true;
-    if (neutralChain) {
-      expect(
-        finalBalances[neutralChain].eq(initialBalances[neutralChain]),
-        'Uninvolved router balance should remain unchanged',
-      ).to.be.true;
-    }
+    const actionsAfterSecondCycle =
+      await context.tracker.getActionsForIntent(intentId);
+    expect(actionsAfterSecondCycle).to.have.lengthOf(1);
   });
 
   it('enforces single active inventory intent when multiple routes are proposed', async function () {

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -134,6 +134,7 @@ async function createFactory(
     createMockRegistry(),
     testLogger,
     undefined,
+    undefined,
     warpCoreConfig,
   );
 }

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -19,6 +19,7 @@ import {
   objMap,
 } from '@hyperlane-xyz/utils';
 
+import { DeBridgeBridge } from '../bridges/DeBridgeBridge.js';
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
@@ -641,6 +642,19 @@ export class RebalancerContextFactory {
                 integrator: lifiConfig.integrator,
                 defaultSlippage: lifiConfig.defaultSlippage,
                 chainMetadata: this.multiProvider.metadata,
+              },
+              this.logger,
+            );
+          }
+          break;
+        }
+        case ExternalBridgeType.DeBridge: {
+          const debridgeConfig = externalBridges?.debridge;
+          if (debridgeConfig) {
+            registry[ExternalBridgeType.DeBridge] = new DeBridgeBridge(
+              {
+                chainMetadata: this.multiProvider.metadata,
+                maxFeePercent: debridgeConfig.maxFeePercent,
               },
               this.logger,
             );

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -683,6 +683,8 @@ export class RebalancerContextFactory {
                 apiUrl: swapsxyzConfig.apiUrl,
                 defaultSlippage: swapsxyzConfig.defaultSlippage,
                 maxQuoteLossBps: swapsxyzConfig.maxQuoteLossBps,
+                maxSolanaNativeSpendLamports:
+                  swapsxyzConfig.maxSolanaNativeSpendLamports,
                 chainMetadata: this.multiProvider.metadata,
               },
               this.logger,

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -22,6 +22,7 @@ import {
 import { DeBridgeBridge } from '../bridges/DeBridgeBridge.js';
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { SwapsXyzBridge } from '../bridges/SwapsXyzBridge.js';
+import { createStatusAdapters } from '../bridges/status/index.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -42,6 +43,7 @@ import { RebalancerOrchestrator } from '../core/RebalancerOrchestrator.js';
 import type { ExternalBridgeRegistry } from '../interfaces/IExternalBridge.js';
 import type { IRebalancer } from '../interfaces/IRebalancer.js';
 import type { IStrategy } from '../interfaces/IStrategy.js';
+import type { StatusAdaptersByKind } from '../interfaces/ITokenBridgeStatusAdapter.js';
 import { Metrics } from '../metrics/Metrics.js';
 import { PriceGetter } from '../metrics/PriceGetter.js';
 import { type InventoryMonitorConfig, Monitor } from '../monitor/Monitor.js';
@@ -75,6 +77,8 @@ const DEFAULT_EXPLORER_URL =
   process.env.EXPLORER_API_URL || 'https://explorer4.hasura.app/v1/graphql';
 
 export class RebalancerContextFactory {
+  private readonly statusAdaptersByKind: StatusAdaptersByKind;
+
   /**
    * @param config - The rebalancer config
    * @param warpCore - An instance of `WarpCore` configured for the specified `warpRouteId`.
@@ -98,7 +102,9 @@ export class RebalancerContextFactory {
     private readonly externalBridgeApiKeys?: Partial<
       Record<ExternalBridgeType, string>
     >,
-  ) {}
+  ) {
+    this.statusAdaptersByKind = createStatusAdapters(this.logger);
+  }
 
   /**
    * @param config - The rebalancer config
@@ -310,6 +316,8 @@ export class RebalancerContextFactory {
       actionTracker,
       this.logger,
       metrics,
+      {},
+      this.statusAdaptersByKind,
     );
 
     return rebalancer;
@@ -405,6 +413,7 @@ export class RebalancerContextFactory {
       multiProtocolCore,
       trackerConfig,
       this.logger,
+      this.statusAdaptersByKind,
     );
 
     // 7. Create InflightContextAdapter

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -21,6 +21,7 @@ import {
 
 import { DeBridgeBridge } from '../bridges/DeBridgeBridge.js';
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
+import { SwapsXyzBridge } from '../bridges/SwapsXyzBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -94,6 +95,9 @@ export class RebalancerContextFactory {
     private readonly inventorySignerKeysByProtocol?: Partial<
       Record<ProtocolType, string>
     >,
+    private readonly externalBridgeApiKeys?: Partial<
+      Record<ExternalBridgeType, string>
+    >,
   ) {}
 
   /**
@@ -110,6 +114,7 @@ export class RebalancerContextFactory {
     registry: IRegistry,
     logger: Logger,
     inventorySignerKeysByProtocol?: Partial<Record<ProtocolType, string>>,
+    externalBridgeApiKeys?: Partial<Record<ExternalBridgeType, string>>,
     warpCoreConfigOverride?: WarpCoreConfig,
   ): Promise<RebalancerContextFactory> {
     logger.debug(
@@ -180,6 +185,7 @@ export class RebalancerContextFactory {
       registry,
       logger,
       inventorySignerKeysByProtocol,
+      externalBridgeApiKeys,
     );
   }
 
@@ -655,6 +661,29 @@ export class RebalancerContextFactory {
               {
                 chainMetadata: this.multiProvider.metadata,
                 maxFeePercent: debridgeConfig.maxFeePercent,
+              },
+              this.logger,
+            );
+          }
+          break;
+        }
+        case ExternalBridgeType.SwapsXyz: {
+          const swapsxyzConfig = externalBridges?.swapsxyz;
+          if (swapsxyzConfig) {
+            const apiKey =
+              this.externalBridgeApiKeys?.[ExternalBridgeType.SwapsXyz];
+            if (!apiKey) {
+              throw new Error(
+                'externalBridges.swapsxyz is configured but SWAPSXYZ_API_KEY is not set',
+              );
+            }
+            registry[ExternalBridgeType.SwapsXyz] = new SwapsXyzBridge(
+              {
+                apiKey,
+                apiUrl: swapsxyzConfig.apiUrl,
+                defaultSlippage: swapsxyzConfig.defaultSlippage,
+                maxQuoteLossBps: swapsxyzConfig.maxQuoteLossBps,
+                chainMetadata: this.multiProvider.metadata,
               },
               this.logger,
             );

--- a/typescript/rebalancer/src/index.ts
+++ b/typescript/rebalancer/src/index.ts
@@ -32,6 +32,8 @@ export {
   RebalancerStrategySchema,
   RebalancerWeightedChainConfigSchema,
   StrategyConfigSchema,
+  TokenBridgeStatusAdapterConfigSchema,
+  TokenBridgeStatusAdapterType,
 } from './config/types.js';
 export type {
   MinAmountStrategyConfig,
@@ -40,6 +42,7 @@ export type {
   RebalancerMinAmountChainConfig,
   RebalancerWeightedChainConfig,
   StrategyConfig,
+  TokenBridgeStatusAdapterConfig,
   WeightedStrategyConfig,
 } from './config/types.js';
 
@@ -89,6 +92,19 @@ export {
   MonitorStartError,
 } from './interfaces/IMonitor.js';
 export type { IMetrics } from './interfaces/IMetrics.js';
+export type {
+  ITokenBridgeStatusAdapter,
+  MCRExecutionContext,
+  MCRSettlementStatus,
+  MCRStatusPollContext,
+  MCRStatusRef,
+  StatusAdaptersByKind,
+} from './interfaces/ITokenBridgeStatusAdapter.js';
+
+export {
+  HyperlaneMessageStatusAdapter,
+  LzScanStatusAdapter,
+} from './bridges/status/index.js';
 
 // Utils
 export {

--- a/typescript/rebalancer/src/index.ts
+++ b/typescript/rebalancer/src/index.ts
@@ -112,6 +112,7 @@ export type {
   IActionTracker,
   CreateRebalanceIntentParams,
   CreateRebalanceActionParams,
+  UpdateRebalanceActionExecutionParams,
 } from './tracking/IActionTracker.js';
 export type {
   Transfer,

--- a/typescript/rebalancer/src/interfaces/IExternalBridge.ts
+++ b/typescript/rebalancer/src/interfaces/IExternalBridge.ts
@@ -90,7 +90,7 @@ export interface IExternalBridge {
 
   /**
    * Execute a bridge transfer using a previously obtained quote.
-   * Callers must persist the returned identity and poll getStatus() before
+   * Callers must record the returned identity and poll getStatus() before
    * treating the cross-chain transfer as settled.
    * @param quote - Quote obtained from quote()
    * @param privateKeys - Private keys keyed by ProtocolType (e.g., { [ProtocolType.Ethereum]: '0x...' })

--- a/typescript/rebalancer/src/interfaces/IExternalBridge.ts
+++ b/typescript/rebalancer/src/interfaces/IExternalBridge.ts
@@ -51,6 +51,9 @@ export interface BridgeQuote<R = unknown> {
 
 /**
  * Result of executing a bridge transfer.
+ * This includes a source transaction identity. Adapters may return immediately
+ * after broadcast or after additional bridge monitoring; callers must still
+ * use getStatus() to determine destination-chain settlement.
  */
 export interface BridgeTransferResult {
   txHash: string; // Origin chain transaction hash
@@ -87,6 +90,8 @@ export interface IExternalBridge {
 
   /**
    * Execute a bridge transfer using a previously obtained quote.
+   * Callers must persist the returned identity and poll getStatus() before
+   * treating the cross-chain transfer as settled.
    * @param quote - Quote obtained from quote()
    * @param privateKeys - Private keys keyed by ProtocolType (e.g., { [ProtocolType.Ethereum]: '0x...' })
    */
@@ -100,11 +105,13 @@ export interface IExternalBridge {
    * @param txHash - Origin chain transaction hash
    * @param fromChain - Source chain ID
    * @param toChain - Destination chain ID
+   * @param transferId - Optional bridge-specific transfer identifier
    */
   getStatus(
     txHash: string,
     fromChain: number,
     toChain: number,
+    transferId?: string,
   ): Promise<BridgeTransferStatus>;
 }
 

--- a/typescript/rebalancer/src/interfaces/IRebalancer.ts
+++ b/typescript/rebalancer/src/interfaces/IRebalancer.ts
@@ -3,6 +3,7 @@ import {
   type IToken,
   type TokenAmount,
 } from '@hyperlane-xyz/sdk';
+import type { Address } from '@hyperlane-xyz/utils';
 
 import {
   type InventoryRoute,
@@ -57,4 +58,10 @@ export type PreparedTransaction = {
   >;
   route: MovableCollateralRoute & { intentId: string };
   originTokenAmount: PreparedOriginTokenAmount;
+  /** Collateral-denominated bridge fee excess pulled from the rebalancer. */
+  collateralFeeApproval?: {
+    token: Address;
+    spender: Address;
+    amount: bigint;
+  };
 };

--- a/typescript/rebalancer/src/interfaces/IRebalancer.ts
+++ b/typescript/rebalancer/src/interfaces/IRebalancer.ts
@@ -10,6 +10,7 @@ import {
   type MovableCollateralRoute,
   type Route,
 } from './IStrategy.js';
+import type { MCRStatusRef } from './ITokenBridgeStatusAdapter.js';
 
 export type RebalancerType = 'movableCollateral' | 'inventory';
 
@@ -25,6 +26,7 @@ export interface ExecutionResult<R extends Route = Route> {
 
 export interface MovableCollateralExecutionResult extends ExecutionResult<MovableCollateralRoute> {
   messageId: string;
+  externalExecutionRef?: MCRStatusRef;
 }
 
 export interface InventoryExecutionResult extends ExecutionResult<InventoryRoute> {

--- a/typescript/rebalancer/src/interfaces/IStrategy.ts
+++ b/typescript/rebalancer/src/interfaces/IStrategy.ts
@@ -1,7 +1,10 @@
 import { type ChainMap, type ChainName } from '@hyperlane-xyz/sdk';
 import type { Address } from '@hyperlane-xyz/utils';
 
-import { ExternalBridgeType } from '../config/types.js';
+import {
+  ExternalBridgeType,
+  type TokenBridgeStatusAdapterConfig,
+} from '../config/types.js';
 import { ExecutionMethod } from '../tracking/types.js';
 
 export type RawBalances = ChainMap<bigint>;
@@ -27,6 +30,7 @@ export interface RouteWithContext extends Route {
 export interface MovableCollateralRoute extends Route {
   executionType: 'movableCollateral';
   bridge: Address;
+  statusAdapter?: TokenBridgeStatusAdapterConfig;
 }
 
 /**

--- a/typescript/rebalancer/src/interfaces/ITokenBridgeStatusAdapter.ts
+++ b/typescript/rebalancer/src/interfaces/ITokenBridgeStatusAdapter.ts
@@ -1,0 +1,60 @@
+import type { providers } from 'ethers';
+import type { Logger } from 'pino';
+
+import type { ChainName, MultiProtocolCore } from '@hyperlane-xyz/sdk';
+import type { Address, Domain } from '@hyperlane-xyz/utils';
+
+export interface MCRExecutionContext {
+  origin: ChainName;
+  destination: ChainName;
+  originDomain: Domain;
+  destinationDomain: Domain;
+  bridge: string;
+  sourceEid?: number;
+  destinationEid?: number;
+  sourceOft?: Address;
+  destinationOft?: Address;
+  destinationRecipient?: Address;
+  sourceTokenDecimals?: number;
+  destinationTokenDecimals?: number;
+  minimumDestinationAmount?: bigint;
+  receipt: providers.TransactionReceipt;
+}
+
+/** Adapter-owned, JSON-serializable settlement cursor stored on an action. */
+export interface MCRStatusRef {
+  provider: string;
+  kind: string;
+  data: Record<string, unknown>;
+}
+
+export type MCRSettlementStatus =
+  | { status: 'pending'; substatus?: string; ref?: MCRStatusRef }
+  | {
+      status: 'complete';
+      receivingTxHash?: string;
+      ref?: MCRStatusRef;
+    }
+  | { status: 'failed'; error?: string; ref?: MCRStatusRef }
+  | { status: 'not_found'; ref?: MCRStatusRef };
+
+export interface MCRStatusPollContext {
+  core: MultiProtocolCore;
+  destination: Domain;
+  blockTag?: string | number;
+}
+
+/** Verifies destination settlement for one movable-collateral bridge kind. */
+export interface ITokenBridgeStatusAdapter {
+  readonly kind: string;
+  readonly logger: Logger;
+
+  initFromReceipt(ctx: MCRExecutionContext): Promise<MCRStatusRef | null>;
+
+  pollStatus(
+    ref: MCRStatusRef,
+    ctx: MCRStatusPollContext,
+  ): Promise<MCRSettlementStatus>;
+}
+
+export type StatusAdaptersByKind = Map<string, ITokenBridgeStatusAdapter>;

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -12,6 +12,7 @@
  * - HYP_KEY: Fallback private key for HYP_REBALANCER_KEY (optional)
  * - HYP_INVENTORY_KEY_<PROTOCOL>: Private key for inventory operations per protocol (e.g., HYP_INVENTORY_KEY_ETHEREUM, HYP_INVENTORY_KEY_SEALEVEL)
  * - COINGECKO_API_KEY: API key for CoinGecko price fetching (optional, for metrics)
+ * - SWAPSXYZ_API_KEY: API key for swaps.xyz external bridge execution and status polling (optional)
  * - HYP_INVENTORY_KEY: Backward-compatible fallback for Ethereum inventory signer (optional, use HYP_INVENTORY_KEY_ETHEREUM preferentially)
  * - CHECK_FREQUENCY: Balance check frequency in ms (default: 60000)
  * - WITH_METRICS: Enable Prometheus metrics (default: "true")
@@ -39,6 +40,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { RebalancerConfig } from './config/RebalancerConfig.js';
+import { ExternalBridgeType } from './config/types.js';
 import { RebalancerService } from './core/RebalancerService.js';
 import { parseSolanaPrivateKey } from './utils/solanaKeyParser.js';
 import type { InventorySignerConfig } from './core/InventoryRebalancer.js';
@@ -96,6 +98,7 @@ async function main(): Promise<void> {
   const withMetrics = process.env.WITH_METRICS !== 'false';
   const monitorOnly = process.env.MONITOR_ONLY === 'true';
   const coingeckoApiKey = process.env.COINGECKO_API_KEY;
+  const swapsXyzApiKey = process.env.SWAPSXYZ_API_KEY;
 
   // Create logger (uses LOG_LEVEL environment variable for level configuration)
   const logger = await createServiceLogger({
@@ -263,6 +266,9 @@ async function main(): Promise<void> {
         monitorOnly,
         withMetrics,
         coingeckoApiKey,
+        externalBridgeApiKeys: swapsXyzApiKey
+          ? { [ExternalBridgeType.SwapsXyz]: swapsXyzApiKey }
+          : undefined,
         logger,
         version: VERSION,
       },

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -40,8 +40,9 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { RebalancerConfig } from './config/RebalancerConfig.js';
-import { ExternalBridgeType } from './config/types.js';
+import { ExternalBridgeType, getStrategyChainNames } from './config/types.js';
 import { RebalancerService } from './core/RebalancerService.js';
+import { configureRebalancerSigners } from './utils/rebalancerSigners.js';
 import { parseSolanaPrivateKey } from './utils/solanaKeyParser.js';
 import type { InventorySignerConfig } from './core/InventoryRebalancer.js';
 
@@ -141,13 +142,19 @@ async function main(): Promise<void> {
     // Apply RPC URL overrides from environment variables
     applyRpcUrlOverridesFromEnv(chainMetadata);
 
-    // Create MultiProvider with signer
+    // Create MultiProvider with protocol-specific signers for the shared key.
     const multiProvider = new MultiProvider(chainMetadata);
-    const rebalancerSigner = new Wallet(rebalancerPrivateKey);
-    multiProvider.setSharedSigner(rebalancerSigner);
+    const rebalancerSignerSetup = configureRebalancerSigners(
+      multiProvider,
+      getStrategyChainNames(rebalancerConfig.strategyConfig),
+      rebalancerPrivateKey,
+    );
     logger.info(
-      { rebalancerAddress: rebalancerSigner.address },
-      '✅ Initialized MultiProvider with rebalancer signer',
+      {
+        rebalancerAddress: rebalancerSignerSetup.address,
+        tronChains: rebalancerSignerSetup.tronChains,
+      },
+      '✅ Initialized MultiProvider with protocol-specific rebalancer signers',
     );
 
     // Build consolidated inventory signers with keys embedded

--- a/typescript/rebalancer/src/strategy/BaseStrategy.ts
+++ b/typescript/rebalancer/src/strategy/BaseStrategy.ts
@@ -506,6 +506,22 @@ export abstract class BaseStrategy implements IStrategy {
     actualBalances: RawBalances,
   ): StrategyRoute[] {
     return routes.filter((route) => {
+      const bridgeConfig = this.getBridgeConfigForRoute(
+        route.origin,
+        route.destination,
+      );
+      if (bridgeConfig.enabled === false) {
+        this.logger.info(
+          {
+            context: this.constructor.name,
+            origin: route.origin,
+            destination: route.destination,
+          },
+          'Dropping config-disabled route',
+        );
+        return false;
+      }
+
       const balance = actualBalances[route.origin] ?? 0n;
       if (balance < route.amount) {
         this.logger.warn(
@@ -524,10 +540,6 @@ export abstract class BaseStrategy implements IStrategy {
       if (this.tokensByChainName) {
         const token = this.tokensByChainName[route.origin];
         if (token) {
-          const bridgeConfig = this.getBridgeConfigForRoute(
-            route.origin,
-            route.destination,
-          );
           if (bridgeConfig.bridgeMinAcceptedAmount != null) {
             const minAmount = normalizeConfiguredAmount(
               bridgeConfig.bridgeMinAcceptedAmount,

--- a/typescript/rebalancer/src/strategy/StrategyFactory.ts
+++ b/typescript/rebalancer/src/strategy/StrategyFactory.ts
@@ -145,6 +145,7 @@ export class StrategyFactory {
           ...baseConfig,
           executionType: 'movableCollateral',
           bridge: config.bridge!, // Validated by config schema
+          statusAdapter: config.statusAdapter,
           override: config.override as ChainMap<
             Partial<MovableCollateralBridgeConfig>
           >,

--- a/typescript/rebalancer/src/strategy/StrategyFactory.ts
+++ b/typescript/rebalancer/src/strategy/StrategyFactory.ts
@@ -128,6 +128,7 @@ export class StrategyFactory {
     for (const [chain, config] of Object.entries(strategyConfig.chains)) {
       const baseConfig = {
         bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount ?? 0,
+        enabled: config.enabled ?? true,
       };
 
       const executionType =

--- a/typescript/rebalancer/src/strategy/WeightedStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/WeightedStrategy.test.ts
@@ -526,4 +526,29 @@ describe('WeightedStrategy', () => {
       );
     });
   });
+
+  it('filters a config-disabled chain pair', () => {
+    const config = {
+      [chain1]: {
+        weighted: { weight: 50n, tolerance: 0n },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+      [chain2]: {
+        weighted: { weight: 50n, tolerance: 0n },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+    };
+    const bridgeConfigs = extractBridgeConfigs(config);
+    bridgeConfigs[chain1].override = { [chain2]: { enabled: false } };
+    const strategy = new WeightedStrategy(config, testLogger, bridgeConfigs);
+
+    const routes = strategy.getRebalancingRoutes({
+      [chain1]: ethers.utils.parseEther('150').toBigInt(),
+      [chain2]: ethers.utils.parseEther('50').toBigInt(),
+    });
+
+    expect(routes).to.be.empty;
+  });
 });

--- a/typescript/rebalancer/src/test/helpers.ts
+++ b/typescript/rebalancer/src/test/helpers.ts
@@ -132,6 +132,7 @@ export interface MockAdapterConfig {
   isBridgeAllowed?: boolean;
   quotes?: InterchainGasQuote[];
   populatedTx?: PopulatedTransaction;
+  wrappedTokenAddress?: string;
   throwOnQuotes?: Error;
   throwOnPopulate?: Error;
 }
@@ -147,6 +148,7 @@ export function createMockAdapter(config: MockAdapterConfig = {}) {
       data: '0x',
       value: ethers.BigNumber.from(0),
     },
+    wrappedTokenAddress = TEST_ADDRESSES.token,
     throwOnQuotes,
     throwOnPopulate,
   } = config;
@@ -161,6 +163,7 @@ export function createMockAdapter(config: MockAdapterConfig = {}) {
     populateRebalanceTx: throwOnPopulate
       ? Sinon.stub().rejects(throwOnPopulate)
       : Sinon.stub().resolves(populatedTx),
+    getWrappedTokenAddress: Sinon.stub().resolves(wrappedTokenAddress),
   };
 
   Object.setPrototypeOf(adapter, EvmMovableCollateralAdapter.prototype);
@@ -231,6 +234,7 @@ export function createMockMultiProvider(config: MockMultiProviderConfig = {}) {
   };
 
   const mockSigner = {
+    _isSigner: true,
     getAddress: Sinon.stub().resolves(signerAddress),
     sendTransaction: throwOnSendTransaction
       ? Sinon.stub().rejects(throwOnSendTransaction)

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -276,6 +276,53 @@ describe('ActionTracker', () => {
       const intents = await rebalanceIntentStore.getAll();
       expect(intents).to.have.lengthOf(0);
     });
+
+    it('should link a restarted pre-send action by transaction hash', async () => {
+      const inflightMessage: ExplorerMessage = {
+        msg_id: '0xmsg1',
+        origin_domain_id: 1,
+        destination_domain_id: 2,
+        sender: '0xrouter1',
+        recipient: '0xrouter2',
+        origin_tx_hash: '0xtx1',
+        origin_tx_sender: '0xrebalancer',
+        origin_tx_recipient: '0xrouter1',
+        is_delivered: false,
+        message_body:
+          '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064',
+        send_occurred_at: null,
+      };
+      await rebalanceIntentStore.save({
+        id: 'intent-1',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await rebalanceActionStore.save({
+        id: 'reserved-action',
+        type: 'rebalance_message',
+        status: 'in_progress',
+        intentId: 'intent-1',
+        txHash: '0xTx1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      explorerClient.getInflightRebalanceActions.resolves([inflightMessage]);
+
+      await tracker.initialize();
+
+      const actions = await rebalanceActionStore.getAll();
+      expect(actions).to.have.lengthOf(1);
+      expect(actions[0].id).to.equal('reserved-action');
+      expect(actions[0].messageId).to.equal('0xmsg1');
+      expect(await rebalanceIntentStore.getAll()).to.have.lengthOf(1);
+    });
   });
 
   describe('syncTransfers', () => {
@@ -443,7 +490,7 @@ describe('ActionTracker', () => {
       expect(updated?.status).to.equal('in_progress');
     });
 
-    it('should mark unfulfilled intents as failed when TTL exceeded', async () => {
+    it('should preserve source-started intents when TTL exceeded', async () => {
       const intent: RebalanceIntent = {
         id: 'intent-1',
         status: 'in_progress',
@@ -473,10 +520,27 @@ describe('ActionTracker', () => {
       await tracker.syncRebalanceIntents();
 
       const updatedIntent = await rebalanceIntentStore.get('intent-1');
-      expect(updatedIntent?.status).to.equal('failed');
+      expect(updatedIntent?.status).to.equal('in_progress');
 
       const updatedAction = await rebalanceActionStore.get('action-1');
-      expect(updatedAction?.status).to.equal('failed');
+      expect(updatedAction?.status).to.equal('in_progress');
+    });
+
+    it('should fail expired intents that never started execution', async () => {
+      await rebalanceIntentStore.save({
+        id: 'intent-1',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now() - DEFAULT_INTENT_TTL_MS - 1,
+        updatedAt: Date.now(),
+      });
+
+      await tracker.syncRebalanceIntents();
+
+      const updatedIntent = await rebalanceIntentStore.get('intent-1');
+      expect(updatedIntent?.status).to.equal('failed');
     });
 
     it('should not expire intents within TTL', async () => {
@@ -1077,7 +1141,7 @@ describe('ActionTracker', () => {
       expect(partialIntents).to.have.lengthOf(0);
     });
 
-    it('fails stale movement and returns intent', async () => {
+    it('keeps stale not_found movement suppressed for the process lifetime', async () => {
       await rebalanceIntentStore.save({
         id: 'intent-stale-movement',
         status: 'in_progress',
@@ -1106,15 +1170,13 @@ describe('ActionTracker', () => {
 
       const partialIntents =
         await tracker.getPartiallyFulfilledInventoryIntents();
-      expect(partialIntents).to.have.lengthOf(1);
-      expect(partialIntents[0].intent.id).to.equal('intent-stale-movement');
+      expect(partialIntents).to.have.lengthOf(0);
 
-      // Verify the stale movement was failed
-      const failedAction = await rebalanceActionStore.get('movement-stale');
-      expect(failedAction?.status).to.equal('failed');
+      const action = await rebalanceActionStore.get('movement-stale');
+      expect(action?.status).to.equal('in_progress');
     });
 
-    it('fails stale movement with undefined lastBridgeStatus (pre-deploy data)', async () => {
+    it('keeps old movement with unknown status suppressed', async () => {
       await rebalanceIntentStore.save({
         id: 'intent-undefined-status',
         status: 'in_progress',
@@ -1141,12 +1203,12 @@ describe('ActionTracker', () => {
 
       const partialIntents =
         await tracker.getPartiallyFulfilledInventoryIntents();
-      expect(partialIntents).to.have.lengthOf(1);
+      expect(partialIntents).to.have.lengthOf(0);
 
       const action = await rebalanceActionStore.get(
         'movement-undefined-status',
       );
-      expect(action?.status).to.equal('failed');
+      expect(action?.status).to.equal('in_progress');
     });
 
     it('does not fail long-running pending movement', async () => {
@@ -1351,7 +1413,17 @@ describe('ActionTracker', () => {
       expect(updatedIntent?.status).to.equal('in_progress');
     });
 
-    it('persists external bridge transfer identifiers', async () => {
+    it('records external bridge transfer identifiers', async () => {
+      await rebalanceIntentStore.save({
+        id: 'intent-1',
+        status: 'not_started',
+        origin: 1,
+        destination: 2,
+        amount: 50n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
       const result = await tracker.createRebalanceAction({
         type: 'inventory_movement',
         intentId: 'intent-1',

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -9,7 +9,9 @@ import {
   DEFAULT_INTENT_TTL_MS,
   DEFAULT_MOVEMENT_STALENESS_MS,
   ExternalBridgeType,
+  TokenBridgeStatusAdapterType,
 } from '../config/types.js';
+import type { ITokenBridgeStatusAdapter } from '../interfaces/ITokenBridgeStatusAdapter.js';
 import type { ExplorerMessage } from '../utils/ExplorerClient.js';
 
 import { ActionTracker, type ActionTrackerConfig } from './ActionTracker.js';
@@ -526,6 +528,39 @@ describe('ActionTracker', () => {
       expect(updatedAction?.status).to.equal('in_progress');
     });
 
+    it('should preserve an expired intent after its inventory movement completes', async () => {
+      const oldTimestamp = Date.now() - DEFAULT_INTENT_TTL_MS - 1;
+      await rebalanceIntentStore.save({
+        id: 'intent-completed-movement',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        executionMethod: 'inventory',
+        createdAt: oldTimestamp,
+        updatedAt: oldTimestamp,
+      });
+      await rebalanceActionStore.save({
+        id: 'completed-movement',
+        status: 'complete',
+        type: 'inventory_movement',
+        intentId: 'intent-completed-movement',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: oldTimestamp,
+        updatedAt: oldTimestamp,
+      });
+
+      await tracker.syncRebalanceIntents();
+
+      expect(
+        (await rebalanceIntentStore.get('intent-completed-movement'))?.status,
+      ).to.equal('in_progress');
+      expect(await rebalanceActionStore.get('completed-movement')).to.not.be
+        .undefined;
+    });
+
     it('should fail expired intents that never started execution', async () => {
       await rebalanceIntentStore.save({
         id: 'intent-1',
@@ -564,6 +599,124 @@ describe('ActionTracker', () => {
   });
 
   describe('syncRebalanceActions', () => {
+    it('records an LZ ref and completes its parent intent after delivery', async () => {
+      const originalRef = {
+        provider: TokenBridgeStatusAdapterType.LayerZeroScan,
+        kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+        data: { originTxHash: '0xorigin' },
+      };
+      const refreshedRef = {
+        ...originalRef,
+        data: { ...originalRef.data, lastObservedStatus: 'DELIVERED' },
+      };
+      const pollStatus = Sinon.stub().resolves({
+        status: 'complete',
+        receivingTxHash: '0xdestination',
+        ref: refreshedRef,
+      });
+      const statusAdapter: ITokenBridgeStatusAdapter = {
+        kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+        logger: testLogger,
+        initFromReceipt: Sinon.stub(),
+        pollStatus,
+      };
+      tracker = new ActionTracker(
+        transferStore,
+        rebalanceIntentStore,
+        rebalanceActionStore,
+        explorerClient,
+        core,
+        config,
+        testLogger,
+        new Map([[statusAdapter.kind, statusAdapter]]),
+      );
+
+      const intent = await tracker.createRebalanceIntent({
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+      });
+      const action = await tracker.createRebalanceAction({
+        intentId: intent.id,
+        type: 'rebalance_message',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        txHash: '0xorigin',
+        externalExecutionRef: originalRef,
+      });
+
+      expect(
+        (await rebalanceActionStore.get(action.id))?.externalExecutionRef,
+      ).to.deep.equal(originalRef);
+
+      await tracker.syncRebalanceActions();
+
+      const updatedAction = await rebalanceActionStore.get(action.id);
+      expect(updatedAction?.status).to.equal('complete');
+      expect(updatedAction?.externalExecutionRef).to.deep.equal(refreshedRef);
+      expect(updatedAction?.destinationTxHash).to.equal('0xdestination');
+      expect((await rebalanceIntentStore.get(intent.id))?.status).to.equal(
+        'complete',
+      );
+      expect(pollStatus.calledOnceWith(originalRef)).to.be.true;
+      expect(mailboxStub.isDelivered.called).to.be.false;
+    });
+
+    it('keeps a source-committed LZ failure suppressed for the process lifetime', async () => {
+      const ref = {
+        provider: TokenBridgeStatusAdapterType.LayerZeroScan,
+        kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+        data: { originTxHash: '0xorigin' },
+      };
+      const statusAdapter: ITokenBridgeStatusAdapter = {
+        kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+        logger: testLogger,
+        initFromReceipt: Sinon.stub(),
+        pollStatus: Sinon.stub().resolves({
+          status: 'failed',
+          error: 'lz_blocked',
+          ref,
+        }),
+      };
+      tracker = new ActionTracker(
+        transferStore,
+        rebalanceIntentStore,
+        rebalanceActionStore,
+        explorerClient,
+        core,
+        config,
+        testLogger,
+        new Map([[statusAdapter.kind, statusAdapter]]),
+      );
+
+      const intent = await tracker.createRebalanceIntent({
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+      });
+      const action = await tracker.createRebalanceAction({
+        intentId: intent.id,
+        type: 'rebalance_message',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        externalExecutionRef: ref,
+      });
+
+      await tracker.syncRebalanceActions();
+
+      expect((await rebalanceActionStore.get(action.id))?.status).to.equal(
+        'in_progress',
+      );
+      expect((await rebalanceIntentStore.get(intent.id))?.status).to.equal(
+        'in_progress',
+      );
+      expect(
+        (await rebalanceActionStore.get(action.id))?.lastBridgeStatus,
+      ).to.equal('failed');
+    });
+
     it('should mark actions as complete when delivered and update parent intent', async () => {
       const intent: RebalanceIntent = {
         id: 'intent-1',

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -576,6 +576,7 @@ describe('ActionTracker', () => {
         destination: 2,
         amount: 100n,
         txHash: '0xtx-pending',
+        externalBridgeTransferId: 'transfer-pending',
         externalBridgeId: ExternalBridgeType.LiFi,
         createdAt: Date.now() - DEFAULT_MOVEMENT_STALENESS_MS - 1,
         updatedAt: Date.now() - DEFAULT_MOVEMENT_STALENESS_MS - 1,
@@ -585,6 +586,15 @@ describe('ActionTracker', () => {
       await tracker.syncInventoryMovementActions({
         lifi: { getStatus } as any,
       });
+
+      expect(
+        getStatus.calledOnceWithExactly(
+          '0xtx-pending',
+          1,
+          2,
+          'transfer-pending',
+        ),
+      ).to.equal(true);
 
       const action = await rebalanceActionStore.get('action-pending');
       expect(action?.status).to.equal('in_progress');
@@ -1339,6 +1349,24 @@ describe('ActionTracker', () => {
 
       const updatedIntent = await rebalanceIntentStore.get('intent-1');
       expect(updatedIntent?.status).to.equal('in_progress');
+    });
+
+    it('persists external bridge transfer identifiers', async () => {
+      const result = await tracker.createRebalanceAction({
+        type: 'inventory_movement',
+        intentId: 'intent-1',
+        origin: 1,
+        destination: 2,
+        amount: 50n,
+        txHash: '0xmovement',
+        externalBridgeTransferId: 'provider-transfer-id',
+        externalBridgeId: ExternalBridgeType.LiFi,
+      });
+
+      expect(result.externalBridgeTransferId).to.equal('provider-transfer-id');
+      expect(result.status).to.equal('in_progress');
+      const stored = await rebalanceActionStore.get(result.id);
+      expect(stored?.externalBridgeTransferId).to.equal('provider-transfer-id');
     });
   });
 

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -5,7 +5,6 @@ import type { MultiProtocolCore } from '@hyperlane-xyz/sdk';
 import type { Address, Domain } from '@hyperlane-xyz/utils';
 import { assert, parseWarpRouteMessage } from '@hyperlane-xyz/utils';
 
-import { DEFAULT_MOVEMENT_STALENESS_MS } from '../config/types.js';
 import type { ExternalBridgeRegistry } from '../interfaces/IExternalBridge.js';
 import type { ConfirmedBlockTags } from '../interfaces/IMonitor.js';
 import type {
@@ -18,6 +17,7 @@ import type {
   CreateRebalanceActionParams,
   CreateRebalanceIntentParams,
   IActionTracker,
+  UpdateRebalanceActionExecutionParams,
 } from './IActionTracker.js';
 import type {
   ActionType,
@@ -90,9 +90,9 @@ export class ActionTracker implements IActionTracker {
     }
 
     // 3. Sync all stores
+    await this.syncRebalanceActions();
     await this.syncTransfers();
     await this.syncRebalanceIntents();
-    await this.syncRebalanceActions();
 
     // Log store contents for debugging
     await this.logStoreContents();
@@ -227,22 +227,23 @@ export class ActionTracker implements IActionTracker {
         });
         this.logger.debug({ id: intent.id }, 'RebalanceIntent completed');
       } else if (now - intent.createdAt > this.config.intentTTL) {
+        const sourceStartedActions = allInProgressActions.filter(
+          (action) => action.intentId === intent.id,
+        );
+        if (sourceStartedActions.length > 0) {
+          this.logger.warn(
+            {
+              intentId: intent.id,
+              actionIds: sourceStartedActions.map((action) => action.id),
+            },
+            'RebalanceIntent exceeded TTL but has source-started actions; retry remains suppressed for this process lifetime',
+          );
+          continue;
+        }
+
         await this.rebalanceIntentStore.update(intent.id, {
           status: 'failed',
         });
-
-        // Fail any in-progress actions associated with the expired intent
-        for (const action of allInProgressActions) {
-          if (action.intentId === intent.id) {
-            await this.rebalanceActionStore.update(action.id, {
-              status: 'failed',
-            });
-            this.logger.warn(
-              { actionId: action.id, intentId: intent.id },
-              'RebalanceAction failed due to parent intent TTL expiry',
-            );
-          }
-        }
 
         this.logger.debug(
           {
@@ -461,11 +462,18 @@ export class ActionTracker implements IActionTracker {
       updatedAt: Date.now(),
     };
 
-    await this.rebalanceActionStore.save(action);
-
-    // Transition parent intent from not_started to in_progress
     const intent = await this.rebalanceIntentStore.get(params.intentId);
-    if (intent && intent.status === 'not_started') {
+    if (!intent) {
+      throw new Error(`RebalanceIntent ${params.intentId} not found`);
+    }
+    assert(
+      intent.status === 'not_started' || intent.status === 'in_progress',
+      `RebalanceIntent ${params.intentId} is not active`,
+    );
+
+    // Record suppression before the action. A crash in between cannot result in
+    // a broadcast because callers wait for this method before sending.
+    if (intent.status === 'not_started') {
       await this.rebalanceIntentStore.update(intent.id, {
         status: 'in_progress',
       });
@@ -475,12 +483,30 @@ export class ActionTracker implements IActionTracker {
       );
     }
 
+    await this.rebalanceActionStore.save(action);
+
     this.logger.debug(
       { id: action.id, intentId: action.intentId, type: action.type },
       'Created RebalanceAction',
     );
 
     return action;
+  }
+
+  async updateRebalanceActionExecution(
+    id: string,
+    params: UpdateRebalanceActionExecutionParams,
+  ): Promise<void> {
+    await this.rebalanceActionStore.update(id, params);
+    this.logger.debug(
+      {
+        id,
+        messageId: params.messageId,
+        txHash: params.txHash,
+        externalBridgeTransferId: params.externalBridgeTransferId,
+      },
+      'Updated RebalanceAction execution identity',
+    );
   }
 
   async completeRebalanceAction(id: string): Promise<void> {
@@ -589,51 +615,17 @@ export class ActionTracker implements IActionTracker {
 
       const actions = await this.getActionsForIntent(intent.id);
 
-      // Check for in-flight inventory_movement actions
-      // Skip intents with active bridge movement(s). Movements still `pending` on
-      // the bridge are kept alive regardless of age. Non-pending movements are only
-      // failed after they've been in a non-pending state for the staleness window
-      // (nonPendingSince), preventing premature failure from transient not_found polls.
-      // `undefined` status (pre-deploy data) falls back to createdAt for staleness.
+      // Any source-started bridge movement blocks automatic retries. A timeout or
+      // not_found status is not proof that the source transaction did not commit.
       const inflightMovements = actions.filter(
         (a) => a.status === 'in_progress' && a.type === 'inventory_movement',
       );
-      const now = Date.now();
-      const staleMovements = inflightMovements.filter((a) => {
-        if (a.lastBridgeStatus === 'pending') return false;
-        // Use nonPendingSince when available; fall back to createdAt for
-        // pre-deploy data that lacks the field.
-        const nonPendingStart = a.nonPendingSince ?? a.createdAt;
-        return now - nonPendingStart >= DEFAULT_MOVEMENT_STALENESS_MS;
-      });
-      const staleMovementIds = new Set(staleMovements.map((a) => a.id));
-
-      const hasBlockingInflightMovement = inflightMovements.some(
-        (a) => !staleMovementIds.has(a.id),
-      );
-
-      if (hasBlockingInflightMovement) {
+      if (inflightMovements.length > 0) {
         this.logger.debug(
           { intentId: intent.id },
           'Skipping partial intent - has in-flight inventory movement',
         );
         continue;
-      }
-
-      // Fail stale movements so the intent can proceed
-      for (const movement of staleMovements) {
-        await this.failRebalanceAction(movement.id);
-        this.logger.warn(
-          {
-            actionId: movement.id,
-            age: now - movement.createdAt,
-            nonPendingDuration:
-              now - (movement.nonPendingSince ?? movement.createdAt),
-            intentId: intent.id,
-            lastBridgeStatus: movement.lastBridgeStatus,
-          },
-          'Failing stale inventory movement to unblock intent',
-        );
       }
 
       // Only inventory_deposit amounts advance fulfillment. inventory_movement
@@ -931,10 +923,24 @@ export class ActionTracker implements IActionTracker {
   }
 
   private async recoverAction(msg: ExplorerMessage): Promise<void> {
-    // Check if action already exists
-    const existing = await this.rebalanceActionStore.get(msg.msg_id);
+    const existingById = await this.rebalanceActionStore.get(msg.msg_id);
+    const existingByExecution = (await this.rebalanceActionStore.getAll()).find(
+      (action) =>
+        action.messageId === msg.msg_id ||
+        action.txHash?.toLowerCase() === msg.origin_tx_hash.toLowerCase(),
+    );
+    const existing = existingById ?? existingByExecution;
     if (existing) {
-      this.logger.debug({ id: msg.msg_id }, 'Action already exists, skipping');
+      if (!existing.messageId || !existing.txHash) {
+        await this.updateRebalanceActionExecution(existing.id, {
+          messageId: msg.msg_id,
+          txHash: msg.origin_tx_hash,
+        });
+      }
+      this.logger.debug(
+        { id: existing.id, messageId: msg.msg_id },
+        'Action already exists, linked recovered execution identity',
+      );
       return;
     }
 

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -5,7 +5,10 @@ import type { MultiProtocolCore } from '@hyperlane-xyz/sdk';
 import type { Address, Domain } from '@hyperlane-xyz/utils';
 import { assert, parseWarpRouteMessage } from '@hyperlane-xyz/utils';
 
+import { createStatusAdapters } from '../bridges/status/index.js';
+import { TokenBridgeStatusAdapterType } from '../config/types.js';
 import type { ExternalBridgeRegistry } from '../interfaces/IExternalBridge.js';
+import type { StatusAdaptersByKind } from '../interfaces/ITokenBridgeStatusAdapter.js';
 import type { ConfirmedBlockTags } from '../interfaces/IMonitor.js';
 import type {
   ExplorerMessage,
@@ -42,6 +45,8 @@ export interface ActionTrackerConfig {
  * ActionTracker implementation managing the lifecycle of tracked entities.
  */
 export class ActionTracker implements IActionTracker {
+  private readonly statusAdaptersByKind: StatusAdaptersByKind;
+
   constructor(
     private readonly transferStore: ITransferStore,
     private readonly rebalanceIntentStore: IRebalanceIntentStore,
@@ -50,7 +55,11 @@ export class ActionTracker implements IActionTracker {
     private readonly core: MultiProtocolCore,
     private readonly config: ActionTrackerConfig,
     private readonly logger: Logger,
-  ) {}
+    statusAdaptersByKind?: StatusAdaptersByKind,
+  ) {
+    this.statusAdaptersByKind =
+      statusAdaptersByKind ?? createStatusAdapters(this.logger);
+  }
 
   // === Lifecycle ===
 
@@ -216,8 +225,7 @@ export class ActionTracker implements IActionTracker {
     // Check in_progress intents for completion or TTL expiry
     const inProgressIntents =
       await this.rebalanceIntentStore.getByStatus('in_progress');
-    const allInProgressActions =
-      await this.rebalanceActionStore.getByStatus('in_progress');
+    const allActions = await this.rebalanceActionStore.getAll();
     const now = Date.now();
     for (const intent of inProgressIntents) {
       const completedAmount = await this.getCompletedAmountForIntent(intent.id);
@@ -227,8 +235,12 @@ export class ActionTracker implements IActionTracker {
         });
         this.logger.debug({ id: intent.id }, 'RebalanceIntent completed');
       } else if (now - intent.createdAt > this.config.intentTTL) {
-        const sourceStartedActions = allInProgressActions.filter(
-          (action) => action.intentId === intent.id,
+        const sourceStartedActions = allActions.filter(
+          (action) =>
+            action.intentId === intent.id &&
+            (action.status === 'in_progress' ||
+              (action.type === 'inventory_movement' &&
+                action.status === 'complete')),
         );
         if (sourceStartedActions.length > 0) {
           this.logger.warn(
@@ -309,13 +321,85 @@ export class ActionTracker implements IActionTracker {
       }
     }
 
-    // Check delivery status for all in-progress actions in our store
-    // Only check delivery for actions that have a messageId (rebalance_message, inventory_deposit)
-    // inventory_movement actions are synced separately via LiFi status API
+    // Check delivery status for all in-progress actions in our store.
+    // Movable-collateral actions may use an adapter-owned settlement ref;
+    // inventory_movement actions are synced separately via bridge APIs.
     const inProgressActions =
       await this.rebalanceActionStore.getByStatus('in_progress');
     for (const action of inProgressActions) {
-      // Skip actions without messageId (e.g., inventory_movement)
+      if (action.externalExecutionRef) {
+        const statusAdapter = this.statusAdaptersByKind.get(
+          action.externalExecutionRef.kind,
+        );
+        if (!statusAdapter) {
+          this.logger.warn(
+            {
+              actionId: action.id,
+              statusAdapterKind: action.externalExecutionRef.kind,
+            },
+            'No status adapter registered for movable collateral action',
+          );
+          continue;
+        }
+
+        const blockTag =
+          action.externalExecutionRef.kind ===
+          TokenBridgeStatusAdapterType.HyperlaneMessage
+            ? await this.getConfirmedBlockTag(
+                action.destination,
+                confirmedBlockTags,
+              )
+            : undefined;
+
+        try {
+          const status = await statusAdapter.pollStatus(
+            action.externalExecutionRef,
+            {
+              core: this.core,
+              destination: action.destination,
+              blockTag,
+            },
+          );
+          await this.rebalanceActionStore.update(action.id, {
+            externalExecutionRef: status.ref ?? action.externalExecutionRef,
+            lastBridgeStatus: status.status,
+            ...(status.status === 'complete' && status.receivingTxHash
+              ? { destinationTxHash: status.receivingTxHash }
+              : {}),
+          });
+
+          if (status.status === 'complete') {
+            await this.completeRebalanceAction(action.id);
+            completedActions++;
+            this.logger.debug(
+              { id: action.id, statusAdapterKind: statusAdapter.kind },
+              'RebalanceAction completed',
+            );
+          } else if (status.status === 'failed') {
+            this.logger.warn(
+              {
+                id: action.id,
+                intentId: action.intentId,
+                statusAdapterKind: statusAdapter.kind,
+                error: status.error,
+              },
+              'Source-committed rebalance remains suppressed for this process lifetime',
+            );
+          }
+        } catch (error) {
+          this.logger.warn(
+            {
+              actionId: action.id,
+              statusAdapterKind: statusAdapter.kind,
+              error,
+            },
+            'Failed to poll movable collateral settlement status',
+          );
+        }
+        continue;
+      }
+
+      // Backward compatibility for recovered/pre-adapter Hyperlane actions.
       if (!action.messageId) {
         continue;
       }
@@ -455,6 +539,7 @@ export class ActionTracker implements IActionTracker {
       txHash: params.txHash,
       externalBridgeTransferId: params.externalBridgeTransferId,
       externalBridgeId: params.externalBridgeId,
+      externalExecutionRef: params.externalExecutionRef,
       origin: params.origin,
       destination: params.destination,
       amount: params.amount,
@@ -504,6 +589,7 @@ export class ActionTracker implements IActionTracker {
         messageId: params.messageId,
         txHash: params.txHash,
         externalBridgeTransferId: params.externalBridgeTransferId,
+        statusAdapterKind: params.externalExecutionRef?.kind,
       },
       'Updated RebalanceAction execution identity',
     );

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -726,6 +726,7 @@ export class ActionTracker implements IActionTracker {
           action.txHash,
           action.origin,
           action.destination,
+          action.externalBridgeTransferId,
         );
 
         if (status.status === 'complete') {

--- a/typescript/rebalancer/src/tracking/IActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/IActionTracker.ts
@@ -36,6 +36,12 @@ export interface CreateRebalanceActionParams {
   externalBridgeId?: ExternalBridgeType; // Optional - for inventory_movement (e.g., 'lifi')
 }
 
+export interface UpdateRebalanceActionExecutionParams {
+  messageId?: string;
+  txHash?: string;
+  externalBridgeTransferId?: string;
+}
+
 /**
  * ActionTracker manages the lifecycle of tracked entities:
  * - Transfers: Inflight user warp transfers
@@ -192,6 +198,12 @@ export interface IActionTracker {
   createRebalanceAction(
     params: CreateRebalanceActionParams,
   ): Promise<RebalanceAction>;
+
+  /** Record source transaction identifiers on a pre-send action. */
+  updateRebalanceActionExecution(
+    id: string,
+    params: UpdateRebalanceActionExecutionParams,
+  ): Promise<void>;
 
   /**
    * Mark a rebalance action as complete.

--- a/typescript/rebalancer/src/tracking/IActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/IActionTracker.ts
@@ -2,6 +2,7 @@ import type { Address, Domain } from '@hyperlane-xyz/utils';
 
 import type { ExternalBridgeType } from '../config/types.js';
 import type { ExternalBridgeRegistry } from '../interfaces/IExternalBridge.js';
+import type { MCRStatusRef } from '../interfaces/ITokenBridgeStatusAdapter.js';
 import type { ConfirmedBlockTags } from '../interfaces/IMonitor.js';
 
 import type {
@@ -34,12 +35,14 @@ export interface CreateRebalanceActionParams {
   txHash?: string;
   externalBridgeTransferId?: string; // Optional - for inventory_movement (external transfer bridge ID)
   externalBridgeId?: ExternalBridgeType; // Optional - for inventory_movement (e.g., 'lifi')
+  externalExecutionRef?: MCRStatusRef; // Optional - movable collateral settlement cursor
 }
 
 export interface UpdateRebalanceActionExecutionParams {
   messageId?: string;
   txHash?: string;
   externalBridgeTransferId?: string;
+  externalExecutionRef?: MCRStatusRef;
 }
 
 /**

--- a/typescript/rebalancer/src/tracking/types.ts
+++ b/typescript/rebalancer/src/tracking/types.ts
@@ -2,6 +2,7 @@ import type { Address, Domain } from '@hyperlane-xyz/utils';
 
 import type { ExternalBridgeType } from '../config/types.js';
 import type { BridgeTransferStatus } from '../interfaces/IExternalBridge.js';
+import type { MCRStatusRef } from '../interfaces/ITokenBridgeStatusAdapter.js';
 
 import type { IStore } from './store/IStore.js';
 
@@ -82,10 +83,12 @@ export interface RebalanceAction extends TrackedActionBase {
   intentId: string; // Links to parent RebalanceIntent
   messageId?: string; // Hyperlane message ID (required for rebalance_message, inventory_deposit)
   txHash?: string; // Origin transaction hash
+  destinationTxHash?: string; // Destination settlement transaction hash
+  externalExecutionRef?: MCRStatusRef; // Movable-collateral settlement cursor
   // Fields for inventory_movement (external bridge)
   externalBridgeTransferId?: string; // External bridge transfer ID (e.g., LiFi transfer ID)
   externalBridgeId?: ExternalBridgeType; // External bridge identifier (e.g., 'lifi')
-  lastBridgeStatus?: BridgeTransferStatus['status']; // Last observed external bridge status
+  lastBridgeStatus?: BridgeTransferStatus['status']; // Last observed bridge/settlement status
   nonPendingSince?: number; // Timestamp when bridge status first became non-pending
 }
 

--- a/typescript/rebalancer/src/utils/balanceUtils.test.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.test.ts
@@ -71,6 +71,19 @@ describe('getRawBalances', () => {
     });
   });
 
+  for (const standard of [
+    TokenStandard.EvmHypXERC20Lockbox,
+    TokenStandard.EvmHypVSXERC20Lockbox,
+  ]) {
+    it(`should return the lockbox bridged supply for the token (${standard})`, () => {
+      token.standard = standard;
+
+      expect(getRawBalances(chains, event, testLogger)).to.deep.equal({
+        mainnet: tokenBridgedSupply,
+      });
+    });
+  }
+
   it('should ignore non supported token standards', () => {
     token.standard = TokenStandard.EvmHypOwnerCollateral;
 

--- a/typescript/rebalancer/src/utils/bridgeUtils.test.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.test.ts
@@ -4,9 +4,14 @@ import { expect } from 'chai';
 
 import { type ChainMap } from '@hyperlane-xyz/sdk';
 
-import { ExecutionType, ExternalBridgeType } from '../config/types.js';
+import {
+  ExecutionType,
+  ExternalBridgeType,
+  TokenBridgeStatusAdapterType,
+} from '../config/types.js';
 import {
   type BridgeConfigWithOverride,
+  createStrategyRoute,
   getBridgeConfig,
   isInventoryConfig,
   isMovableCollateralConfig,
@@ -90,6 +95,83 @@ describe('bridgeConfig', () => {
       bridge: '0xABCDEF0123456789ABCDEF0123456789ABCDEF01',
       bridgeMinAcceptedAmount: 1000,
     });
+  });
+
+  it('should apply and propagate a destination settlement adapter override', () => {
+    const bridges: ChainMap<BridgeConfigWithOverride> = {
+      chain1: {
+        executionType: ExecutionType.MovableCollateral,
+        bridge: '0x1234567890123456789012345678901234567890',
+        override: {
+          chain2: {
+            statusAdapter: {
+              kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+              sourceEid: 30110,
+              destinationEid: 30420,
+              sourceOft: '0x1111111111111111111111111111111111111111',
+              destinationOft: '0x2222222222222222222222222222222222222222',
+            },
+          },
+        },
+      },
+      chain2: {
+        executionType: ExecutionType.MovableCollateral,
+        bridge: '0x0987654321098765432109876543210987654321',
+      },
+    };
+
+    const config = getBridgeConfig(bridges, 'chain1', 'chain2');
+    const route = createStrategyRoute(config, 'chain1', 'chain2', 100n);
+
+    assert(isMovableCollateralConfig(config));
+    expect(config.statusAdapter?.kind).to.equal(
+      TokenBridgeStatusAdapterType.LayerZeroScan,
+    );
+    assert(route.executionType === ExecutionType.MovableCollateral);
+    expect(route.statusAdapter?.kind).to.equal(
+      TokenBridgeStatusAdapterType.LayerZeroScan,
+    );
+  });
+
+  it('should switch an inventory base to a movable collateral override', () => {
+    const bridge = '0x1234567890123456789012345678901234567890';
+    const bridges: ChainMap<BridgeConfigWithOverride> = {
+      chain1: {
+        executionType: ExecutionType.Inventory,
+        externalBridge: ExternalBridgeType.SwapsXyz,
+        override: {
+          chain2: {
+            executionType: ExecutionType.MovableCollateral,
+            bridge,
+            statusAdapter: {
+              kind: TokenBridgeStatusAdapterType.LayerZeroScan,
+              sourceEid: 30110,
+              destinationEid: 30420,
+              sourceOft: '0x1111111111111111111111111111111111111111',
+              destinationOft: '0x2222222222222222222222222222222222222222',
+            },
+          },
+        },
+      },
+      chain2: {
+        executionType: ExecutionType.Inventory,
+        externalBridge: ExternalBridgeType.SwapsXyz,
+      },
+    };
+
+    const config = getBridgeConfig(bridges, 'chain1', 'chain2');
+    const route = createStrategyRoute(config, 'chain1', 'chain2', 100n);
+
+    assert(isMovableCollateralConfig(config));
+    expect(config.bridge).to.equal(bridge);
+    expect(config.statusAdapter?.kind).to.equal(
+      TokenBridgeStatusAdapterType.LayerZeroScan,
+    );
+    assert(route.executionType === ExecutionType.MovableCollateral);
+    expect(route.bridge).to.equal(bridge);
+    expect(route.statusAdapter?.kind).to.equal(
+      TokenBridgeStatusAdapterType.LayerZeroScan,
+    );
   });
 
   it('should apply override with executionType: inventory', () => {

--- a/typescript/rebalancer/src/utils/bridgeUtils.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.ts
@@ -9,6 +9,7 @@ import type { StrategyRoute } from '../interfaces/IStrategy.js';
 
 type BaseBridgeConfig = {
   bridgeMinAcceptedAmount?: string | number;
+  enabled?: boolean;
 };
 
 export type MovableCollateralBridgeConfig = BaseBridgeConfig & {

--- a/typescript/rebalancer/src/utils/bridgeUtils.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.ts
@@ -1,7 +1,10 @@
 import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 import type { Address } from '@hyperlane-xyz/utils';
 
-import type { ExternalBridgeType } from '../config/types.js';
+import type {
+  ExternalBridgeType,
+  TokenBridgeStatusAdapterConfig,
+} from '../config/types.js';
 import type { StrategyRoute } from '../interfaces/IStrategy.js';
 
 type BaseBridgeConfig = {
@@ -11,6 +14,7 @@ type BaseBridgeConfig = {
 export type MovableCollateralBridgeConfig = BaseBridgeConfig & {
   executionType: 'movableCollateral';
   bridge: Address;
+  statusAdapter?: TokenBridgeStatusAdapterConfig;
 };
 
 export type InventoryBridgeConfig = BaseBridgeConfig & {
@@ -90,6 +94,9 @@ export function createStrategyRoute(
         amount,
         executionType: 'movableCollateral',
         bridge: bridgeConfig.bridge,
+        ...(bridgeConfig.statusAdapter
+          ? { statusAdapter: bridgeConfig.statusAdapter }
+          : {}),
       };
     default: {
       const _exhaustive: never = bridgeConfig;

--- a/typescript/rebalancer/src/utils/rebalancerSigners.test.ts
+++ b/typescript/rebalancer/src/utils/rebalancerSigners.test.ts
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { TronJsonRpcProvider, TronWallet } from '@hyperlane-xyz/tron-sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { configureRebalancerSigners } from './rebalancerSigners.js';
+
+const PRIVATE_KEY = `0x${'01'.repeat(32)}`;
+
+describe('configureRebalancerSigners', () => {
+  it('uses TronWallet on Tron and ethers Wallet elsewhere', async () => {
+    const multiProvider = new MultiProvider({
+      ethereum: {
+        name: 'ethereum',
+        chainId: 1,
+        domainId: 1,
+        protocol: ProtocolType.Ethereum,
+        rpcUrls: [{ http: 'http://ethereum.invalid' }],
+      },
+      tron: {
+        name: 'tron',
+        chainId: 728126428,
+        domainId: 728126428,
+        protocol: ProtocolType.Tron,
+        rpcUrls: [{ http: 'http://tron.invalid' }],
+      },
+    });
+
+    const setup = configureRebalancerSigners(
+      multiProvider,
+      ['ethereum', 'tron'],
+      PRIVATE_KEY,
+    );
+
+    expect(setup.tronChains).to.deep.equal(['tron']);
+    expect(multiProvider.getSigner('tron')).to.be.instanceOf(TronWallet);
+    expect(multiProvider.getSigner('ethereum')).not.to.be.instanceOf(
+      TronWallet,
+    );
+    expect(await multiProvider.getSignerAddress('tron')).to.equal(
+      setup.address,
+    );
+  });
+
+  it('uses the configured Tron RPC URL including custom headers', () => {
+    const tronRpcUrl =
+      'https://tron.example/jsonrpc?custom_rpc_header=X-Api-Key:secret';
+    const multiProvider = new MultiProvider({
+      tron: {
+        name: 'tron',
+        chainId: 728126428,
+        domainId: 728126428,
+        protocol: ProtocolType.Tron,
+        rpcUrls: [{ http: tronRpcUrl }],
+      },
+    });
+
+    configureRebalancerSigners(multiProvider, ['tron'], PRIVATE_KEY);
+
+    const provider = multiProvider.getSigner('tron').provider;
+    expect(provider).to.be.instanceOf(TronJsonRpcProvider);
+    if (!(provider instanceof TronJsonRpcProvider)) {
+      throw new Error('Expected Tron signer to use TronJsonRpcProvider');
+    }
+    expect(provider.host).to.equal(tronRpcUrl);
+    expect(provider.connection.url).to.equal('https://tron.example/jsonrpc');
+    expect(provider.connection.headers).to.deep.include({
+      'X-Api-Key': 'secret',
+    });
+  });
+
+  it('configures duplicate strategy chains once', () => {
+    const multiProvider = new MultiProvider({
+      tron: {
+        name: 'tron',
+        chainId: 728126428,
+        domainId: 728126428,
+        protocol: ProtocolType.Tron,
+        rpcUrls: [{ http: 'http://tron.invalid' }],
+      },
+    });
+
+    const setup = configureRebalancerSigners(
+      multiProvider,
+      ['tron', 'tron'],
+      PRIVATE_KEY,
+    );
+
+    expect(setup.tronChains).to.deep.equal(['tron']);
+  });
+
+  it('requires an HTTP RPC URL for Tron', () => {
+    const multiProvider = new MultiProvider({
+      tron: {
+        name: 'tron',
+        chainId: 728126428,
+        domainId: 728126428,
+        protocol: ProtocolType.Tron,
+        rpcUrls: [{ http: 'http://tron.invalid' }],
+      },
+    });
+    multiProvider.metadata.tron.rpcUrls.splice(0);
+
+    expect(() =>
+      configureRebalancerSigners(multiProvider, ['tron'], PRIVATE_KEY),
+    ).to.throw('No RPC URLs configured for tron');
+  });
+});

--- a/typescript/rebalancer/src/utils/rebalancerSigners.ts
+++ b/typescript/rebalancer/src/utils/rebalancerSigners.ts
@@ -1,0 +1,41 @@
+import { Wallet } from 'ethers';
+
+import { type MultiProvider } from '@hyperlane-xyz/sdk';
+import { TronWallet } from '@hyperlane-xyz/tron-sdk';
+import { ProtocolType, assert } from '@hyperlane-xyz/utils';
+
+export interface RebalancerSignerSetup {
+  address: string;
+  tronChains: string[];
+}
+
+/**
+ * Configure the shared rebalancer key with the protocol-specific signer needed
+ * by each strategy chain. Tron cannot broadcast through eth_sendRawTransaction,
+ * so it must use TronWallet instead of a connected ethers Wallet.
+ */
+export function configureRebalancerSigners(
+  multiProvider: MultiProvider,
+  chains: string[],
+  privateKey: string,
+): RebalancerSignerSetup {
+  const evmSigner = new Wallet(privateKey);
+  const tronChains: string[] = [];
+
+  for (const chain of new Set(chains)) {
+    const metadata = multiProvider.getChainMetadata(chain);
+
+    if (metadata.protocol === ProtocolType.Tron) {
+      assert(metadata.rpcUrls.length, `No RPC URLs configured for ${chain}`);
+      multiProvider.setSigner(
+        chain,
+        new TronWallet(privateKey, metadata.rpcUrls[0].http),
+      );
+      tronChains.push(chain);
+    } else {
+      multiProvider.setSigner(chain, evmSigner);
+    }
+  }
+
+  return { address: evmSigner.address, tronChains };
+}

--- a/typescript/rebalancer/src/utils/receiptTimeout.test.ts
+++ b/typescript/rebalancer/src/utils/receiptTimeout.test.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+
+import {
+  DEFAULT_RECEIPT_TIMEOUT_MS,
+  ReceiptWaitTimeoutError,
+  isReceiptWaitTimeoutError,
+  waitForReceiptWithTimeout,
+} from './receiptTimeout.js';
+
+describe('receiptTimeout', () => {
+  it('uses a five-minute default receipt deadline', () => {
+    expect(DEFAULT_RECEIPT_TIMEOUT_MS).to.equal(300_000);
+  });
+
+  it('returns a receipt that resolves before the deadline', async () => {
+    const receipt = { status: 1 };
+
+    const result = await waitForReceiptWithTimeout(Promise.resolve(receipt), {
+      txHash: '0xreceipt',
+      operation: 'test receipt',
+    });
+
+    expect(result).to.equal(receipt);
+  });
+
+  it('throws a typed error with transaction context on timeout', async () => {
+    const neverResolves = new Promise<never>(() => undefined);
+
+    try {
+      await waitForReceiptWithTimeout(neverResolves, {
+        txHash: '0xtimeout',
+        operation: 'erc20 approve',
+        timeoutMs: 1,
+        role: 'approval',
+      });
+      expect.fail('Expected receipt wait to time out');
+    } catch (error) {
+      expect(isReceiptWaitTimeoutError(error)).to.equal(true);
+      expect(error).to.be.instanceOf(ReceiptWaitTimeoutError);
+      if (error instanceof ReceiptWaitTimeoutError) {
+        expect(error.txHash).to.equal('0xtimeout');
+        expect(error.operation).to.equal('erc20 approve');
+        expect(error.timeoutMs).to.equal(1);
+        expect(error.role).to.equal('approval');
+      }
+    }
+  });
+
+  it('preserves receipt errors from the provider', async () => {
+    const providerError = new Error('transaction reverted');
+
+    try {
+      await waitForReceiptWithTimeout(Promise.reject(providerError), {
+        txHash: '0xreverted',
+        operation: 'test receipt',
+      });
+      expect.fail('Expected provider error');
+    } catch (error) {
+      expect(error).to.equal(providerError);
+    }
+  });
+
+  it('rejects non-positive receipt deadlines', async () => {
+    try {
+      await waitForReceiptWithTimeout(Promise.resolve({ status: 1 }), {
+        txHash: '0xreceipt',
+        operation: 'test receipt',
+        timeoutMs: 0,
+      });
+      expect.fail('Expected receipt timeout validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).to.equal('Receipt timeout must be positive');
+      }
+    }
+  });
+});

--- a/typescript/rebalancer/src/utils/receiptTimeout.ts
+++ b/typescript/rebalancer/src/utils/receiptTimeout.ts
@@ -1,0 +1,63 @@
+import { assert, timeout } from '@hyperlane-xyz/utils';
+
+/** Default deadline for waiting for a single on-chain transaction receipt. */
+export const DEFAULT_RECEIPT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type ReceiptWaitRole = 'primary' | 'approval';
+
+export interface ReceiptWaitTimeoutOptions {
+  txHash: string;
+  operation: string;
+  timeoutMs?: number;
+  role?: ReceiptWaitRole;
+}
+
+export class ReceiptWaitTimeoutError extends Error {
+  readonly txHash: string;
+  readonly operation: string;
+  readonly timeoutMs: number;
+  readonly role: ReceiptWaitRole;
+
+  constructor(options: ReceiptWaitTimeoutOptions) {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_RECEIPT_TIMEOUT_MS;
+    const role = options.role ?? 'primary';
+    super(
+      `${options.operation} receipt wait timed out after ${timeoutMs}ms for tx ${options.txHash}`,
+    );
+    this.name = 'ReceiptWaitTimeoutError';
+    this.txHash = options.txHash;
+    this.operation = options.operation;
+    this.timeoutMs = timeoutMs;
+    this.role = role;
+  }
+}
+
+export function isReceiptWaitTimeoutError(
+  error: unknown,
+): error is ReceiptWaitTimeoutError {
+  return error instanceof ReceiptWaitTimeoutError;
+}
+
+export async function waitForReceiptWithTimeout<T>(
+  receiptPromise: Promise<T>,
+  options: ReceiptWaitTimeoutOptions,
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RECEIPT_TIMEOUT_MS;
+  assert(timeoutMs > 0, 'Receipt timeout must be positive');
+  const timeoutMarker = [
+    '__receipt_wait_timeout__',
+    options.role ?? 'primary',
+    options.operation,
+    options.txHash,
+    timeoutMs,
+  ].join(':');
+
+  try {
+    return await timeout(receiptPromise, timeoutMs, timeoutMarker);
+  } catch (error) {
+    if (error instanceof Error && error.message === timeoutMarker) {
+      throw new ReceiptWaitTimeoutError({ ...options, timeoutMs });
+    }
+    throw error;
+  }
+}

--- a/typescript/rebalancer/src/utils/tokenUtils.test.ts
+++ b/typescript/rebalancer/src/utils/tokenUtils.test.ts
@@ -18,12 +18,14 @@ const ROUTER_ADDRESS = '0x1111111111111111111111111111111111111111';
 const LOCKBOX_ADDRESS = '0x2222222222222222222222222222222222222222';
 const WRAPPED_TOKEN_ADDRESS = '0x3333333333333333333333333333333333333333';
 const NATIVE_TOKEN_ADDRESS = '0x4444444444444444444444444444444444444444';
+// CAST: This unit test only exercises adapter lookup; no provider methods are used.
 const multiProvider = {} as MultiProviderAdapter;
 
 function createToken(
   standard: TokenStandard,
   overrides: Partial<Token> = {},
 ): Token {
+  // CAST: This focused token fixture implements only fields used by tokenUtils.
   return {
     chainName: 'ethereum',
     standard,

--- a/typescript/rebalancer/src/utils/tokenUtils.test.ts
+++ b/typescript/rebalancer/src/utils/tokenUtils.test.ts
@@ -1,0 +1,119 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import { type Token, TokenStandard } from '@hyperlane-xyz/sdk';
+import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
+
+import { ExternalBridgeType } from '../config/types.js';
+
+import {
+  getExternalBridgeTokenAddress,
+  isCollateralizedTokenEligibleForRebalancing,
+} from './tokenUtils.js';
+
+chai.use(chaiAsPromised);
+
+const ROUTER_ADDRESS = '0x1111111111111111111111111111111111111111';
+const LOCKBOX_ADDRESS = '0x2222222222222222222222222222222222222222';
+const WRAPPED_TOKEN_ADDRESS = '0x3333333333333333333333333333333333333333';
+const NATIVE_TOKEN_ADDRESS = '0x4444444444444444444444444444444444444444';
+const multiProvider = {} as MultiProviderAdapter;
+
+function createToken(
+  standard: TokenStandard,
+  overrides: Partial<Token> = {},
+): Token {
+  return {
+    chainName: 'ethereum',
+    standard,
+    addressOrDenom: ROUTER_ADDRESS,
+    collateralAddressOrDenom: LOCKBOX_ADDRESS,
+    isCollateralized: sinon.stub().returns(true),
+    ...overrides,
+  } as Token;
+}
+
+describe('tokenUtils', () => {
+  describe('isCollateralizedTokenEligibleForRebalancing', () => {
+    for (const standard of [
+      TokenStandard.EvmHypXERC20Lockbox,
+      TokenStandard.EvmHypVSXERC20Lockbox,
+    ]) {
+      it(`supports ${standard}`, () => {
+        expect(
+          isCollateralizedTokenEligibleForRebalancing(createToken(standard)),
+        ).to.be.true;
+      });
+    }
+  });
+
+  describe('getExternalBridgeTokenAddress', () => {
+    for (const standard of [
+      TokenStandard.EvmHypXERC20Lockbox,
+      TokenStandard.EvmHypVSXERC20Lockbox,
+    ]) {
+      it(`reads the wrapped token address for ${standard}`, async () => {
+        const getWrappedTokenAddress = sinon
+          .stub()
+          .resolves(WRAPPED_TOKEN_ADDRESS);
+        const getHypAdapter = sinon.stub().returns({
+          getWrappedTokenAddress,
+        });
+        const token = createToken(standard, { getHypAdapter });
+
+        const result = await getExternalBridgeTokenAddress(
+          token,
+          multiProvider,
+          ExternalBridgeType.LiFi,
+          () => NATIVE_TOKEN_ADDRESS,
+        );
+
+        expect(result).to.equal(WRAPPED_TOKEN_ADDRESS);
+        expect(getHypAdapter.calledOnceWithExactly(multiProvider)).to.be.true;
+        expect(getWrappedTokenAddress.calledOnce).to.be.true;
+      });
+    }
+
+    it('rejects a lockbox adapter without wrapped token resolution', async () => {
+      const token = createToken(TokenStandard.EvmHypXERC20Lockbox, {
+        getHypAdapter: sinon.stub().returns({}),
+      });
+
+      await expect(
+        getExternalBridgeTokenAddress(
+          token,
+          multiProvider,
+          ExternalBridgeType.LiFi,
+          () => NATIVE_TOKEN_ADDRESS,
+        ),
+      ).to.be.rejectedWith('does not expose getWrappedTokenAddress');
+    });
+
+    it('uses collateralAddressOrDenom for ordinary collateral', async () => {
+      const token = createToken(TokenStandard.EvmHypCollateral);
+
+      expect(
+        await getExternalBridgeTokenAddress(
+          token,
+          multiProvider,
+          ExternalBridgeType.LiFi,
+          () => NATIVE_TOKEN_ADDRESS,
+        ),
+      ).to.equal(LOCKBOX_ADDRESS);
+    });
+
+    it('uses the bridge native token representation for native collateral', async () => {
+      const token = createToken(TokenStandard.EvmHypNative);
+
+      expect(
+        await getExternalBridgeTokenAddress(
+          token,
+          multiProvider,
+          ExternalBridgeType.LiFi,
+          () => NATIVE_TOKEN_ADDRESS,
+        ),
+      ).to.equal(NATIVE_TOKEN_ADDRESS);
+    });
+  });
+});

--- a/typescript/rebalancer/src/utils/tokenUtils.ts
+++ b/typescript/rebalancer/src/utils/tokenUtils.ts
@@ -3,14 +3,22 @@ import { ProtocolType, assert } from '@hyperlane-xyz/utils';
 import type { ExternalBridgeType } from '../config/types.js';
 
 import {
+  type IHypTokenAdapter,
   PROTOCOL_TO_HYP_NATIVE_STANDARD,
   type Token,
   TokenStandard,
 } from '@hyperlane-xyz/sdk';
+import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
+
+const REBALANCEABLE_LOCKBOX_STANDARDS = new Set<TokenStandard>([
+  TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20Lockbox,
+]);
 
 const REBALANCEABLE_TOKEN_COLLATERALIZED_STANDARDS = new Set<TokenStandard>([
   TokenStandard.EvmHypCollateral,
   TokenStandard.EvmHypNative,
+  ...REBALANCEABLE_LOCKBOX_STANDARDS,
   TokenStandard.SealevelHypCollateral,
   TokenStandard.SealevelHypNative,
   TokenStandard.TronHypCollateral,
@@ -58,6 +66,19 @@ export function isCollateralizedTokenEligibleForRebalancing(
   );
 }
 
+type WrappedTokenAddressAdapter = IHypTokenAdapter<unknown> & {
+  getWrappedTokenAddress(): Promise<string>;
+};
+
+function isWrappedTokenAddressAdapter(
+  adapter: IHypTokenAdapter<unknown>,
+): adapter is WrappedTokenAddressAdapter {
+  return (
+    'getWrappedTokenAddress' in adapter &&
+    typeof adapter.getWrappedTokenAddress === 'function'
+  );
+}
+
 /**
  * Resolves the correct token address for external bridges (e.g. LiFi).
  *
@@ -65,20 +86,33 @@ export function isCollateralizedTokenEligibleForRebalancing(
  * NOT the underlying token. External bridges need the actual token address:
  * - Native tokens (EvmHypNative, SealevelHypNative): Use the bridge's native token representation
  * - Collateral tokens (EvmHypCollateral, SealevelHypCollateral): Use `collateralAddressOrDenom` (the underlying token)
+ * - xERC20 lockbox tokens: Read the wrapped ERC20 from the router adapter because
+ *   `collateralAddressOrDenom` contains the lockbox address
  * - Synthetic tokens: `collateralAddressOrDenom` is undefined, `addressOrDenom` IS the token
  *
  * @param token - The warp route token to resolve
+ * @param multiProvider - Provider used to read lockbox router state
  * @param externalBridgeType - The type of external bridge (e.g. 'lifi')
  * @param getNativeTokenAddress - Function to get the bridge's native token representation
  * @returns The correct token address for the external bridge
  */
-export function getExternalBridgeTokenAddress(
+export async function getExternalBridgeTokenAddress(
   token: Token,
+  multiProvider: MultiProviderAdapter,
   externalBridgeType: ExternalBridgeType,
   getNativeTokenAddress: (type: ExternalBridgeType) => string,
-): string {
+): Promise<string> {
   if (isNativeTokenStandard(token.standard)) {
     return getNativeTokenAddress(externalBridgeType);
+  }
+
+  if (REBALANCEABLE_LOCKBOX_STANDARDS.has(token.standard)) {
+    const adapter = token.getHypAdapter(multiProvider);
+    assert(
+      isWrappedTokenAddressAdapter(adapter),
+      `Hyp adapter for lockbox token on ${token.chainName} (${token.standard}) does not expose getWrappedTokenAddress`,
+    );
+    return adapter.getWrappedTokenAddress();
   }
 
   if (token.collateralAddressOrDenom) return token.collateralAddressOrDenom;


### PR DESCRIPTION
## Summary
- Points the oUSDT rebalancer's `SWAPSXYZ_API_KEY` at a dedicated GCP secret `mainnet3-swapsxyz-api-key-ousdt` so swaps.xyz (Decent) usage is attributable per service instead of sharing one key across all rebalancers.
- Adds an optional `hyperlane.swapsxyzApiKeySecretName` helm value; the template falls back to the shared `mainnet3-swapsxyz-api-key` when a route has no dedicated key.
- `helm.ts` maps warp route IDs to their dedicated secret (`oUSDT/production`, `USDT/eclipsemainnet`).

## Context
The shared swaps.xyz key made rate-limit attribution impossible. The dedicated GCP secrets already exist and the live ExternalSecret was hand-patched to use them; this makes that reproducible from source so a helm redeploy no longer reverts it. Redeploy the rebalancer after merge to apply.

Source Haggis thread: https://hyperlaneworkspace.slack.com/archives/C08QUGLHUUC/p1788900411981719

## Test plan
- [ ] `helm template` renders `remoteRef.key: mainnet3-swapsxyz-api-key-ousdt` for the oUSDT release
- [ ] Redeploy oUSDT rebalancer; confirm ExternalSecret + synced secret carry the dedicated key