### PR TITLE
perf(rebalancer): batch tracker hot paths

### DIFF
--- a/.changeset/batch-rebalancer-tracker.md
+++ b/.changeset/batch-rebalancer-tracker.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+'@hyperlane-xyz/rebalancer-sim': patch
+---
+
+The action tracker batched intent projections and bounded independent delivery checks to avoid repeated store scans and serial RPC latency.

--- a/typescript/rebalancer-sim/src/runners/MockActionTracker.ts
+++ b/typescript/rebalancer-sim/src/runners/MockActionTracker.ts
@@ -70,6 +70,18 @@ export class MockActionTracker implements IActionTracker {
     );
   }
 
+  async getActionsForIntents(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>> {
+    const actionsByIntent = new Map(
+      intentIds.map((intentId) => [intentId, [] as RebalanceAction[]]),
+    );
+    for (const action of this.actions.values()) {
+      actionsByIntent.get(action.intentId)?.push(action);
+    }
+    return actionsByIntent;
+  }
+
   async getInflightInventoryMovements(_origin: Domain): Promise<bigint> {
     // No inventory movements in simulation
     return 0n;

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -46,6 +46,7 @@ function createMockActionTracker(): IActionTracker {
     getPartiallyFulfilledInventoryIntents: Sinon.stub().resolves([]),
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
+    getActionsForIntents: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
 }

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -99,6 +99,7 @@ function createMockActionTracker(): IActionTracker {
     getPartiallyFulfilledInventoryIntents: Sinon.stub().resolves([]),
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
+    getActionsForIntents: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
 }

--- a/typescript/rebalancer/src/core/RebalancerService.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.test.ts
@@ -136,6 +136,7 @@ function createMockActionTracker(): IActionTracker {
     getPartiallyFulfilledInventoryIntents: Sinon.stub().resolves([]),
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
+    getActionsForIntents: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
 }

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -569,6 +569,42 @@ describe('ActionTracker', () => {
     });
   });
 
