### PR TITLE
fix(rebalancer): expose cycle freshness and failures

### DIFF
--- a/.changeset/rebalancer-cycle-freshness.md
+++ b/.changeset/rebalancer-cycle-freshness.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Rebalancer cycles reported tracker-source freshness and preserved route failures across all execution types and executor-level errors.

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -216,9 +216,16 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(0);
+      expect(result.executionResults).to.eql([]);
       expect(result.executedCount).to.equal(0);
       expect(result.failedCount).to.equal(0);
+      expect(result.trackerSync).to.deep.equal({
+        freshSources: ['transfers', 'rebalanceIntents', 'rebalanceActions'],
+        staleSources: [],
+      });
+      expect(result.errors).to.eql([]);
       expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
     });
 
@@ -300,7 +307,9 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(1);
+      expect(result.executionResults).to.have.lengthOf(1);
       expect(result.executedCount).to.equal(1);
       expect(result.failedCount).to.equal(0);
       expect(rebalancer.rebalance.calledOnce).to.be.true;
@@ -350,9 +359,74 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('failed');
       expect(result.proposedRoutes).to.have.lengthOf(1);
       expect(result.executedCount).to.equal(0);
       expect(result.failedCount).to.equal(1);
+    });
+
+    it('maps executor errors to failed route results', async () => {
+      const route = {
+        origin: 'ethereum',
+        destination: 'arbitrum',
+        amount: 1000n,
+        bridge: TEST_ADDRESSES.bridge,
+        executionType: 'movableCollateral' as const,
+      };
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([route]);
+      const rebalancer = createMockRebalancer();
+      rebalancer.rebalance.rejects(new Error('executor unavailable'));
+
+      const orchestrator = new RebalancerOrchestrator({
+        strategy,
+        rebalancers: [rebalancer],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+      });
+
+      const result = await orchestrator.executeCycle(createMonitorEvent());
+
+      expect(result.status).to.equal('failed');
+      expect(result.executedCount).to.equal(0);
+      expect(result.failedCount).to.equal(1);
+      expect(result.executionResults).to.deep.equal([
+        {
+          route,
+          success: false,
+          error: 'executor unavailable',
+          reason: 'executor_error',
+        },
+      ]);
+    });
+
+    it('reports a proposed route with no configured executor', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([
+        {
+          origin: 'ethereum',
+          destination: 'arbitrum',
+          amount: 1000n,
+          bridge: TEST_ADDRESSES.bridge,
+          executionType: 'movableCollateral',
+        },
+      ]);
+      const orchestrator = new RebalancerOrchestrator({
+        strategy,
+        rebalancers: [],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+      });
+
+      const result = await orchestrator.executeCycle(createMonitorEvent());
+
+      expect(result.status).to.equal('failed');
+      expect(result.failedCount).to.equal(1);
+      expect(result.executionResults[0].reason).to.equal('missing_rebalancer');
     });
   });
 
@@ -421,7 +495,10 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(1);
+      expect(result.executedCount).to.equal(1);
+      expect(result.failedCount).to.equal(0);
       expect(inventoryRebalancer.rebalance.calledOnce).to.be.true;
     });
   });
@@ -519,8 +596,9 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(2);
-      expect(result.executedCount).to.equal(1);
+      expect(result.executedCount).to.equal(2);
       expect(result.failedCount).to.equal(0);
       expect(rebalancer.rebalance.calledOnce).to.be.true;
       expect(inventoryRebalancer.rebalance.calledOnce).to.be.true;
