### PR TITLE
fix(scraper-proxy): normalize signed domain ids

### DIFF
--- a/.changeset/canonical-scraper-domains.md
+++ b/.changeset/canonical-scraper-domains.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/scraper-proxy': patch
+---
+
+Normalized legacy signed database domain IDs to canonical unsigned values on agent WebSocket streams.

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -47,6 +47,7 @@ const db: EventDatabase = {
   },
   async queryLive<T>(sql, values = []) {
     if (sql.includes('"gas_payment_stream_head"')) {
+      databaseDomainFilters.push(values[0]);
       const durable = [...gasPaymentRows.entries()].filter(
         ([, payment]) =>
           payment.domain === values[0] &&
@@ -116,6 +117,7 @@ const db: EventDatabase = {
       sql.includes('ORDER BY "event_row"."id"') &&
       sql.includes('"gas_payment"')
     ) {
+      databaseDomainFilters.push(values[0]);
       const after = BigInt(String(values[2]));
       const through = BigInt(String(values[3]));
       return queryRows<T>(
@@ -140,6 +142,7 @@ const db: EventDatabase = {
       !sql.includes('notification_id') &&
       sql.includes('FROM "gas_payment_stream_cursor"')
     ) {
+      databaseDomainFilters.push(values[0]);
       if (omitMappedGasPaymentRows) return [];
       const after = BigInt(String(values[2]));
       const through = BigInt(String(values[3]));
@@ -398,6 +401,79 @@ void it('queries high domains using the legacy signed representation', async () 
   } finally {
     socket.close();
     await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+    databaseDomainFilters.length = 0;
+  }
+});
+
+void it('queries high gas payment domains using the legacy signed representation', async () => {
+  const signedDomain = -846_819_108;
+  const unsignedDomain = 3_448_148_188;
+  gasPaymentRows.clear();
+  databaseDomainFilters.length = 0;
+  gasPaymentRows.set('10', {
+    ...gasPaymentRow('10', null),
+    destination: signedDomain,
+    domain: signedDomain,
+    origin: signedDomain,
+  });
+  gasPaymentRows.set('30', {
+    ...gasPaymentRow('30', null, '11'),
+    destination: signedDomain,
+    domain: signedDomain,
+    origin: signedDomain,
+  });
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+
+  try {
+    await waitFor(messages, 'ready');
+    socket.send(
+      JSON.stringify({
+        streams: [
+          {
+            cursors: [
+              {
+                address: gasPaymaster,
+                afterStreamCursor: '0',
+                domain: unsignedDomain,
+              },
+            ],
+            eventType: 'gas_payment',
+            streamCursorVersion: 3,
+          },
+        ],
+        type: 'subscribe',
+      }),
+    );
+    await waitFor(messages, 'caught_up');
+
+    assert.deepEqual(databaseDomainFilters, [
+      signedDomain,
+      signedDomain,
+      signedDomain,
+    ]);
+    const events = messages.filter(({ type }) => type === 'event');
+    assert.equal(events.length, 2);
+    for (const event of events) {
+      assert.equal(event.domain, unsignedDomain);
+      assert.deepEqual(
+        {
+          destination: record(event.data).destination,
+          domain: record(event.data).domain,
+          origin: record(event.data).origin,
+        },
+        {
+          destination: unsignedDomain,
+          domain: unsignedDomain,
+          origin: unsignedDomain,
+        },
+      );
+    }
+  } finally {
+    socket.close();
+    await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+    gasPaymentRows.clear();
     databaseDomainFilters.length = 0;
   }
 });

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -26,7 +26,10 @@ const rows = new Map([
   ['1', row(hookB)],
   ['2', row(hookA)],
 ]);
+const deliveryRows = new Map<string, Record<string, unknown>>();
+const dispatchRows = new Map<string, Record<string, unknown>>();
 const gasPaymentRows = new Map<string, Record<string, unknown>>();
+const databaseDomainFilters: unknown[] = [];
 let notify: (channel: string, payload?: string) => void;
 const explorerBatchSizes: number[] = [];
 let explorerQuery = '';
@@ -64,7 +67,8 @@ const db: EventDatabase = {
         },
       ]);
     }
-    if (sql.includes('MIN('))
+    if (sql.includes('MIN(')) {
+      databaseDomainFilters.push(values[0]);
       return queryRows<T>([
         values[1] === emptyHook
           ? { first: '0', last: '-1' }
@@ -76,6 +80,7 @@ const db: EventDatabase = {
                 ? { first: '0', last: '1' }
                 : { first: '0', last: '0' },
       ]);
+    }
     if (sql.includes('"message_view"')) {
       explorerQuery = sql;
       explorerQueryCount++;
@@ -94,6 +99,7 @@ const db: EventDatabase = {
       );
     }
     if (sql.includes('ORDER BY "leaf_index"')) {
+      databaseDomainFilters.push(values[0]);
       if (values[1] === budgetHook)
         return queryRows<T>([
           row(budgetHook, 0),
@@ -103,7 +109,7 @@ const db: EventDatabase = {
       if (values[1] === historyHook) return queryRows<T>([row(historyHook, 5)]);
       if (values[1] === pacedHook)
         return queryRows<T>([row(pacedHook, 0), row(pacedHook, 1)]);
-      return queryRows<T>([row(hookA, 0)]);
+      return queryRows<T>([{ ...row(hookA, 0), domain: values[0] }]);
     }
     if (
       !sql.includes('notification_id') &&
@@ -161,9 +167,13 @@ const db: EventDatabase = {
     ids.forEach((id) => notifiedIds.add(id));
     return queryRows<T>(
       ids.flatMap((id) => {
-        const event = sql.includes('"gas_payment"')
-          ? gasPaymentRows.get(id)
-          : rows.get(id);
+        const event = sql.includes('"raw_message_dispatch"')
+          ? dispatchRows.get(id)
+          : sql.includes('"delivered_message"')
+            ? deliveryRows.get(id)
+            : sql.includes('"gas_payment"')
+              ? gasPaymentRows.get(id)
+              : rows.get(id);
         return event
           ? [
               {
@@ -239,6 +249,157 @@ void it('keeps agent capacity independent from Explorer capacity', async () => {
       ({ readyState }) => readyState === WebSocket.CLOSED,
     ),
   );
+});
+
+void it('normalizes legacy signed domains on the agent wire', async () => {
+  const signedDomain = -846_819_108;
+  const unsignedDomain = 3_448_148_188;
+  const ids = {
+    delivery: '9002',
+    dispatch: '9001',
+    gas_payment: '9003',
+    merkle_tree_insertion: '9004',
+  } as const;
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+
+  try {
+    await waitFor(messages, 'ready');
+    socket.send(
+      JSON.stringify({
+        streams: Object.keys(ids).map((eventType) => ({
+          domains: [unsignedDomain],
+          eventType,
+        })),
+        type: 'subscribe',
+      }),
+    );
+    await waitFor(messages, 'subscribed');
+
+    dispatchRows.set(ids.dispatch, {
+      destination_domain: signedDomain,
+      id: ids.dispatch,
+      msg_body: '\\x',
+      msg_id: msgId,
+      nonce: 1,
+      origin_block_hash: `\\x${'02'.repeat(32)}`,
+      origin_block_height: '1',
+      origin_domain: signedDomain,
+      origin_mailbox: hookA,
+      origin_tx_hash: `\\x${'03'.repeat(64)}`,
+      recipient: hookB,
+      sender: hookA,
+      time_created: new Date(0).toISOString(),
+    });
+    deliveryRows.set(ids.delivery, {
+      destination_mailbox: hookB,
+      destination_tx_id: `\\x${'04'.repeat(32)}`,
+      domain: signedDomain,
+      msg_id: msgId,
+      sequence: '1',
+      time_created: new Date(0).toISOString(),
+    });
+    gasPaymentRows.set(ids.gas_payment, {
+      ...gasPaymentRow(ids.gas_payment, '1'),
+      destination: signedDomain,
+      domain: signedDomain,
+      origin: signedDomain,
+    });
+    rows.set(ids.merkle_tree_insertion, {
+      ...row(hookA),
+      domain: signedDomain,
+    });
+
+    for (const [index, [eventType, id]] of Object.entries(ids).entries()) {
+      notify(
+        'scraper_event',
+        JSON.stringify({ domain: signedDomain, eventType, id }),
+      );
+      await waitUntil(
+        () =>
+          messages.filter(({ type }) => type === 'event').length === index + 1,
+      );
+    }
+
+    const event = (eventType: string) => {
+      const message = messages.find(
+        (item) => item.type === 'event' && item.eventType === eventType,
+      );
+      assert(message);
+      assert.equal(message.domain, unsignedDomain);
+      return record(message.data);
+    };
+    assert.deepEqual(
+      {
+        destination_domain: event('dispatch').destination_domain,
+        origin_domain: event('dispatch').origin_domain,
+      },
+      { destination_domain: unsignedDomain, origin_domain: unsignedDomain },
+    );
+    assert.equal(event('delivery').domain, unsignedDomain);
+    assert.deepEqual(
+      {
+        destination: event('gas_payment').destination,
+        domain: event('gas_payment').domain,
+        origin: event('gas_payment').origin,
+      },
+      {
+        destination: unsignedDomain,
+        domain: unsignedDomain,
+        origin: unsignedDomain,
+      },
+    );
+    assert.equal(event('merkle_tree_insertion').domain, unsignedDomain);
+  } finally {
+    deliveryRows.delete(ids.delivery);
+    dispatchRows.delete(ids.dispatch);
+    gasPaymentRows.delete(ids.gas_payment);
+    rows.delete(ids.merkle_tree_insertion);
+    socket.close();
+    await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+  }
+});
+
+void it('queries high domains using the legacy signed representation', async () => {
+  const signedDomain = -846_819_108;
+  const unsignedDomain = 3_448_148_188;
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  databaseDomainFilters.length = 0;
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+
+  try {
+    await waitFor(messages, 'ready');
+    socket.send(
+      JSON.stringify({
+        streams: [
+          {
+            cursors: [
+              {
+                address: hookA,
+                afterSequence: '-1',
+                domain: unsignedDomain,
+              },
+            ],
+            eventType: 'merkle_tree_insertion',
+          },
+        ],
+        type: 'subscribe',
+      }),
+    );
+    await waitFor(messages, 'caught_up');
+
+    assert.deepEqual(databaseDomainFilters, [signedDomain, signedDomain]);
+    const event = messages.find(({ type }) => type === 'event');
+    assert(event);
+    assert.equal(event.domain, unsignedDomain);
+    assert.equal(record(event.data).domain, unsignedDomain);
+  } finally {
+    socket.close();
+    await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+    databaseDomainFilters.length = 0;
+  }
 });
 
 void it('accepts fleet-sized agent subscriptions without raising the Explorer payload limit', async () => {
@@ -694,9 +855,11 @@ void it('checks each cursor before sharing a live agent frame', async () => {
 void it('keeps gas cursor boundaries specific to each subscriber', async () => {
   gasPaymentRows.clear();
   const payment = {
+    destination: 2,
     id: '14',
     domain: 1,
     interchain_gas_paymaster: gasPaymaster,
+    origin: 1,
   };
   gasPaymentRows.set('14', payment);
   const sockets = [new WebSocket(url), new WebSocket(url)];

--- a/typescript/scraper-proxy/src/live/event-websocket.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 
 import {
   parseClientMessage,
+  parseDatabaseDomain,
   parseEventNotification,
   parseExplorerNotification,
 } from './protocol.js';
@@ -362,6 +363,36 @@ void describe('event websocket protocol', () => {
         '{"eventType":"dispatch","id":"123","domain":-2147483649}',
       ),
     );
+  });
+
+  void it('normalizes only valid signed database domain encodings', () => {
+    for (const [stored, domain] of [
+      [-0x8000_0000, 0x8000_0000],
+      [-1, 0xffff_ffff],
+      [0, 0],
+      [0x7fff_ffff, 0x7fff_ffff],
+      [0x8000_0000, 0x8000_0000],
+      [0xffff_ffff, 0xffff_ffff],
+      ['-2147483648', 0x8000_0000],
+      ['4294967295', 0xffff_ffff],
+    ] as const) {
+      assert.equal(parseDatabaseDomain(stored, 'invalid domain'), domain);
+    }
+    for (const stored of [
+      -0x8000_0001,
+      0x1_0000_0000,
+      1.5,
+      '',
+      ' 1',
+      '0x1',
+      '1e3',
+      '1.5',
+    ]) {
+      assert.throws(
+        () => parseDatabaseDomain(stored, 'invalid domain'),
+        /invalid domain/,
+      );
+    }
   });
 
   void it('parses Explorer message notifications', () => {

--- a/typescript/scraper-proxy/src/live/event-websocket.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.test.ts
@@ -346,9 +346,20 @@ void describe('event websocket protocol', () => {
       ),
       { domain: 42161, eventType: 'merkle_tree_insertion', id: 123n },
     );
+    assert.deepEqual(
+      parseEventNotification(
+        '{"eventType":"dispatch","id":"124","domain":-846819108}',
+      ),
+      { domain: 3448148188, eventType: 'dispatch', id: 124n },
+    );
     assert.throws(() =>
       parseEventNotification(
         '{"eventType":"unknown","id":"123","domain":42161}',
+      ),
+    );
+    assert.throws(() =>
+      parseEventNotification(
+        '{"eventType":"dispatch","id":"123","domain":-2147483649}',
       ),
     );
   });

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -23,9 +23,9 @@ import {
   EVENT_TYPES,
   type EventNotification,
   type EventType,
-  isDomain,
   isSequencedEventType,
   normalizeSequenceAddress,
+  parseDatabaseDomain,
   parseClientMessage,
   parseEventNotification,
   parseExplorerNotification,
@@ -162,6 +162,13 @@ const STREAMS: Record<EventType, Stream> = {
     'merkle_tree_hook',
     'leaf_index',
   ),
+};
+
+const EVENT_DOMAIN_COLUMNS: Record<EventType, readonly string[]> = {
+  delivery: ['domain'],
+  dispatch: ['origin_domain', 'destination_domain'],
+  gas_payment: ['domain', 'origin', 'destination'],
+  merkle_tree_insertion: ['domain'],
 };
 
 export class EventWebSocketServer {
@@ -903,7 +910,7 @@ export class EventWebSocketServer {
         subscription.sequences.set(sequenceCursorKey, sequence.value);
       }
     }
-    const data = eventType === 'gas_payment' ? withoutStreamCursor(row) : row;
+    const data = eventData(eventType, row);
     const rowId =
       eventType === 'gas_payment' ? parseId(row.id).toString() : undefined;
     const legacyMaxStreamCursor = streamCursor
@@ -947,7 +954,7 @@ export class EventWebSocketServer {
     return this.db.queryLive<Row>(
       `SELECT ${columns(stream)} FROM ${q(stream.table)} WHERE ${q(stream.domain)} = $1 AND ${q(sequence.address)} = $2::bytea AND ${q(sequence.value)} > $3::bigint AND ${q(sequence.value)} <= $4::bigint ORDER BY ${q(sequence.value)} ASC LIMIT $5`,
       [
-        cursor.domain,
+        storedDomain(cursor.domain),
         cursor.address,
         after.toString(),
         through.toString(),
@@ -964,7 +971,7 @@ export class EventWebSocketServer {
     const sequence = sequenceConfig(stream);
     const [row] = await this.db.queryLive<{ first: string; last: string }>(
       `SELECT COALESCE(MIN(${q(sequence.value)}), 0)::text AS first, COALESCE(MAX(${q(sequence.value)}), -1)::text AS last FROM ${q(stream.table)} WHERE ${q(stream.domain)} = $1 AND ${q(sequence.address)} = $2::bytea`,
-      [cursor.domain, cursor.address],
+      [storedDomain(cursor.domain), cursor.address],
     );
     return {
       first: parseSequence(row?.first ?? '0'),
@@ -981,7 +988,7 @@ export class EventWebSocketServer {
     return this.db.queryLive<Row>(
       `SELECT ${gasPaymentColumns(stream)}, ${q('event_row')}.${q('id')} AS ${q(STREAM_CURSOR_COLUMN)} FROM ${q(stream.table)} AS ${q('event_row')}${gasPaymentMetadataJoins('LEFT JOIN')} WHERE ${q('event_row')}.${q(stream.domain)} = $1 AND ${q('event_row')}.${q('interchain_gas_paymaster')} = $2::bytea AND ${q('event_row')}.${q('id')} > $3::bigint AND ${q('event_row')}.${q('id')} <= $4::bigint ORDER BY ${q('event_row')}.${q('id')} ASC LIMIT $5`,
       [
-        cursor.domain,
+        storedDomain(cursor.domain),
         cursor.address,
         after.toString(),
         through.toString(),
@@ -999,7 +1006,7 @@ export class EventWebSocketServer {
     return this.db.queryLive<Row>(
       `SELECT ${gasPaymentColumns(stream)}, ${q('event_cursor')}.${q('stream_cursor')} AS ${q(STREAM_CURSOR_COLUMN)} FROM ${q(GAS_PAYMENT_STREAM_CURSOR)} AS ${q('event_cursor')} INNER JOIN ${q(stream.table)} AS ${q('event_row')} ON ${q('event_row')}.${q('id')} = ${q('event_cursor')}.${q('gas_payment_id')}${gasPaymentMetadataJoins('LEFT JOIN')} WHERE ${q('event_cursor')}.${q('domain')} = $1 AND ${q('event_cursor')}.${q('interchain_gas_paymaster')} = $2::bytea AND ${q('event_cursor')}.${q('stream_cursor')} > $3::bigint AND ${q('event_cursor')}.${q('stream_cursor')} <= $4::bigint ORDER BY ${q('event_cursor')}.${q('stream_cursor')} ASC LIMIT $5`,
       [
-        cursor.domain,
+        storedDomain(cursor.domain),
         cursor.address,
         after.toString(),
         through.toString(),
@@ -1016,7 +1023,7 @@ export class EventWebSocketServer {
       legacy_max_id: string;
     }>(
       `SELECT COALESCE(${q('legacy_max_id')}, 0)::text AS legacy_max_id, COALESCE(${q('last_cursor')}, 0)::text AS last_cursor FROM ${q(GAS_PAYMENT_STREAM_HEAD)} WHERE ${q('domain')} = $1 AND ${q('interchain_gas_paymaster')} = $2::bytea`,
-      [cursor.domain, cursor.address],
+      [storedDomain(cursor.domain), cursor.address],
     );
     return {
       lastCursor: parseId(row?.last_cursor ?? '0'),
@@ -1539,10 +1546,23 @@ function sequenceConfig(stream: Stream): NonNullable<Stream['sequence']> {
 }
 
 function rowDomain(row: Row, column: string): number {
-  const value = row[column];
-  const domain = typeof value === 'string' ? Number(value) : value;
-  if (!isDomain(domain)) throw new Error(`Invalid ${column} in event row`);
-  return domain;
+  return parseDatabaseDomain(row[column], `Invalid ${column} in event row`);
+}
+
+function eventData(eventType: EventType, row: Row): Row {
+  let data = eventType === 'gas_payment' ? withoutStreamCursor(row) : row;
+  for (const column of EVENT_DOMAIN_COLUMNS[eventType]) {
+    const domain = parseDatabaseDomain(
+      data[column],
+      `Invalid ${column} in event row`,
+    );
+    if (data[column] !== domain) data = { ...data, [column]: domain };
+  }
+  return data;
+}
+
+function storedDomain(domain: number): number {
+  return domain > 0x7fff_ffff ? domain - 0x1_0000_0000 : domain;
 }
 
 function rowSequence(

--- a/typescript/scraper-proxy/src/live/protocol.ts
+++ b/typescript/scraper-proxy/src/live/protocol.ts
@@ -82,15 +82,14 @@ export function parseEventNotification(
   } catch {
     throw new Error('Invalid scraper event notification JSON');
   }
-  if (
-    !isRecord(value) ||
-    !isEventType(value.eventType) ||
-    !isDomain(value.domain)
-  ) {
+  if (!isRecord(value) || !isEventType(value.eventType)) {
     throw new Error('Invalid scraper event notification');
   }
   return {
-    domain: value.domain,
+    domain: parseDatabaseDomain(
+      value.domain,
+      'Invalid scraper event notification',
+    ),
     eventType: value.eventType,
     id: parseId(value.id),
   };
@@ -128,6 +127,19 @@ export function isDomain(value: unknown): value is number {
     value >= 0 &&
     value <= 0xffff_ffff
   );
+}
+
+export function parseDatabaseDomain(value: unknown, error: string): number {
+  const stored = typeof value === 'string' ? Number(value) : value;
+  if (
+    typeof stored !== 'number' ||
+    !Number.isInteger(stored) ||
+    stored < -0x8000_0000 ||
+    stored > 0xffff_ffff
+  ) {
+    throw new Error(error);
+  }
+  return stored < 0 ? stored + 0x1_0000_0000 : stored;
 }
 
 export function normalizeAddress(value: string): string {

--- a/typescript/scraper-proxy/src/live/protocol.ts
+++ b/typescript/scraper-proxy/src/live/protocol.ts
@@ -130,7 +130,8 @@ export function isDomain(value: unknown): value is number {
 }
 
 export function parseDatabaseDomain(value: unknown, error: string): number {
-  const stored = typeof value === 'string' ? Number(value) : value;
+  const stored =
+    typeof value === 'string' && /^-?\d+$/.test(value) ? Number(value) : value;
   if (
     typeof stored !== 'number' ||
     !Number.isInteger(stored) ||


### PR DESCRIPTION
## Summary

- normalize legacy signed PostgreSQL domain IDs before emitting private agent WebSocket events
- encode canonical unsigned high domains back to signed database keys for historical replay queries
- accept signed database notifications and cover every current agent stream shape

## Why

The testnet4 omniscient relayer repeatedly rejected Hyperliquid testnet dispatch nonce 888 because destination domain `3448148188` is stored as `-846819108` in the scraper database. The proxy forwarded that signed value unchanged, while the Rust agent wire type requires `u32`, so the shadow stream disconnected and replayed the same row roughly every five seconds.

This is separate from proxy buffer pressure: rejection and buffer-failure counters were zero on the current proxy rollout. The relayer remains RPC-authoritative, so delivery was not blocked, but the scraper-proxy warning correctly detected the repeated send failures.

Public GraphQL responses are unchanged; normalization is limited to the private `/agents` WebSocket boundary and its catch-up filters.

## Validation

- `pnpm --filter @hyperlane-xyz/scraper-proxy... build`
- `pnpm --filter @hyperlane-xyz/scraper-proxy test` (104 passed)
- `pnpm --filter @hyperlane-xyz/scraper-proxy lint`
- `pnpm --filter @hyperlane-xyz/scraper-proxy build`
- pre-commit gitleaks, oxlint, and oxfmt

## Rollout

Code-only draft. After merge: build and deploy a scraper-proxy image, then verify relayer shadow-stream reconnects stop and proxy `send_error` no longer increases. No alert tuning is included.