+  describe('batched action queries', () => {
+    it('groups requested intents with one store scan', async () => {
+      const getAll = Sinon.spy(rebalanceActionStore, 'getAll');
+      const createAction = (id: string, intentId: string): RebalanceAction => ({
+        id,
+        intentId,
+        type: 'rebalance_message',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await rebalanceActionStore.save(createAction('action-1', 'intent-1'));
+      await rebalanceActionStore.save(createAction('action-2', 'intent-2'));
+      await rebalanceActionStore.save(createAction('action-3', 'other'));
+
+      const actionsByIntent = await tracker.getActionsForIntents([
+        'intent-1',
+        'intent-2',
+        'missing',
+      ]);
+
+      expect(getAll.calledOnce).to.equal(true);
+      expect(actionsByIntent.get('intent-1')?.map(({ id }) => id)).to.eql([
+        'action-1',
+      ]);
+      expect(actionsByIntent.get('intent-2')?.map(({ id }) => id)).to.eql([
+        'action-2',
+      ]);
+      expect(actionsByIntent.get('missing')).to.eql([]);
+      expect(actionsByIntent.has('other')).to.equal(false);
+    });
+  });
+
   describe('syncInventoryMovementActions', () => {
     it('stores pending status on in-progress movement', async () => {
       await rebalanceActionStore.save({
@@ -1468,6 +1504,122 @@ describe('ActionTracker', () => {
   });
 
   describe('delivery check synchronization', () => {
+    it('limits delivery reads and reuses the destination block tag', async () => {
+      for (let index = 0; index < 10; index += 1) {
+        await transferStore.save({
+          id: `0xmsg${index}`,
+          status: 'in_progress',
+          messageId: `0xmsg${index}`,
+          origin: 1,
+          destination: 2,
+          amount: 100n,
+          sender: '0xuser1',
+          recipient: '0xuser2',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+      }
+      explorerClient.getInflightUserTransfers.resolves([]);
+      core.multiProvider.getChainMetadata = Sinon.stub().throws(
+        new Error('no metadata'),
+      );
+
+      let active = 0;
+      let maxActive = 0;
+      let started = 0;
+      let releaseReads: () => void;
+      const readsReleased = new Promise<void>((resolve) => {
+        releaseReads = resolve;
+      });
+      let resolveLimitReached: () => void;
+      const limitReached = new Promise<void>((resolve) => {
+        resolveLimitReached = resolve;
+      });
+      mailboxStub.isDelivered.callsFake(async () => {
+        active += 1;
+        started += 1;
+        maxActive = Math.max(maxActive, active);
+        if (started === 8) resolveLimitReached();
+        await readsReleased;
+        active -= 1;
+        return false;
+      });
+
+      const syncPromise = tracker.syncTransfers();
+      await limitReached;
+      expect(started).to.equal(8);
+      releaseReads!();
+      await syncPromise;
+
+      expect(mailboxStub.isDelivered.callCount).to.equal(10);
+      expect(maxActive).to.equal(8);
+      expect(core.multiProvider.getChainMetadata.calledOnce).to.equal(true);
+    });
+
+    it('shares the delivery limit across concurrent tracker syncs', async () => {
+      for (let index = 0; index < 8; index += 1) {
+        await transferStore.save({
+          id: `0xtransfer${index}`,
+          status: 'in_progress',
+          messageId: `0xtransfer${index}`,
+          origin: 1,
+          destination: 2,
+          amount: 100n,
+          sender: '0xuser1',
+          recipient: '0xuser2',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+        await rebalanceActionStore.save({
+          id: `action-${index}`,
+          intentId: `intent-${index}`,
+          status: 'in_progress',
+          type: 'rebalance_message',
+          messageId: `0xaction${index}`,
+          origin: 1,
+          destination: 2,
+          amount: 100n,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+      }
+      explorerClient.getInflightUserTransfers.resolves([]);
+      explorerClient.getInflightRebalanceActions.resolves([]);
+
+      let active = 0;
+      let maxActive = 0;
+      let started = 0;
+      let releaseReads: () => void;
+      const readsReleased = new Promise<void>((resolve) => {
+        releaseReads = resolve;
+      });
+      let resolveLimitReached: () => void;
+      const limitReached = new Promise<void>((resolve) => {
+        resolveLimitReached = resolve;
+      });
+      mailboxStub.isDelivered.callsFake(async () => {
+        active += 1;
+        started += 1;
+        maxActive = Math.max(maxActive, active);
+        if (started === 8) resolveLimitReached();
+        await readsReleased;
+        active -= 1;
+        return false;
+      });
+
+      const syncPromise = Promise.all([
+        tracker.syncTransfers({ chain2: 123 }),
+        tracker.syncRebalanceActions({ chain2: 123 }),
+      ]);
+      await limitReached;
+      expect(started).to.equal(8);
+      releaseReads!();
+      await syncPromise;
+
+      expect(mailboxStub.isDelivered.callCount).to.equal(16);
+      expect(maxActive).to.equal(8);
+    });
+
     it('should check delivery status in syncTransfers using adapter', async () => {
       await transferStore.save({
         id: '0xmsg1',
@@ -1731,6 +1883,74 @@ describe('ActionTracker', () => {
       const call = mailboxStub.isDelivered.firstCall;
       expect(call.args[0]).to.equal('0xmsg1');
       expect(call.args[1]).to.be.undefined;
+    });
+  });
+
+  describe('logStoreContents', () => {
+    it('keeps the summary at info and item details at debug', async () => {
+      await transferStore.save({
+        id: 'transfer-1',
+        status: 'in_progress',
+        messageId: '0xmsg1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        sender: '0xsender1',
+        recipient: '0xrecipient1',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await rebalanceIntentStore.save({
+        id: 'intent-1',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await rebalanceActionStore.save({
+        id: 'action-1',
+        status: 'in_progress',
+        type: 'rebalance_message',
+        intentId: 'intent-1',
+        messageId: '0xmsg1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      const logger = {
+        info: Sinon.stub(),
+        debug: Sinon.stub(),
+      };
+      const trackerWithLogger = new ActionTracker(
+        transferStore,
+        rebalanceIntentStore,
+        rebalanceActionStore,
+        explorerClient,
+        core,
+        config,
+        logger as any,
+      );
+
+      await trackerWithLogger.logStoreContents();
+
+      expect(logger.info.calledOnce).to.equal(true);
+      expect(
+        logger.info.calledWithMatch(Sinon.match.any, 'Store summary'),
+      ).to.equal(true);
+      expect(logger.debug.callCount).to.equal(3);
+      expect(
+        logger.debug.calledWithMatch(Sinon.match.any, 'In-progress transfer'),
+      ).to.equal(true);
+      expect(
+        logger.debug.calledWithMatch(Sinon.match.any, 'Active intent'),
+      ).to.equal(true);
+      expect(
+        logger.debug.calledWithMatch(Sinon.match.any, 'In-progress action'),
+      ).to.equal(true);
     });
   });
 });

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -3,7 +3,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { MultiProtocolCore } from '@hyperlane-xyz/sdk';
 import type { Address, Domain } from '@hyperlane-xyz/utils';
-import { assert, parseWarpRouteMessage } from '@hyperlane-xyz/utils';
+import {
+  assert,
+  concurrentMap,
+  parseWarpRouteMessage,
+} from '@hyperlane-xyz/utils';
 
 import { DEFAULT_MOVEMENT_STALENESS_MS } from '../config/types.js';
 import type { ExternalBridgeRegistry } from '../interfaces/IExternalBridge.js';
@@ -30,6 +34,8 @@ import type {
   Transfer,
 } from './types.js';
 
+const DELIVERY_CHECK_CONCURRENCY = 8;
+
 export interface ActionTrackerConfig {
   routersByDomain: Record<number, string>; // Domain ID → router address (source of truth for routers and domains)
   bridges: Address[]; // Bridge contract addresses for rebalance action queries
@@ -42,6 +48,9 @@ export interface ActionTrackerConfig {
  * ActionTracker implementation managing the lifecycle of tracked entities.
  */
 export class ActionTracker implements IActionTracker {
+  private activeDeliveryChecks = 0;
+  private readonly pendingDeliveryChecks: Array<() => void> = [];
+
   constructor(
     private readonly transferStore: ITransferStore,
     private readonly rebalanceIntentStore: IRebalanceIntentStore,
@@ -180,18 +189,24 @@ export class ActionTracker implements IActionTracker {
       }
     }
 
+    const getBlockTag = this.getConfirmedBlockTagLoader(confirmedBlockTags);
     const existingTransfers = await this.getInProgressTransfers();
-    for (const transfer of existingTransfers) {
-      const blockTag = await this.getConfirmedBlockTag(
-        transfer.destination,
-        confirmedBlockTags,
-      );
-      const delivered = await this.isMessageDelivered(
-        transfer.messageId,
-        transfer.destination,
-        blockTag,
-      );
+    const transferDeliveries = await concurrentMap(
+      DELIVERY_CHECK_CONCURRENCY,
+      existingTransfers,
+      async (transfer) => ({
+        transfer,
+        delivered: await this.withDeliveryCheckLimit(async () =>
+          this.isMessageDelivered(
+            transfer.messageId,
+            transfer.destination,
+            await getBlockTag(transfer.destination),
+          ),
+        ),
+      }),
+    );
 
+    for (const { transfer, delivered } of transferDeliveries) {
       if (delivered) {
         await this.transferStore.update(transfer.id, { status: 'complete' });
         completedTransfers++;
@@ -216,11 +231,13 @@ export class ActionTracker implements IActionTracker {
     // Check in_progress intents for completion or TTL expiry
     const inProgressIntents =
       await this.rebalanceIntentStore.getByStatus('in_progress');
-    const allInProgressActions =
-      await this.rebalanceActionStore.getByStatus('in_progress');
+    const actionsByIntent = await this.getActionsForIntents(
+      inProgressIntents.map((intent) => intent.id),
+    );
     const now = Date.now();
     for (const intent of inProgressIntents) {
-      const completedAmount = await this.getCompletedAmountForIntent(intent.id);
+      const actions = actionsByIntent.get(intent.id) ?? [];
+      const completedAmount = this.getCompletedAmount(actions);
       if (completedAmount >= intent.amount) {
         await this.rebalanceIntentStore.update(intent.id, {
           status: 'complete',
@@ -232,8 +249,8 @@ export class ActionTracker implements IActionTracker {
         });
 
         // Fail any in-progress actions associated with the expired intent
-        for (const action of allInProgressActions) {
-          if (action.intentId === intent.id) {
+        for (const action of actions) {
+          if (action.status === 'in_progress') {
             await this.rebalanceActionStore.update(action.id, {
               status: 'failed',
             });
@@ -289,10 +306,12 @@ export class ActionTracker implements IActionTracker {
       'Found inflight rebalance actions from Explorer',
     );
 
-    const allActions = await this.rebalanceActionStore.getAll();
+    const actionsByMessageId = await this.getActionsByMessageIds(
+      inflightMessages.map((message) => message.msg_id),
+    );
 
     for (const msg of inflightMessages) {
-      const existingAction = allActions.find((a) => a.messageId === msg.msg_id);
+      const existingAction = actionsByMessageId.get(msg.msg_id);
 
       if (!existingAction) {
         this.logger.info(
@@ -313,22 +332,30 @@ export class ActionTracker implements IActionTracker {
     // inventory_movement actions are synced separately via LiFi status API
     const inProgressActions =
       await this.rebalanceActionStore.getByStatus('in_progress');
-    for (const action of inProgressActions) {
-      // Skip actions without messageId (e.g., inventory_movement)
-      if (!action.messageId) {
-        continue;
-      }
+    const deliverableActions = inProgressActions.filter(
+      (action) => action.messageId,
+    );
+    const getBlockTag = this.getConfirmedBlockTagLoader(confirmedBlockTags);
+    const actionDeliveries = await concurrentMap(
+      DELIVERY_CHECK_CONCURRENCY,
+      deliverableActions,
+      async (action) => {
+        const messageId = action.messageId;
+        assert(messageId, `Missing messageId for action ${action.id}`);
+        return {
+          action,
+          delivered: await this.withDeliveryCheckLimit(async () =>
+            this.isMessageDelivered(
+              messageId,
+              action.destination,
+              await getBlockTag(action.destination),
+            ),
+          ),
+        };
+      },
+    );
 
-      const blockTag = await this.getConfirmedBlockTag(
-        action.destination,
-        confirmedBlockTags,
-      );
-      const delivered = await this.isMessageDelivered(
-        action.messageId,
-        action.destination,
-        blockTag,
-      );
-
+    for (const { action, delivered } of actionDeliveries) {
       if (delivered) {
         await this.completeRebalanceAction(action.id);
         completedActions++;
@@ -525,6 +552,10 @@ export class ActionTracker implements IActionTracker {
    */
   private async getCompletedAmountForIntent(intentId: string): Promise<bigint> {
     const actions = await this.getActionsForIntent(intentId);
+    return this.getCompletedAmount(actions);
+  }
+
+  private getCompletedAmount(actions: readonly RebalanceAction[]): bigint {
     return actions
       .filter(
         (a) =>
@@ -582,12 +613,16 @@ export class ActionTracker implements IActionTracker {
 
     const allActiveIntents = [...inProgressIntents, ...notStartedIntents];
     const partialIntents: PartialInventoryIntent[] = [];
+    const inventoryIntentIds = allActiveIntents
+      .filter((intent) => intent.executionMethod === 'inventory')
+      .map((intent) => intent.id);
+    const actionsByIntent = await this.getActionsForIntents(inventoryIntentIds);
 
     for (const intent of allActiveIntents) {
       // Only inventory execution method
       if (intent.executionMethod !== 'inventory') continue;
 
-      const actions = await this.getActionsForIntent(intent.id);
+      const actions = actionsByIntent.get(intent.id) ?? [];
 
       // Check for in-flight inventory_movement actions
       // Skip intents with active bridge movement(s). Movements still `pending` on
@@ -671,6 +706,21 @@ export class ActionTracker implements IActionTracker {
   async getActionsForIntent(intentId: string): Promise<RebalanceAction[]> {
     const allActions = await this.rebalanceActionStore.getAll();
     return allActions.filter((a) => a.intentId === intentId);
+  }
+
+  async getActionsForIntents(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>> {
+    const actionsByIntent = new Map(
+      intentIds.map((intentId) => [intentId, [] as RebalanceAction[]]),
+    );
+    if (actionsByIntent.size === 0) return actionsByIntent;
+
+    for (const action of await this.rebalanceActionStore.getAll()) {
+      actionsByIntent.get(action.intentId)?.push(action);
+    }
+
+    return actionsByIntent;
   }
 
   async syncInventoryMovementActions(
@@ -804,10 +854,7 @@ export class ActionTracker implements IActionTracker {
 
   // === Debug Helpers ===
 
-  /**
-   * Log the contents of all stores.
-   * Logs each item separately for full visibility (avoids [Object] truncation).
-   */
+  /** Log active store counts at info and item details at debug. */
   async logStoreContents(): Promise<void> {
     const transfers = await this.transferStore.getAll();
     const intents = await this.rebalanceIntentStore.getAll();
@@ -831,9 +878,8 @@ export class ActionTracker implements IActionTracker {
       'Store summary',
     );
 
-    // Log each transfer separately
     for (const t of inProgressTransfers) {
-      this.logger.info(
+      this.logger.debug(
         {
           type: 'transfer',
           origin: t.origin,
@@ -845,9 +891,8 @@ export class ActionTracker implements IActionTracker {
       );
     }
 
-    // Log each intent separately
     for (const i of activeIntents) {
-      this.logger.info(
+      this.logger.debug(
         {
           type: 'intent',
           id: i.id,
@@ -861,9 +906,8 @@ export class ActionTracker implements IActionTracker {
       );
     }
 
-    // Log each action separately
     for (const a of inProgressActions) {
-      this.logger.info(
+      this.logger.debug(
         {
           type: 'action',
           id: a.id,
@@ -879,6 +923,56 @@ export class ActionTracker implements IActionTracker {
   }
 
   // === Private Helpers ===
+
+  private async withDeliveryCheckLimit<T>(run: () => Promise<T>): Promise<T> {
+    if (this.activeDeliveryChecks >= DELIVERY_CHECK_CONCURRENCY) {
+      await new Promise<void>((resolve) => {
+        this.pendingDeliveryChecks.push(resolve);
+      });
+    }
+
+    this.activeDeliveryChecks += 1;
+    try {
+      return await run();
+    } finally {
+      this.activeDeliveryChecks -= 1;
+      this.pendingDeliveryChecks.shift()?.();
+    }
+  }
+
+  private async getActionsByMessageIds(
+    messageIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction>> {
+    const requestedMessageIds = new Set(messageIds);
+    if (requestedMessageIds.size === 0) return new Map();
+
+    const actionsByMessageId = new Map<string, RebalanceAction>();
+    for (const action of await this.rebalanceActionStore.getAll()) {
+      if (
+        action.messageId &&
+        requestedMessageIds.has(action.messageId) &&
+        !actionsByMessageId.has(action.messageId)
+      ) {
+        actionsByMessageId.set(action.messageId, action);
+      }
+    }
+    return actionsByMessageId;
+  }
+
+  private getConfirmedBlockTagLoader(
+    confirmedBlockTags?: ConfirmedBlockTags,
+  ): (destination: Domain) => Promise<string | number | undefined> {
+    const blockTags = new Map<Domain, Promise<string | number | undefined>>();
+
+    return (destination) => {
+      let blockTag = blockTags.get(destination);
+      if (!blockTag) {
+        blockTag = this.getConfirmedBlockTag(destination, confirmedBlockTags);
+        blockTags.set(destination, blockTag);
+      }
+      return blockTag;
+    };
+  }
 
   /**
    * Get the confirmed block tag for delivery checks.

--- a/typescript/rebalancer/src/tracking/IActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/IActionTracker.ts
@@ -168,6 +168,13 @@ export interface IActionTracker {
   getActionsForIntent(intentId: string): Promise<RebalanceAction[]>;
 
   /**
+   * Get actions grouped by intent ID using one tracker snapshot.
+   */
+  getActionsForIntents?(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>>;
+
+  /**
    * Get total inflight inventory movement amount from a specific chain.
    * Returns the sum of amounts for all in_progress inventory_movement actions
    * that originate from the specified domain.

--- a/typescript/rebalancer/src/tracking/InflightContextAdapter.test.ts
+++ b/typescript/rebalancer/src/tracking/InflightContextAdapter.test.ts
@@ -5,7 +5,7 @@ import type { MultiProvider } from '@hyperlane-xyz/sdk';
 
 import type { IActionTracker } from './IActionTracker.js';
 import { InflightContextAdapter } from './InflightContextAdapter.js';
-import type { RebalanceIntent, Transfer } from './types.js';
+import type { RebalanceAction, RebalanceIntent, Transfer } from './types.js';
 
 describe('InflightContextAdapter', () => {
   let actionTracker: Sinon.SinonStubbedInstance<IActionTracker>;
@@ -17,6 +17,7 @@ describe('InflightContextAdapter', () => {
       getActiveRebalanceIntents: Sinon.stub(),
       getInProgressTransfers: Sinon.stub(),
       getActionsForIntent: Sinon.stub(),
+      getActionsForIntents: Sinon.stub(),
     } as any;
 
     multiProvider = {
@@ -65,6 +66,7 @@ describe('InflightContextAdapter', () => {
       actionTracker.getActiveRebalanceIntents.resolves(mockIntents);
       actionTracker.getInProgressTransfers.resolves(mockTransfers);
       actionTracker.getActionsForIntent.resolves([]); // No actions
+      actionTracker.getActionsForIntents!.resolves(new Map());
       multiProvider.getChainName.withArgs(1).returns('ethereum');
       multiProvider.getChainName.withArgs(2).returns('arbitrum');
 
@@ -130,6 +132,7 @@ describe('InflightContextAdapter', () => {
       actionTracker.getActiveRebalanceIntents.resolves(mockIntents);
       actionTracker.getInProgressTransfers.resolves(mockTransfers);
       actionTracker.getActionsForIntent.resolves([]);
+      actionTracker.getActionsForIntents!.resolves(new Map());
       multiProvider.getChainName.withArgs(137).returns('polygon');
       multiProvider.getChainName.withArgs(10).returns('optimism');
 
@@ -193,6 +196,7 @@ describe('InflightContextAdapter', () => {
       actionTracker.getActiveRebalanceIntents.resolves(mockIntents);
       actionTracker.getInProgressTransfers.resolves(mockTransfers);
       actionTracker.getActionsForIntent.resolves([]);
+      actionTracker.getActionsForIntents!.resolves(new Map());
       multiProvider.getChainName.withArgs(1).returns('ethereum');
       multiProvider.getChainName.withArgs(2).returns('arbitrum');
       multiProvider.getChainName.withArgs(3).returns('optimism');
@@ -201,6 +205,108 @@ describe('InflightContextAdapter', () => {
 
       expect(result.pendingRebalances).to.have.lengthOf(2);
       expect(result.pendingTransfers).to.have.lengthOf(2);
+    });
+
+    it('loads inventory actions in one grouped tracker query', async () => {
+      const intents: RebalanceIntent[] = [
+        {
+          id: 'intent1',
+          origin: 1,
+          destination: 2,
+          amount: 1000n,
+          status: 'in_progress',
+          executionMethod: 'inventory',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        {
+          id: 'intent2',
+          origin: 2,
+          destination: 3,
+          amount: 1500n,
+          status: 'in_progress',
+          executionMethod: 'inventory',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+      const actions = new Map<string, RebalanceAction[]>([
+        [
+          'intent1',
+          [
+            {
+              id: 'action1',
+              intentId: 'intent1',
+              origin: 1,
+              destination: 2,
+              amount: 400n,
+              type: 'inventory_deposit',
+              status: 'complete',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          ],
+        ],
+        [
+          'intent2',
+          [
+            {
+              id: 'action2',
+              intentId: 'intent2',
+              origin: 2,
+              destination: 3,
+              amount: 500n,
+              type: 'inventory_deposit',
+              status: 'in_progress',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          ],
+        ],
+      ]);
+      actionTracker.getActiveRebalanceIntents.resolves(intents);
+      actionTracker.getInProgressTransfers.resolves([]);
+      actionTracker.getActionsForIntents!.resolves(actions);
+      multiProvider.getChainName.withArgs(1).returns('ethereum');
+      multiProvider.getChainName.withArgs(2).returns('arbitrum');
+      multiProvider.getChainName.withArgs(3).returns('optimism');
+
+      const result = await adapter.getInflightContext();
+
+      expect(
+        actionTracker.getActionsForIntents!.calledOnceWithExactly([
+          'intent1',
+          'intent2',
+        ]),
+      ).to.equal(true);
+      expect(actionTracker.getActionsForIntent.called).to.equal(false);
+      expect(result.pendingRebalances[0].deliveredAmount).to.equal(400n);
+      expect(result.pendingRebalances[1].awaitingDeliveryAmount).to.equal(500n);
+    });
+
+    it('supports trackers without the optional grouped query', async () => {
+      const intent: RebalanceIntent = {
+        id: 'intent1',
+        origin: 1,
+        destination: 2,
+        amount: 1000n,
+        status: 'in_progress',
+        executionMethod: 'inventory',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      actionTracker.getActiveRebalanceIntents.resolves([intent]);
+      actionTracker.getInProgressTransfers.resolves([]);
+      actionTracker.getActionsForIntents = undefined;
+      actionTracker.getActionsForIntent.resolves([]);
+      multiProvider.getChainName.withArgs(1).returns('ethereum');
+      multiProvider.getChainName.withArgs(2).returns('arbitrum');
+
+      await adapter.getInflightContext();
+
+      expect(
+        actionTracker.getActionsForIntent.calledOnceWithExactly('intent1'),
+      ).to.equal(true);
     });
   });
 });

--- a/typescript/rebalancer/src/tracking/InflightContextAdapter.ts
+++ b/typescript/rebalancer/src/tracking/InflightContextAdapter.ts
@@ -6,6 +6,7 @@ import type {
 } from '../interfaces/IStrategy.js';
 
 import type { IActionTracker } from './IActionTracker.js';
+import type { RebalanceAction } from './types.js';
 
 /**
  * Adapter that converts ActionTracker data to strategy-consumable InflightContext.
@@ -24,45 +25,47 @@ export class InflightContextAdapter {
   async getInflightContext(): Promise<InflightContext> {
     const intents = await this.actionTracker.getActiveRebalanceIntents();
     const transfers = await this.actionTracker.getInProgressTransfers();
+    const inventoryIntentIds = intents
+      .filter((intent) => intent.executionMethod === 'inventory')
+      .map((intent) => intent.id);
+    const actionsByIntent =
+      inventoryIntentIds.length > 0
+        ? await this.getActionsForIntents(inventoryIntentIds)
+        : new Map<string, RebalanceAction[]>();
 
-    const pendingRebalances: RouteWithContext[] = await Promise.all(
-      intents.map(async (intent) => {
-        let deliveredAmount = 0n;
-        let awaitingDeliveryAmount = 0n;
+    const pendingRebalances: RouteWithContext[] = intents.map((intent) => {
+      let deliveredAmount = 0n;
+      let awaitingDeliveryAmount = 0n;
 
-        // For inventory intents, compute delivered and awaiting amounts from actions
-        if (intent.executionMethod === 'inventory') {
-          const actions = await this.actionTracker.getActionsForIntent(
-            intent.id,
-          );
+      // For inventory intents, compute delivered and awaiting amounts from actions
+      if (intent.executionMethod === 'inventory') {
+        const actions = actionsByIntent.get(intent.id) ?? [];
 
-          // Sum of complete inventory_deposit actions (message delivered)
-          deliveredAmount = actions
-            .filter(
-              (a) => a.type === 'inventory_deposit' && a.status === 'complete',
-            )
-            .reduce((sum, a) => sum + a.amount, 0n);
+        // Sum of complete inventory_deposit actions (message delivered)
+        deliveredAmount = actions
+          .filter(
+            (a) => a.type === 'inventory_deposit' && a.status === 'complete',
+          )
+          .reduce((sum, a) => sum + a.amount, 0n);
 
-          // Sum of in_progress inventory_deposit actions (tx confirmed, message pending)
-          awaitingDeliveryAmount = actions
-            .filter(
-              (a) =>
-                a.type === 'inventory_deposit' && a.status === 'in_progress',
-            )
-            .reduce((sum, a) => sum + a.amount, 0n);
-        }
+        // Sum of in_progress inventory_deposit actions (tx confirmed, message pending)
+        awaitingDeliveryAmount = actions
+          .filter(
+            (a) => a.type === 'inventory_deposit' && a.status === 'in_progress',
+          )
+          .reduce((sum, a) => sum + a.amount, 0n);
+      }
 
-        return {
-          origin: this.multiProvider.getChainName(intent.origin),
-          destination: this.multiProvider.getChainName(intent.destination),
-          amount: intent.amount,
-          deliveredAmount,
-          awaitingDeliveryAmount,
-          executionMethod: intent.executionMethod,
-          bridge: intent.bridge,
-        };
-      }),
-    );
+      return {
+        origin: this.multiProvider.getChainName(intent.origin),
+        destination: this.multiProvider.getChainName(intent.destination),
+        amount: intent.amount,
+        deliveredAmount,
+        awaitingDeliveryAmount,
+        executionMethod: intent.executionMethod,
+        bridge: intent.bridge,
+      };
+    });
 
     const pendingTransfers = transfers.map((transfer) => ({
       origin: this.multiProvider.getChainName(transfer.origin),
@@ -71,5 +74,25 @@ export class InflightContextAdapter {
     }));
 
     return { pendingRebalances, pendingTransfers };
+  }
+
+  private async getActionsForIntents(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>> {
+    if (this.actionTracker.getActionsForIntents) {
+      return this.actionTracker.getActionsForIntents(intentIds);
+    }
+
+    return new Map(
+      await Promise.all(
+        intentIds.map(
+          async (intentId) =>
+            [
+              intentId,
+              await this.actionTracker.getActionsForIntent(intentId),
+            ] as const,
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
### Description

Removes recurring tracker hot-path serialization and repeated store scans.

Live merged-main rebalancers with no pending transfers spend roughly 0.15-0.28 seconds in tracker sync. Routes with two or three pending transfers spend roughly 0.45-1.94 seconds on average and up to 2.36 seconds at p95. This change:

- bounds delivery checks at eight concurrent reads across transfer and rebalance-action syncs;
- reuses one confirmed destination block tag per sync;
- batches intent/action projections from one store snapshot, with a compatibility fallback for custom trackers;
- batches message-ID lookups instead of rescanning the store per message; and
- retains store counts at INFO while moving repeated per-item dumps to DEBUG (900 item records versus 660 summaries in the sampled hour).

The measured timings describe the current deployment; this branch has not been deployed, so improvement claims remain code- and test-backed.

### Stack

- #9630
- #9631 (this PR)
- #9632
- #9633

### Drive-by changes

None.

### Related issues

Supersedes the remaining recurring tracker hot paths in #8880.

### Backward compatibility

Yes. The grouped tracker query is optional and callers fall back to the existing per-intent API.

### Testing

- Unit tests for the shared concurrency ceiling, block-tag reuse, grouped projections, compatibility fallback, and log levels
- `pnpm -C typescript/rebalancer test:ci` (413 passing on the combined stack)
- Rebalancer and simulator builds/lints