@@ -672,7 +750,7 @@ describe('RebalancerOrchestrator', () => {
   });
 
   describe('syncActionTracker() Error Handling', () => {
-    it('should warn but continue when syncTransfers fails', async () => {
+    it('blocks planning when transfer state is stale', async () => {
       const strategy = createMockStrategy();
       strategy.getRebalancingRoutes.returns([]);
 
@@ -698,7 +776,50 @@ describe('RebalancerOrchestrator', () => {
       const result = await orchestrator.executeCycle(event);
 
       expect(result.proposedRoutes).to.have.lengthOf(0);
-      expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
+      expect(result.trackerSync.staleSources).to.deep.equal(['transfers']);
+      expect(result.trackerSync.freshSources).to.deep.equal([
+        'rebalanceIntents',
+        'rebalanceActions',
+      ]);
+      expect(result.status).to.equal('failed');
+      expect(result.errors).to.deep.equal([
+        'ActionTracker transfers sync failed',
+      ]);
+      expect(
+        (actionTracker.syncRebalanceIntents as Sinon.SinonStub).calledOnce,
+      ).to.equal(true);
+      expect(
+        (actionTracker.syncRebalanceActions as Sinon.SinonStub).calledOnce,
+      ).to.equal(true);
+      expect(strategy.getRebalancingRoutes.called).to.be.false;
+    });
+
+    it('blocks planning when inventory movement status is stale', async () => {
+      const strategy = createMockStrategy();
+      const actionTracker = createMockActionTracker();
+      (actionTracker.syncInventoryMovementActions as Sinon.SinonStub).rejects(
+        new Error('Bridge status unavailable'),
+      );
+      const rebalancer = createMockInventoryRebalancer();
+      const bridge = createMockBridge();
+      const orchestrator = new RebalancerOrchestrator({
+        strategy,
+        actionTracker,
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        rebalancers: [rebalancer],
+        externalBridgeRegistry: { lifi: bridge },
+      });
+
+      const result = await orchestrator.executeCycle(createMonitorEvent());
+
+      expect(result.status).to.equal('failed');
+      expect(result.trackerSync.staleSources).to.deep.equal([
+        'inventoryMovementActions',
+      ]);
+      expect(strategy.getRebalancingRoutes.called).to.equal(false);
+      expect(rebalancer.rebalance.called).to.equal(false);
     });
 
     it('should sync inventory movement actions when bridge is provided', async () => {
@@ -722,18 +843,50 @@ describe('RebalancerOrchestrator', () => {
       const orchestrator = new RebalancerOrchestrator(deps);
       const event = createMonitorEvent();
 
-      await orchestrator.executeCycle(event);
+      const result = await orchestrator.executeCycle(event);
 
       expect(
         (actionTracker.syncInventoryMovementActions as Sinon.SinonStub)
           .calledOnce,
       ).to.be.true;
+      expect(result.trackerSync).to.deep.equal({
+        freshSources: [
+          'transfers',
+          'rebalanceIntents',
+          'rebalanceActions',
+          'inventoryMovementActions',
+        ],
+        staleSources: [],
+      });
       expect(
         (
           actionTracker.syncInventoryMovementActions as Sinon.SinonStub
         ).calledWith({ lifi: bridge }),
       ).to.be.true;
     });
+  });
+
+  it('reports an inventory continuation error with no proposed route', async () => {
+    const strategy = createMockStrategy();
+    strategy.getRebalancingRoutes.returns([]);
+    const inventoryRebalancer = createMockInventoryRebalancer();
+    inventoryRebalancer.rebalance.rejects(new Error('continuation failed'));
+    const orchestrator = new RebalancerOrchestrator({
+      strategy,
+      rebalancers: [inventoryRebalancer],
+      actionTracker: createMockActionTracker(),
+      inflightContextAdapter: createMockInflightContextAdapter(),
+      rebalancerConfig: createMockRebalancerConfig(),
+      logger: testLogger,
+    });
+
+    const result = await orchestrator.executeCycle(createMonitorEvent());
+
+    expect(result.status).to.equal('failed');
+    expect(result.executionResults).to.eql([]);
+    expect(result.errors).to.deep.equal([
+      'Inventory continuation failed: continuation failed',
+    ]);
   });
 
   describe('Metrics Recording', () => {

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -24,15 +24,39 @@ import { getRawBalances } from '../utils/balanceUtils.js';
 
 import { InventoryRebalancer } from './InventoryRebalancer.js';
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export type TrackerSyncSource =
+  | 'transfers'
+  | 'rebalanceIntents'
+  | 'rebalanceActions'
+  | 'inventoryMovementActions';
+
+export interface TrackerSyncResult {
+  freshSources: TrackerSyncSource[];
+  staleSources: TrackerSyncSource[];
+}
+
+type TrackerSyncStep = {
+  source: TrackerSyncSource;
+  run: () => Promise<unknown>;
+};
+
 /**
  * Result of a rebalancing cycle.
- * executedCount/failedCount: Counts from movable_collateral execution ONLY
+ * Includes results from every configured execution type.
  */
 export interface CycleResult {
+  status: 'success' | 'partial' | 'failed';
   balances: Record<string, bigint>;
   proposedRoutes: StrategyRoute[];
+  executionResults: ExecutionResult[];
   executedCount: number;
   failedCount: number;
+  trackerSync: TrackerSyncResult;
+  errors: string[];
 }
 
 export interface RebalancerOrchestratorDeps {
@@ -85,7 +109,7 @@ export class RebalancerOrchestrator {
       );
     }
 
-    await this.syncActionTracker(event.confirmedBlockTags);
+    const trackerSync = await this.syncActionTracker(event.confirmedBlockTags);
 
     const rawBalances = getRawBalances(
       getStrategyChainNames(this.rebalancerConfig.strategyConfig),
@@ -103,6 +127,26 @@ export class RebalancerOrchestrator {
       'Router balances',
     );
 
+    const errors = trackerSync.staleSources.map(
+      (source) => `ActionTracker ${source} sync failed`,
+    );
+    if (errors.length > 0) {
+      this.logger.error(
+        { staleSources: trackerSync.staleSources },
+        'Skipping rebalancing because tracker state is stale',
+      );
+      return {
+        status: 'failed',
+        balances: rawBalances,
+        proposedRoutes: [],
+        executionResults: [],
+        executedCount: 0,
+        failedCount: 0,
+        trackerSync,
+        errors,
+      };
+    }
+
     // Get inflight context for strategy decision-making
     const inflightContext = await this.getInflightContext();
 
@@ -111,8 +155,7 @@ export class RebalancerOrchestrator {
       inflightContext,
     );
 
-    let executedCount = 0;
-    let failedCount = 0;
+    let executionResults: ExecutionResult[] = [];
 
     if (strategyRoutes.length > 0) {
       this.logger.info(
@@ -127,24 +170,48 @@ export class RebalancerOrchestrator {
       );
 
       const results = await this.executeWithTracking(strategyRoutes, event);
-      executedCount = results.executedCount;
-      failedCount = results.failedCount;
+      executionResults = results;
     } else {
       this.logger.info('No rebalancing needed');
     }
 
     const inventoryRebalancer = this.rebalancersByType.get('inventory');
     if (inventoryRebalancer && strategyRoutes.length === 0) {
-      await this.executeRoutes([], inventoryRebalancer, event);
+      try {
+        executionResults = await this.executeRoutes(
+          [],
+          inventoryRebalancer,
+          event,
+        );
+      } catch (error) {
+        errors.push(`Inventory continuation failed: ${errorMessage(error)}`);
+      }
     }
+
+    const executedCount = executionResults.filter(
+      (result) => result.success,
+    ).length;
+    const failedCount = executionResults.length - executedCount;
+    const status =
+      errors.length > 0
+        ? 'failed'
+        : failedCount === 0
+          ? 'success'
+          : executedCount === 0
+            ? 'failed'
+            : 'partial';
 
     this.logger.info('Polling cycle completed');
 
     return {
+      status,
       balances: rawBalances,
       proposedRoutes: strategyRoutes,
+      executionResults,
       executedCount,
       failedCount,
+      trackerSync,
+      errors,
     };
   }
 
@@ -153,28 +220,61 @@ export class RebalancerOrchestrator {
    */
   private async syncActionTracker(
     confirmedBlockTags?: ConfirmedBlockTags,
-  ): Promise<void> {
-    try {
-      await Promise.all([
-        this.actionTracker.syncTransfers(confirmedBlockTags),
-        this.actionTracker.syncRebalanceIntents(),
-        this.actionTracker.syncRebalanceActions(confirmedBlockTags),
-      ]);
+  ): Promise<TrackerSyncResult> {
+    const syncSteps: TrackerSyncStep[] = [
+      {
+        source: 'transfers',
+        run: () => this.actionTracker.syncTransfers(confirmedBlockTags),
+      },
+      {
+        source: 'rebalanceIntents',
+        run: () => this.actionTracker.syncRebalanceIntents(),
+      },
+      {
+        source: 'rebalanceActions',
+        run: () => this.actionTracker.syncRebalanceActions(confirmedBlockTags),
+      },
+    ];
+    const externalBridgeRegistry = this.externalBridgeRegistry;
+    if (externalBridgeRegistry) {
+      syncSteps.push({
+        source: 'inventoryMovementActions',
+        run: () =>
+          this.actionTracker.syncInventoryMovementActions(
+            externalBridgeRegistry,
+          ),
+      });
+    }
 
-      // Sync inventory movement actions via external bridge API
-      if (this.externalBridgeRegistry) {
-        await this.actionTracker.syncInventoryMovementActions(
-          this.externalBridgeRegistry,
+    const results = await Promise.allSettled(
+      syncSteps.map(({ run }) => Promise.resolve().then(run)),
+    );
+    const trackerSync: TrackerSyncResult = {
+      freshSources: [],
+      staleSources: [],
+    };
+
+    results.forEach((result, index) => {
+      const source = syncSteps[index].source;
+      if (result.status === 'fulfilled') {
+        trackerSync.freshSources.push(source);
+      } else {
+        trackerSync.staleSources.push(source);
+        this.logger.warn(
+          { source, error: errorMessage(result.reason) },
+          'ActionTracker sync source failed, using stale data',
         );
       }
+    });
 
+    try {
       await this.actionTracker.logStoreContents();
     } catch (error) {
-      this.logger.warn(
-        { error },
-        'ActionTracker sync failed, using stale data',
-      );
+      this.logger.warn({ error }, 'Failed to log ActionTracker store contents');
     }
+
+    this.logger.info(trackerSync, 'ActionTracker sync freshness');
+    return trackerSync;
   }
 
   /**
@@ -187,12 +287,11 @@ export class RebalancerOrchestrator {
   private async executeWithTracking(
     routes: StrategyRoute[],
     event: MonitorEvent,
-  ): Promise<{ executedCount: number; failedCount: number }> {
+  ): Promise<ExecutionResult[]> {
     const movableCollateral = routes.filter(isMovableCollateralRoute);
     const inventory = routes.filter(isInventoryRoute);
 
-    let executedCount = 0;
-    let failedCount = 0;
+    const executionResults: ExecutionResult[] = [];
 
     const movableCollateralRebalancer =
       this.rebalancersByType.get('movableCollateral');
@@ -202,16 +301,28 @@ export class RebalancerOrchestrator {
         movableCollateralRebalancer,
         event,
       );
-      executedCount = results.filter((r) => r.success).length;
-      failedCount = results.filter((r) => !r.success).length;
+      executionResults.push(...results);
+    } else if (movableCollateral.length > 0) {
+      executionResults.push(
+        ...this.missingRebalancerResults(
+          movableCollateral,
+          'movableCollateral',
+        ),
+      );
     }
 
     const inventoryRebalancer = this.rebalancersByType.get('inventory');
     if (inventory.length > 0 && inventoryRebalancer) {
-      await this.executeRoutes(inventory, inventoryRebalancer, event);
+      executionResults.push(
+        ...(await this.executeRoutes(inventory, inventoryRebalancer, event)),
+      );
+    } else if (inventory.length > 0) {
+      executionResults.push(
+        ...this.missingRebalancerResults(inventory, 'inventory'),
+      );
     }
 
-    return { executedCount, failedCount };
+    return executionResults;
   }
 
   private async executeRoutes(
@@ -259,7 +370,7 @@ export class RebalancerOrchestrator {
       }
 
       return results;
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (rebalancer.rebalancerType === 'movableCollateral') {
         this.metrics?.recordRebalancerFailure();
       }
@@ -267,7 +378,28 @@ export class RebalancerOrchestrator {
         { error, type: rebalancer.rebalancerType },
         'Error while executing routes',
       );
-      return [];
+      if (routes.length === 0) throw error;
+      const message = errorMessage(error);
+      return routes.map((route) => ({
+        route,
+        success: false,
+        error: message,
+        reason: 'executor_error',
+      }));
     }
+  }
+
+  private missingRebalancerResults(
+    routes: StrategyRoute[],
+    rebalancerType: RebalancerType,
+  ): ExecutionResult[] {
+    const error = `No ${rebalancerType} rebalancer configured`;
+    this.logger.error({ rebalancerType, count: routes.length }, error);
+    return routes.map((route) => ({
+      route,
+      success: false,
+      error,
+      reason: 'missing_rebalancer',
+    }));
   }
 }

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -376,6 +376,28 @@ describe('ActionTracker', () => {
       const transfer = await transferStore.get('0xmsg1');
       expect(transfer?.status).to.equal('complete');
     });
+
+    it('rejects the sync when an Explorer transfer cannot be parsed', async () => {
+      const inflightMessage: ExplorerMessage = {
+        msg_id: '0xinvalid',
+        origin_domain_id: 1,
+        destination_domain_id: 2,
+        sender: '0xuser1',
+        recipient: '0xuser2',
+        origin_tx_hash: '0xtx1',
+        origin_tx_sender: '0xuser1',
+        origin_tx_recipient: '0xrouter1',
+        is_delivered: false,
+        message_body: '0xinvalid',
+        send_occurred_at: null,
+      };
+      explorerClient.getInflightUserTransfers.resolves([inflightMessage]);
+
+      await expect(tracker.syncTransfers()).to.be.rejectedWith(
+        'Failed to sync 1 transfer message(s)',
+      );
+      expect(await transferStore.getAll()).to.have.lengthOf(0);
+    });
   });
 
   describe('syncRebalanceIntents', () => {
@@ -711,6 +733,33 @@ describe('ActionTracker', () => {
         'action-repeated-not-found',
       );
       expect(action?.nonPendingSince).to.equal(originalNonPendingSince);
+    });
+
+    it('rejects the sync when bridge status cannot be observed', async () => {
+      await rebalanceActionStore.save({
+        id: 'action-status-error',
+        type: 'inventory_movement',
+        status: 'in_progress',
+        intentId: 'intent-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        txHash: '0xtx-error',
+        externalBridgeId: ExternalBridgeType.LiFi,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      const getStatus = Sinon.stub().rejects(new Error('provider unavailable'));
+
+      await expect(
+        tracker.syncInventoryMovementActions({
+          lifi: { getStatus } as any,
+        }),
+      ).to.be.rejectedWith('Failed to sync 1 inventory movement(s)');
+      expect(
+        (await rebalanceActionStore.get('action-status-error'))?.status,
+      ).to.equal('in_progress');
     });
   });
 

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -135,6 +135,7 @@ export class ActionTracker implements IActionTracker {
 
     let newTransfers = 0;
     let completedTransfers = 0;
+    const syncErrors: Error[] = [];
 
     for (const msg of inflightMessages) {
       const transfer = await this.transferStore.get(msg.msg_id);
@@ -174,6 +175,9 @@ export class ActionTracker implements IActionTracker {
             'Created new transfer',
           );
         } catch (error) {
+          syncErrors.push(
+            new Error(`Failed to parse transfer message ${msg.msg_id}`),
+          );
           this.logger.warn(
             {
               msgId: msg.msg_id,
@@ -223,6 +227,13 @@ export class ActionTracker implements IActionTracker {
       },
       'Transfers synced',
     );
+
+    if (syncErrors.length > 0) {
+      throw new AggregateError(
+        syncErrors,
+        `Failed to sync ${syncErrors.length} transfer message(s)`,
+      );
+    }
   }
 
   async syncRebalanceIntents(): Promise<void> {
@@ -730,6 +741,7 @@ export class ActionTracker implements IActionTracker {
 
     let completed = 0;
     let failed = 0;
+    const syncErrors: Error[] = [];
 
     // Get all in-progress inventory_movement actions
     const inProgressActions =
@@ -746,6 +758,9 @@ export class ActionTracker implements IActionTracker {
     for (const action of inventoryMovements) {
       // Skip if no txHash (shouldn't happen but be safe)
       if (!action.txHash) {
+        syncErrors.push(
+          new Error(`Inventory movement ${action.id} has no txHash`),
+        );
         this.logger.warn(
           { actionId: action.id },
           'Inventory movement action has no txHash',
@@ -755,6 +770,9 @@ export class ActionTracker implements IActionTracker {
 
       // Skip if no externalBridgeId (shouldn't happen but be safe)
       if (!action.externalBridgeId) {
+        syncErrors.push(
+          new Error(`Inventory movement ${action.id} has no externalBridgeId`),
+        );
         this.logger.warn(
           { actionId: action.id },
           'Inventory movement action has no externalBridgeId',
@@ -764,6 +782,11 @@ export class ActionTracker implements IActionTracker {
 
       const externalBridge = externalBridgeRegistry[action.externalBridgeId];
       if (!externalBridge) {
+        syncErrors.push(
+          new Error(
+            `Inventory movement ${action.id} bridge ${action.externalBridgeId} is not configured`,
+          ),
+        );
         this.logger.warn(
           { actionId: action.id, bridgeId: action.externalBridgeId },
           'Bridge not found in registry',
@@ -827,6 +850,9 @@ export class ActionTracker implements IActionTracker {
           );
         }
       } catch (error) {
+        syncErrors.push(
+          new Error(`Failed to get inventory movement ${action.id} status`),
+        );
         this.logger.debug(
           {
             actionId: action.id,
@@ -846,6 +872,13 @@ export class ActionTracker implements IActionTracker {
           pending: inventoryMovements.length - completed - failed,
         },
         'Inventory movements synced',
+      );
+    }
+
+    if (syncErrors.length > 0) {
+      throw new AggregateError(
+        syncErrors,
+        `Failed to sync ${syncErrors.length} inventory movement(s)`,
       );
     }
 


### PR DESCRIPTION
### Description

Makes cycle outcomes and tracker freshness explicit so the performance work cannot execute against partially observed state.

This change:

- runs independent tracker sync sources concurrently and reports fresh/stale sources;
- blocks strategy and execution when any safety-relevant tracker source is stale;
- propagates swallowed transfer parsing and external-bridge status failures into freshness;
- returns per-route execution results and correct success/partial/failed counts;
- maps executor and missing-rebalancer failures into structured results; and
- reports inventory-continuation failures even when no new route was proposed.

### Stack

- #9630
- #9631
- #9632 (this PR)
- #9633

### Drive-by changes

None.

### Related issues

Replaces the planning/execution outcome work proposed in #8881 while avoiding the stale architectural split.

### Backward compatibility

Cycle result fields are additive. A tracker observation failure now intentionally suppresses planning/execution instead of proceeding with incomplete state.

### Testing

- Unit tests for stale transfer and inventory-movement sources, zero execution on stale state, executor failures, missing executors, mixed outcomes, and inventory continuation failures
- `pnpm -C typescript/rebalancer test:ci` (413 passing on the combined stack)
- Rebalancer and simulator builds/lints
