### PR TITLE
perf(rebalancer): bound monitor snapshot reads

### DIFF
--- a/.changeset/bounded-rebalancer-monitor.md
+++ b/.changeset/bounded-rebalancer-monitor.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+The monitor bounded and parallelized independent chain, token supply, and inventory balance reads while preserving snapshot ordering.

--- a/typescript/rebalancer/src/monitor/Monitor.test.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.test.ts
@@ -1,0 +1,157 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import type { ChainName, Token, WarpCore } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { MonitorEventType } from '../interfaces/IMonitor.js';
+import { Monitor } from './Monitor.js';
+
+const logger = pino({ level: 'silent' });
+
+type TestToken = Token & { bridgedSupplyStub: Sinon.SinonStub };
+
+function createToken(chainName: ChainName, symbol: string): TestToken {
+  const getBridgedSupply = Sinon.stub();
+  return {
+    chainName,
+    symbol,
+    name: symbol,
+    decimals: 18,
+    addressOrDenom: `0x${symbol.padEnd(40, '0')}`,
+    protocol: ProtocolType.Ethereum,
+    isHypToken: () => true,
+    getHypAdapter: () => ({ getBridgedSupply }),
+    bridgedSupplyStub: getBridgedSupply,
+    // Monitor only reads this Token subset in these unit tests.
+  } as unknown as TestToken;
+}
+
+function createMultiProvider() {
+  return {
+    getChainMetadata: (chain: ChainName) => ({
+      protocol: ProtocolType.Ethereum,
+      blocks: { reorgPeriod: chain === 'ethereum' ? 10 : 20 },
+    }),
+    getEthersV5Provider: (chain: ChainName) => ({
+      getBlockNumber: async () => (chain === 'ethereum' ? 100 : 200),
+    }),
+  };
+}
+
+describe('Monitor', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('preserves token order and uses confirmed block tags per token chain', async () => {
+    const ethereumToken = createToken('ethereum', 'ETH');
+    const arbitrumToken = createToken('arbitrum', 'ARB');
+    const secondEthereumToken = createToken('ethereum', 'ETH2');
+    ethereumToken.bridgedSupplyStub.resolves(100n);
+    arbitrumToken.bridgedSupplyStub.resolves(200n);
+    secondEthereumToken.bridgedSupplyStub.resolves(300n);
+
+    const warpCore = {
+      tokens: [ethereumToken, arbitrumToken, secondEthereumToken],
+      multiProvider: createMultiProvider(),
+      // Monitor only reads tokens and multiProvider in these unit tests.
+    } as unknown as WarpCore;
+    const monitor = new Monitor(0, warpCore, logger);
+
+    const eventPromise = new Promise<unknown>((resolve) => {
+      monitor.on(MonitorEventType.TokenInfo, (event) => {
+        resolve(event);
+        void monitor.stop();
+      });
+    });
+
+    await monitor.start();
+    const event = (await eventPromise) as {
+      tokensInfo: Array<{ token: Token; bridgedSupply: bigint }>;
+      confirmedBlockTags: Record<string, number>;
+    };
+
+    expect(event.tokensInfo.map(({ token }) => token.symbol)).to.deep.equal([
+      'ETH',
+      'ARB',
+      'ETH2',
+    ]);
+    expect(event.tokensInfo.map(({ bridgedSupply }) => bridgedSupply)).to.eql([
+      100n,
+      200n,
+      300n,
+    ]);
+    expect(event.confirmedBlockTags).to.deep.equal({
+      ethereum: 90,
+      arbitrum: 180,
+    });
+    expect(
+      ethereumToken.bridgedSupplyStub.calledWithExactly({ blockTag: 90 }),
+    ).to.equal(true);
+    expect(
+      arbitrumToken.bridgedSupplyStub.calledWithExactly({ blockTag: 180 }),
+    ).to.equal(true);
+    expect(
+      secondEthereumToken.bridgedSupplyStub.calledWithExactly({
+        blockTag: 90,
+      }),
+    ).to.equal(true);
+  });
+
+  it('limits bridged supply reads to eight at a time', async () => {
+    const tokens = Array.from({ length: 10 }, (_, index) =>
+      createToken('ethereum', `T${index}`),
+    );
+    let active = 0;
+    let maxActive = 0;
+    let started = 0;
+    let releaseReads: () => void;
+    const readsReleased = new Promise<void>((resolve) => {
+      releaseReads = resolve;
+    });
+    let resolveLimitReached: () => void;
+    const limitReached = new Promise<void>((resolve) => {
+      resolveLimitReached = resolve;
+    });
+
+    tokens.forEach((token, index) => {
+      token.bridgedSupplyStub.callsFake(async () => {
+        active += 1;
+        started += 1;
+        maxActive = Math.max(maxActive, active);
+        if (started === 8) resolveLimitReached();
+        await readsReleased;
+        active -= 1;
+        return BigInt(index);
+      });
+    });
+
+    const warpCore = {
+      tokens,
+      multiProvider: createMultiProvider(),
+    } as unknown as WarpCore;
+    const monitor = new Monitor(0, warpCore, logger);
+    const eventPromise = new Promise<unknown>((resolve) => {
+      monitor.on(MonitorEventType.TokenInfo, (event) => {
+        resolve(event);
+        void monitor.stop();
+      });
+    });
+
+    const startPromise = monitor.start();
+    await limitReached;
+    expect(started).to.equal(8);
+    releaseReads!();
+    const event = (await eventPromise) as {
+      tokensInfo: Array<{ bridgedSupply: bigint }>;
+    };
+    await startPromise;
+
+    expect(maxActive).to.equal(8);
+    expect(event.tokensInfo.map(({ bridgedSupply }) => bridgedSupply)).to.eql(
+      Array.from({ length: 10 }, (_, index) => BigInt(index)),
+    );
+  });
+});

