### PR TITLE
chore(infra): update scraper proxy image tags

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: 'fc544bf-20260908-174702',
   warpMonitor: 'fc544bf-20260908-174702',
   rebalancer: 'fc544bf-20260908-174702',
-  scraperProxy: '7762855-20260911-015136',
+  scraperProxy: '9e61e65-20260911-233459',
   feeQuoting: '12d899d-20260325-184337',
 };
 
@@ -72,5 +72,5 @@ export const testnetDockerTags: BaseDockerTags = {
   scraper: 'b83bac5-20260909-225045',
   // standalone services
   keyFunder: 'fc544bf-20260908-174702',
-  scraperProxy: '7762855-20260911-015136',
+  scraperProxy: '9e61e65-20260911-233459',
 };


### PR DESCRIPTION
## Problem

The mainnet3 and testnet4 scraper-proxy infra defaults must track the merged signed-domain normalization release.

## Change

Update both scraper-proxy tags to `9e61e65-20260911-233459` (`sha256:07df3cab092b1779e5cbf16ae27619e010652dee0f76e3a912d0617d573e0663`), built from merged `main` commit `9e61e6532d6d98c9ac8d33734cb1abfd62d5890a`.

## Validation

- Published image manifest and digest verified
- Agent config tests: 24 passing
- Commit hooks: gitleaks, oxlint, oxfmt
- `git diff --check`
- testnet4: Helm revision 5; deployment Ready, 1/1 updated, zero pod restarts; listener ready; zero database query errors and queue overflows
- mainnet3: Helm revision 13; deployment Ready, 1/1 updated, zero pod restarts; listener ready; zero database query, catch-up, send, and queue errors
- Both running containers resolve to `sha256:07df3cab092b1779e5cbf16ae27619e010652dee0f76e3a912d0617d573e0663`
- Testnet Seismic no-history and client-reset warnings were confirmed in GCP logs on the prior image before rollout