### PR TITLE
perf(rebalancer): batch token price metrics

### DIFF
--- a/.changeset/batch-rebalancer-price-metrics.md
+++ b/.changeset/batch-rebalancer-price-metrics.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Batch-prefetched token prices before updating rebalancer metrics, removing the fixed rate-limit delay and request fan-out from cache-miss cycles.

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -143,6 +143,7 @@ function createMockMetrics(): Metrics {
     recordRebalancerFailure: Sinon.stub(),
     recordIntentCreated: Sinon.stub(),
     processToken: Sinon.stub().resolves(),
+    processTokens: Sinon.stub().resolves(),
   } as unknown as Metrics;
 }
 
@@ -1018,7 +1019,43 @@ describe('RebalancerOrchestrator', () => {
 
       await orchestrator.executeCycle(event);
 
-      expect((metrics.processToken as Sinon.SinonStub).calledTwice).to.be.true;
+      expect(
+        (metrics.processTokens as Sinon.SinonStub).calledOnceWithExactly(
+          event.tokensInfo,
+        ),
+      ).to.equal(true);
+    });
+
+    it('waits for batched metrics before syncing tracker state', async () => {
+      const actionTracker = createMockActionTracker();
+      const metrics = createMockMetrics();
+      let releaseMetrics: () => void;
+      (metrics.processTokens as Sinon.SinonStub).returns(
+        new Promise<void>((resolve) => {
+          releaseMetrics = resolve;
+        }),
+      );
+      const orchestrator = new RebalancerOrchestrator({
+        strategy: createMockStrategy(),
+        actionTracker,
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        rebalancers: [],
+        metrics,
+      });
+
+      const cycle = orchestrator.executeCycle(createMonitorEvent());
+      await Promise.resolve();
+      expect((actionTracker.syncTransfers as Sinon.SinonStub).called).to.equal(
+        false,
+      );
+
+      releaseMetrics!();
+      await cycle;
+      expect(
+        (actionTracker.syncTransfers as Sinon.SinonStub).calledOnce,
+      ).to.equal(true);
     });
   });
 });

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -104,9 +104,7 @@ export class RebalancerOrchestrator {
 
     const { metrics } = this;
     if (metrics) {
-      await Promise.all(
-        event.tokensInfo.map((tokenInfo) => metrics.processToken(tokenInfo)),
-      );
+      await metrics.processTokens(event.tokensInfo);
     }
 
     const trackerSync = await this.syncActionTracker(event.confirmedBlockTags);

--- a/typescript/rebalancer/src/core/RebalancerService.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.test.ts
@@ -713,6 +713,7 @@ describe('RebalancerService', () => {
         recordRebalancerFailure,
         recordIntentCreated: Sinon.stub(),
         processToken: Sinon.stub().resolves(),
+        processTokens: Sinon.stub().resolves(),
       } as unknown as Metrics;
 
       let tokenInfoHandler: ((event: any) => Promise<void>) | undefined;
@@ -805,6 +806,7 @@ describe('RebalancerService', () => {
         recordRebalancerFailure,
         recordIntentCreated: Sinon.stub(),
         processToken: Sinon.stub().resolves(),
+        processTokens: Sinon.stub().resolves(),
       } as unknown as Metrics;
 
       let tokenInfoHandler: ((event: any) => Promise<void>) | undefined;
@@ -914,6 +916,7 @@ describe('RebalancerService', () => {
         recordRebalancerFailure,
         recordIntentCreated: Sinon.stub(),
         processToken: Sinon.stub().resolves(),
+        processTokens: Sinon.stub().resolves(),
       } as unknown as Metrics;
 
       let tokenInfoHandler: ((event: any) => Promise<void>) | undefined;

--- a/typescript/rebalancer/src/interfaces/IMetrics.ts
+++ b/typescript/rebalancer/src/interfaces/IMetrics.ts
@@ -2,4 +2,5 @@ import { type MonitorEvent } from './IMonitor.js';
 
 export interface IMetrics {
   processToken(tokenInfo: MonitorEvent['tokensInfo'][number]): Promise<void>;
+  processTokens?(tokensInfo: MonitorEvent['tokensInfo']): Promise<void>;
 }

--- a/typescript/rebalancer/src/metrics/Metrics.ts
+++ b/typescript/rebalancer/src/metrics/Metrics.ts
@@ -41,6 +41,7 @@ import {
 export class Metrics implements IMetrics {
   private readonly logger: Logger;
   private readonly priceGetter: TokenPriceGetter;
+  private readonly cachedPriceGetter: TokenPriceGetter;
 
   constructor(
     private readonly tokenPriceGetter: PriceGetter,
@@ -57,6 +58,10 @@ export class Metrics implements IMetrics {
       tryGetTokenPrice: async (token: Token) => {
         return this.tokenPriceGetter.tryGetTokenPrice(token);
       },
+    };
+    this.cachedPriceGetter = {
+      tryGetTokenPrice: async (token: Token) =>
+        this.tokenPriceGetter.tryGetCachedTokenPrice(token),
     };
   }
 
@@ -115,9 +120,41 @@ export class Metrics implements IMetrics {
     token,
     bridgedSupply,
   }: MonitorEvent['tokensInfo'][number]) {
+    await this.processTokenWithPriceGetter(
+      token,
+      bridgedSupply,
+      this.priceGetter,
+    );
+  }
+
+  async processTokens(tokensInfo: MonitorEvent['tokensInfo']): Promise<void> {
+    const coinGeckoIds = tokensInfo.flatMap(({ token }) =>
+      token.coinGeckoId ? [token.coinGeckoId] : [],
+    );
+    await tryFn(
+      () => this.tokenPriceGetter.prefetchMissing(coinGeckoIds),
+      'Prefetching warp route token prices',
+      this.logger,
+    );
+    await Promise.all(
+      tokensInfo.map(({ token, bridgedSupply }) =>
+        this.processTokenWithPriceGetter(
+          token,
+          bridgedSupply,
+          this.cachedPriceGetter,
+        ),
+      ),
+    );
+  }
+
+  private async processTokenWithPriceGetter(
+    token: Token,
+    bridgedSupply: bigint | undefined,
+    priceGetter: TokenPriceGetter,
+  ): Promise<void> {
     await tryFn(
       async () => {
-        await this.updateTokenMetrics(token, bridgedSupply);
+        await this.updateTokenMetrics(token, bridgedSupply, priceGetter);
       },
       'Updating warp route metrics',
       this.logger,
@@ -128,6 +165,7 @@ export class Metrics implements IMetrics {
   private async updateTokenMetrics(
     token: Token,
     bridgedSupply?: bigint,
+    priceGetter: TokenPriceGetter = this.priceGetter,
   ): Promise<void> {
     const promises = [
       tryFn(
@@ -135,7 +173,7 @@ export class Metrics implements IMetrics {
           const balanceInfo = await getTokenBridgedBalance(
             this.warpCore,
             token,
-            this.priceGetter,
+            priceGetter,
             this.logger,
             bridgedSupply,
           );
@@ -263,7 +301,7 @@ export class Metrics implements IMetrics {
               const balance = await getExtraLockboxBalance(
                 this.warpCore.multiProvider,
                 token,
-                this.priceGetter,
+                priceGetter,
                 lockbox.lockbox,
                 this.logger,
               );

--- a/typescript/rebalancer/src/metrics/PriceGetter.test.ts
+++ b/typescript/rebalancer/src/metrics/PriceGetter.test.ts
@@ -110,4 +110,46 @@ describe('PriceGetter concurrent lookups', () => {
     expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(2);
     expect(lookup.callCount).to.equal(2);
   });
+
+  it('prefetches unique valid and invalid IDs in one request', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const getter = PriceGetter.create({}, logger, undefined, 60, 0);
+
+    await getter.prefetchMissing(['usd-coin', 'missing', 'usd-coin']);
+
+    expect(fetch.callCount).to.equal(1);
+    expect(getter.getCachedTokenPrice('usd-coin')).to.equal(1);
+    expect(getter.getCachedTokenPrice('missing')).to.be.undefined;
+  });
+
+  it('reuses valid cached prices while retrying uncached IDs next cycle', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const getter = PriceGetter.create({}, logger, undefined, 60, 0);
+
+    await getter.prefetchMissing(['usd-coin', 'missing']);
+    await getter.prefetchMissing(['usd-coin', 'missing']);
+
+    expect(fetch.callCount).to.equal(2);
+    const secondUrl = String(fetch.secondCall.args[0]);
+    expect(secondUrl).to.include('ids=missing');
+    expect(secondUrl).not.to.include('usd-coin');
+  });
+
+  it('leaves prices uncached after a failed batch and retries next cycle', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch');
+    fetch.onFirstCall().rejects(new Error('network unavailable'));
+    fetch.onSecondCall().resolves(response(2));
+    const getter = PriceGetter.create({}, logger, undefined, 60, 0);
+
+    await getter.prefetchMissing(['usd-coin']);
+    expect(getter.getCachedTokenPrice('usd-coin')).to.be.undefined;
+    await getter.prefetchMissing(['usd-coin']);
+
+    expect(getter.getCachedTokenPrice('usd-coin')).to.equal(2);
+    expect(fetch.callCount).to.equal(2);
+  });
 });

--- a/typescript/rebalancer/src/metrics/PriceGetter.ts
+++ b/typescript/rebalancer/src/metrics/PriceGetter.ts
@@ -70,6 +70,22 @@ export class PriceGetter extends CoinGeckoTokenPriceGetter {
     return this.getCoingeckoPrice(coinGeckoId);
   }
 
+  async prefetchMissing(coingeckoIds: readonly string[]): Promise<void> {
+    const missingIds = [...new Set(coingeckoIds)].filter(
+      (id) => this.getCachedTokenPrice(id) === undefined,
+    );
+    if (missingIds.length === 0) return;
+
+    await this.prefetchTokenPrices(missingIds);
+  }
+
+  tryGetCachedTokenPrice(token: Token): number | undefined {
+    const coinGeckoId = token.coinGeckoId;
+    if (!coinGeckoId) return undefined;
+
+    return this.getCachedTokenPrice(coinGeckoId);
+  }
+
   async getCoingeckoPrice(coingeckoId: string): Promise<number | undefined> {
     const pending = this.pendingPrices.get(coingeckoId);
     if (pending) return pending;


### PR DESCRIPTION
### Description

Batch-prefetches unique CoinGecko IDs once per metrics cycle and uses cache-only price reads for the subsequent token updates.

All 11 in-scope merged-main rebalancers run with metrics enabled every 60 seconds. In a 60-minute sample, 360 of 658 cycles took at least four seconds; ten pods alternated between fast and roughly five-second-delayed cycles, while USDC/subtensor was delayed on all 60 cycles because an invalid `usdc` CoinGecko ID never entered the cache. This represented about 1,800 aggregate seconds/hour of fixed awaited delay across the fleet.

The SDK already provides fault-tolerant batch prefetch and cache-only reads. This change uses them to:

- deduplicate IDs and fetch missing prices in one batch per cycle;
- avoid per-token request fanout and the first-request rate-limit sleep;
- retain valid cached prices while retrying missing/failed IDs on the next cycle; and
- keep metrics awaited before tracker sync and strategy evaluation.

The live sample establishes the existing bottleneck. The replacement behavior is locally tested but not yet deployed or telemetry-verified.

### Stack

- #9630
- #9631
- #9632
- #9633 (this PR)

### Drive-by changes

None.

### Related issues

Identified from current merged-main rebalancer usage while replacing #8880-#8883.

### Backward compatibility

Yes. `processToken` remains available, the batch interface is additive, and metrics remain an awaited cycle gate.

### Testing

- Unit tests for unique valid/invalid ID batching, cached subsequent cycles, failed-fetch retry, and orchestrator gating
- `pnpm -C typescript/rebalancer test:ci` (413 passing on the combined stack)
- Rebalancer and simulator builds/lints