--- a/typescript/rebalancer/src/monitor/Monitor.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.ts
@@ -6,7 +6,13 @@ import {
   type Token,
   type WarpCore,
 } from '@hyperlane-xyz/sdk';
-import { Address, ProtocolType, fromWei, sleep } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  ProtocolType,
+  concurrentMap,
+  fromWei,
+  sleep,
+} from '@hyperlane-xyz/utils';
 
 import {
   type ConfirmedBlockTag,
@@ -18,6 +24,8 @@ import {
   MonitorStartError,
 } from '../interfaces/IMonitor.js';
 import { getConfirmedBlockTag } from '../utils/blockTag.js';
+
+const MONITOR_READ_CONCURRENCY = 8;
 
 /**
  * Configuration for the Monitor's inventory tracking.
@@ -51,14 +59,24 @@ export class Monitor implements IMonitor {
 
   private async computeConfirmedBlockTags(): Promise<ConfirmedBlockTags> {
     const blockTags: ConfirmedBlockTags = {};
-    const chains = new Set(this.warpCore.tokens.map((t) => t.chainName));
-
-    for (const chain of chains) {
-      blockTags[chain] = await getConfirmedBlockTag(
-        this.warpCore.multiProvider,
+    const chains = Array.from(
+      new Set(this.warpCore.tokens.map((token) => token.chainName)),
+    );
+    const results = await concurrentMap(
+      MONITOR_READ_CONCURRENCY,
+      chains,
+      async (chain) => ({
         chain,
-        this.logger,
-      );
+        blockTag: await getConfirmedBlockTag(
+          this.warpCore.multiProvider,
+          chain,
+          this.logger,
+        ),
+      }),
+    );
+
+    for (const { chain, blockTag } of results) {
+      blockTags[chain] = blockTag;
     }
 
     return blockTags;
@@ -112,30 +130,29 @@ export class Monitor implements IMonitor {
           const confirmedBlockTags = await this.computeConfirmedBlockTags();
 
           const event: MonitorEvent = {
-            tokensInfo: [],
+            tokensInfo: await concurrentMap(
+              MONITOR_READ_CONCURRENCY,
+              this.warpCore.tokens,
+              async (token) => {
+                this.logger.debug(
+                  {
+                    chain: token.chainName,
+                    tokenSymbol: token.symbol,
+                    tokenAddress: token.addressOrDenom,
+                  },
+                  'Checking token',
+                );
+                const blockTag = confirmedBlockTags[token.chainName];
+                const bridgedSupply = await this.getTokenBridgedSupply(
+                  token,
+                  blockTag,
+                );
+
+                return { token, bridgedSupply };
+              },
+            ),
             confirmedBlockTags,
           };
-
-          for (const token of this.warpCore.tokens) {
-            this.logger.debug(
-              {
-                chain: token.chainName,
-                tokenSymbol: token.symbol,
-                tokenAddress: token.addressOrDenom,
-              },
-              'Checking token',
-            );
-            const blockTag = confirmedBlockTags[token.chainName];
-            const bridgedSupply = await this.getTokenBridgedSupply(
-              token,
-              blockTag,
-            );
-
-            event.tokensInfo.push({
-              token,
-              bridgedSupply,
-            });
-          }
 
           const inventoryBalances = await this.fetchInventoryBalances();
           if (Object.keys(inventoryBalances).length > 0) {
@@ -264,51 +281,55 @@ export class Monitor implements IMonitor {
   }
 
   private async fetchInventoryBalances(): Promise<ChainMap<bigint>> {
-    if (!this.inventoryConfig) return {};
+    const inventoryConfig = this.inventoryConfig;
+    if (!inventoryConfig) return {};
 
     const balances: ChainMap<bigint> = {};
 
-    const readPromises = this.inventoryConfig.chains.map(async (chainName) => {
-      const token = this.warpCore.tokens.find((t) => t.chainName === chainName);
-      if (!token) {
-        this.logger.warn(
-          { chain: chainName },
-          'No token found for inventory chain',
+    const results = await concurrentMap(
+      MONITOR_READ_CONCURRENCY,
+      inventoryConfig.chains,
+      async (chainName) => {
+        const token = this.warpCore.tokens.find(
+          (candidate) => candidate.chainName === chainName,
         );
-        return { chainName, balance: 0n };
-      }
-
-      try {
-        const address =
-          this.inventoryConfig!.inventoryAddresses[token.protocol];
-        if (!address) {
+        if (!token) {
           this.logger.warn(
-            { chain: chainName, protocol: token.protocol },
-            'No inventory address for chain protocol, skipping',
+            { chain: chainName },
+            'No token found for inventory chain',
           );
           return { chainName, balance: 0n };
         }
-        const adapter = token.getAdapter(this.warpCore.multiProvider);
-        const balance = await adapter.getBalance(address);
-        this.logger.debug(
-          {
-            chain: chainName,
-            token: token.addressOrDenom,
-            balance: balance.toString(),
-          },
-          'Read inventory balance',
-        );
-        return { chainName, balance };
-      } catch (error) {
-        this.logger.error(
-          { chain: chainName, error: (error as Error).message },
-          'Failed to read inventory balance',
-        );
-        return { chainName, balance: 0n };
-      }
-    });
 
-    const results = await Promise.all(readPromises);
+        try {
+          const address = inventoryConfig.inventoryAddresses[token.protocol];
+          if (!address) {
+            this.logger.warn(
+              { chain: chainName, protocol: token.protocol },
+              'No inventory address for chain protocol, skipping',
+            );
+            return { chainName, balance: 0n };
+          }
+          const adapter = token.getAdapter(this.warpCore.multiProvider);
+          const balance = await adapter.getBalance(address);
+          this.logger.debug(
+            {
+              chain: chainName,
+              token: token.addressOrDenom,
+              balance: balance.toString(),
+            },
+            'Read inventory balance',
+          );
+          return { chainName, balance };
+        } catch (error) {
+          this.logger.error(
+            { chain: chainName, error: (error as Error).message },
+            'Failed to read inventory balance',
+          );
+          return { chainName, balance: 0n };
+        }
+      },
+    );
 
     for (const { chainName, balance } of results) {
       balances[chainName] = balance;


### PR DESCRIPTION
### Description

Bounds the rebalancer monitor's recurring RPC fanout at eight concurrent reads while preserving token order and confirmed block tags.

The current merged-main fleet runs 11 rebalancers every 60 seconds and monitors 77 route-token entries across 28 distinct chains. Previously, confirmed block tags and bridged supplies were read serially within each process. This change:

- reads unique-chain confirmed block tags with bounded concurrency;
- reads route-token bridged supplies with the same bound while preserving input order;
- applies the bound to inventory balance reads as well; and
- adds regression coverage for confirmed tags, ordering, and the concurrency ceiling.

This is code/cardinality-backed; it has not been deployed or measured in production yet.

### Stack

- #9630 (this PR)
- #9631
- #9632
- #9633

### Drive-by changes

None.

### Related issues

Supersedes the monitor hot-path portion of #8880.

### Backward compatibility

Yes. Polling semantics and emitted monitor events are unchanged.

### Testing

- Unit tests for ordering, confirmed block tags, and maximum concurrency
- `pnpm -C typescript/rebalancer test:ci` (413 passing on the combined stack)
- `pnpm -C typescript/rebalancer build`
- `pnpm -C typescript/rebalancer lint`
- `pnpm -C typescript/rebalancer-sim build`
- `pnpm -C typescript/rebalancer-sim lint`
